### PR TITLE
Adds IE11 support for the app and for Auth with polyfills.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "perfect-scrollbar": "^1.1.0",
     "popper.js": "^1.12.6",
     "react": "^16.8.6",
+    "react-app-polyfill": "^1.0.1",
     "react-chartjs-2": "^2.7.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,13 @@
     </script>
 
     <!--
+      This promise polyfill enables the webcrypto shim polyfill which allows Auth0 to
+      fall back to msCrypto in the absence of the standard crypto in IE11.
+    -->
+    <script src="https://unpkg.com/bluebird"></script>
+    <script src="https://unpkg.com/webcrypto-shim"></script>
+
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";


### PR DESCRIPTION
The [polyfills](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md) in `index.js` ensure that the transpiled JS works for IE11.

The [polyfills](https://github.com/kevlened/isomorphic-webcrypto#i-just-want-to-drop-in-a-script-tag) in `index.html` cover an error in IE11 when you attempt to authenticate with Auth0: the standard `crypto` support bundled into modern browsers is replaced by something called `msCrypto`, and so a shim is necessary to fallback to the latter in browsers where the former is unavailable.

Besides some visual hiccups, the app appears completely functional on Windows in both Edge and IE11, with the exception of the export buttons. I'm not sure if those are failing for reasons under control of the app or for environmental issues (running inside of a Parallels VM on my Mac), but more investigation is needed to fix that.

This has been tested successfully in stage.