### PR TITLE
Fixes exports of chart images and data in the MS browsers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "datatables": "^1.10.13",
     "debug": "~2.6.9",
     "dotenv": "^6.1.0",
+    "downloadjs": "^1.4.7",
     "easy-pie-chart": "^2.1.7",
     "env-cmd": "^9.0.3",
     "express": "^4.16.4",

--- a/src/assets/scripts/charts/chartJS/downloads.js
+++ b/src/assets/scripts/charts/chartJS/downloads.js
@@ -16,39 +16,17 @@
 // =============================================================================
 
 import { timeStamp } from '../../utils/time';
+import downloadjs from 'downloadjs';
 
 function downloadCanvasImage(canvas, filename) {
-  // create an "off-screen" anchor tag
-  const link = document.createElement('a');
-
-  // the key here is to set the download attribute of the a tag
-  link.download = filename;
-  link.href = canvas.toDataURL('image/png;base64');
-
-  // create a "fake" click-event to trigger the download
-  if (document.createEvent) {
-    const e = document.createEvent('MouseEvents');
-    e.initMouseEvent(
-      'click', true, true, window,
-      0, 0, 0, 0, 0, false, false, false, false, 0, null,
-    );
-
-    link.dispatchEvent(e);
-  } else if (link.fireEvent) {
-    link.fireEvent('onclick');
-  }
+  const data = canvas.toDataURL('image/png;base64');
+  downloadjs(data, filename, 'image/png;base64');
 }
 
 function downloadObjectAsJson(exportObj, exportName) {
   const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj, null, '\t'))}`;
-
-  const downloadAnchorNode = document.createElement('a');
-  downloadAnchorNode.setAttribute('href', dataStr);
-  downloadAnchorNode.setAttribute('download', `${exportName}.json`);
-  document.body.appendChild(downloadAnchorNode); // required for firefox
-
-  downloadAnchorNode.click();
-  downloadAnchorNode.remove();
+  const filename = `${exportName}.json`;
+  downloadjs(dataStr, filename, 'text/json');
 }
 
 function configureDownloadButtons(

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -45,7 +45,7 @@ const TopBar = (props) => {
             <li className="dropdown">
               <a href="#" onClick={() => loginWithRedirect({appState: { targetUrl: "/snapshots" }})} className="dropdown-toggle no-after peers fxw-nw ai-c lh-1" data-toggle="dropdown">
                 <div className="peer mR-10">
-                  <i class="ti-power-off"></i>
+                  <i className="ti-power-off"></i>
                 </div>
                 <div className="peer">
                   <span className="fsz-sm c-grey-900">Log in</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,6 +3241,10 @@ dotenv@6.2.0, dotenv@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
This closes #39. Replaces my artisan download code with a dedicated [library](https://github.com/rndme/download), which is how it should be.

Tested image and json exports successfully in multiple browsers in stage (and production, for the Friday morning release), including Edge and IE11.