### PR TITLE
Chart API sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,16 +163,17 @@ React [documentation](https://reactjs.org/docs/hello-world.html) is very high qu
 A quick overview of the directory structure and suggestions on where to put different things.
 
 ```
-/build
-/public
-/src
+/build/
+/public/
+/src/
   assets/
   components/
   utils/
   views/
-/static
-  fonts/
-  images/
+  App.js
+  index.js
+/server/
+server.js
 ```
 ### Application root (/)
 Home to files such as `server.js`, for running the backend server, and `package.json` for configuring build, dependencies, etc. Files in the application root are generally not bundled by Webpack.
@@ -184,7 +185,7 @@ The bundled, static frontend. This is what gets exposed on the public frontend s
 These are the raw public assets that form the _website itself_, i.e. `index.html` and the Favicon. When a build is generated, the contents of `src` are combined with the contents of `public` to generate `build`.
 
 ### src
-Application frontend source code. If you're writing it, it should most likely end up here.
+Application frontend source code. If you're writing it, it should most likely end up here or in `/server` below.
 
 #### src/assets
 This is where frontend assets should live. JS logic, e.g. for creating exported images and json files of a given visualization, should live in `src/assets/scripts`. Static assets and CSS should live in `src/assets/static` and `src/assets/styles`, respectively.
@@ -194,13 +195,20 @@ All React components should exist under this directory. Charts in particular liv
 
 Test files and CSS files should also be placed in the component directory.
 
-For further discussion on React application structure and rationale for the above choices, see [this blog post](https://hackernoon.com/the-100-correct-way-to-structure-a-react-app-or-why-theres-no-such-thing-3ede534ef1ed).
-
 #### src/utils
 Application configuration files, shared constants, etc.
 
-### src/views
+#### src/views
 This is where individual page layouts are constructed. The main app is configured via `src/App.js` which uses the React Router to route to appropriate views depending on the requested path, e.g. routing the `/revocations` path to `src/views/Revocations.js`.
+
+#### src/App.js and src/index.js
+`App.js` is where the primary application view is defined, i.e. the central page layout and the frontend routing. `index.js` is the actual entry point to the frontend, i.e. where the `ReactDOM` is rendered.
+
+### server
+Application backend source code. If you're writing it, it should most likely end up here or in `/src` above.
+
+### server.js
+The actual entry point to the backend, i.e. where the Node/Express server, middleware, and routing are defined.
 
 ## License
 This project is licensed under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/server/core/objectStorage.js
+++ b/server/core/objectStorage.js
@@ -12,13 +12,13 @@ const { Storage } = require('@google-cloud/storage');
  * Returns a Promise which will eventually return either an error or the contents of the file as a
  * Buffer of bytes.
  */
-function downloadFile(bucketName, srcFilename) {
+function downloadFile(bucketName, stateCode, srcFilename) {
   const storage = new Storage();
 
   // Returns a Promise that returns a Buffer with the file bytes once the download completes
   return storage
     .bucket(bucketName)
-    .file(srcFilename)
+    .file(`${stateCode}/${srcFilename}`)
     .download();
 }
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -84,12 +84,12 @@ function external(req, res) {
       'April': {probation: 16, parole: 36}
     },
     revocationCountsByMonthByViolationType: {
-      'November': {new_offense:17, absconsion:15,  technical:8},
-      'December': {new_offense:22, absconsion:19,  technical: 7},
-      'January': {new_offense:26, absconsion:24,  technical: 10},
-      'February': {new_offense:17, absconsion:21,  technical: 6},
-      'March': {new_offense:22, absconsion:24,  technical: 8},
-      'April': {new_offense:21, absconsion:23,  technical: 8},
+      'November': {newOffense:17, absconsion:15,  technical:8},
+      'December': {newOffense:22, absconsion:19,  technical: 7},
+      'January': {newOffense:26, absconsion:24,  technical: 10},
+      'February': {newOffense:17, absconsion:21,  technical: 6},
+      'March': {newOffense:22, absconsion:24,  technical: 8},
+      'April': {newOffense:21, absconsion:23,  technical: 8},
     },
     revocationCountsByOfficer: {
       '176': {technical: 7, nonTechnical: 2},

--- a/src/components/charts/programEvaluation/ProgramCostEffectiveness.js
+++ b/src/components/charts/programEvaluation/ProgramCostEffectiveness.js
@@ -2,47 +2,26 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS, COLORS_GOOD_BAD } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const ProgramCostEffectiveness = () => {
+const ProgramCostEffectiveness = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const costReductionByProgram = responseData.programCostEffectiveness;
+  const processResponse = () => {
+    const costReductionByProgram = props.programCostEffectiveness;
 
-    var byProgram = [];
+    var sorted = [];
     for (var program in costReductionByProgram) {
-        byProgram.push([program, costReductionByProgram[program]]);
+        sorted.push([program, costReductionByProgram[program]]);
     }
 
-    return byProgram;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.programCostEffectiveness]);
 
   return (
     <Bar data={{

--- a/src/components/charts/programEvaluation/RecidivismRateByProgram.js
+++ b/src/components/charts/programEvaluation/RecidivismRateByProgram.js
@@ -2,49 +2,28 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS, COLORS_STACKED_TWO_VALUES } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const RecidivismRateByProgram = () => {
+const RecidivismRateByProgram = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [newOffensesDataPoints, setNewOffensesDataPoints] = useState([]);
   const [revocationDataPoints, setRevocationDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const rateByProgram = responseData.recidivismRateByProgram;
+  const processResponse = () => {
+    const rateByProgram = props.recidivismRateByProgram;
 
-    var byProgram = [];
+    var sorted = [];
     for (var program in rateByProgram) {
-        byProgram.push([program, rateByProgram[program]]);
+        sorted.push([program, rateByProgram[program]]);
     }
 
-    return byProgram;
+    setChartLabels(sorted.map(element => element[0]));
+    setNewOffensesDataPoints(sorted.map(element => element[1].newOffenses));
+    setRevocationDataPoints(sorted.map(element => element[1].revocations));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setNewOffensesDataPoints(sorted.map(element => element[1].newOffenses));
-      setRevocationDataPoints(sorted.map(element => element[1].revocations));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.recidivismRateByProgram]);
 
   return (
     <Bar data={{

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -3,47 +3,26 @@ import React, { useState, useEffect } from "react";
 import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from "../../../assets/scripts/charts/chartJS/downloads";
 import { COLORS } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const ReincarcerationCountOverTime = () => {
+const ReincarcerationCountOverTime = props => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByMonth = responseData.reincarcerationCountsByMonth;
+  const processResponse = () => {
+    const countsByMonth = props.reincarcerationCountsByMonth;
 
-    var sortable = [];
+    var sorted = [];
     for (var month in countsByMonth) {
-        sortable.push([month, countsByMonth[month]]);
+        sorted.push([month, countsByMonth[month]]);
     }
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.reincarcerationCountsByMonth]);
 
   const chart =
     <Line id="reincarceration-drivers-chart" data={{

--- a/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
@@ -2,50 +2,29 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const ReincarcerationRateByReleaseFacility = () => {
+const ReincarcerationRateByReleaseFacility = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const ratesByFacility = responseData.ratesByReleaseFacility;
+  const processResponse = () => {
+    const ratesByFacility = props.ratesByReleaseFacility;
 
-    var sortable = [];
+    var sorted = [];
     for (var facility in ratesByFacility) {
-        sortable.push([facility, ratesByFacility[facility]]);
+        sorted.push([facility, ratesByFacility[facility]]);
     }
-    sortable.sort(function(a, b) {
+    sorted.sort(function(a, b) {
         return a[1] - b[1];
     });
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.ratesByReleaseFacility]);
 
   return (
     <Bar data={{

--- a/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
@@ -14,6 +14,7 @@ const ReincarcerationRateByReleaseFacility = (props) => {
     for (var facility in ratesByFacility) {
         sorted.push([facility, ratesByFacility[facility]]);
     }
+    // Sort the facilities in ascending order by rate
     sorted.sort(function(a, b) {
         return a[1] - b[1];
     });

--- a/src/components/charts/reincarcerations/ReincarcerationRateByStayLength.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByStayLength.js
@@ -2,50 +2,29 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const ReincarcerationRateByStayLength = () => {
+const ReincarcerationRateByStayLength = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const ratesByStayLength = responseData.ratesByStayLength;
+  const processResponse = () => {
+    const ratesByStayLength = props.ratesByStayLength;
 
-    var sortable = [];
+    var sorted = [];
     for (var stayLength in ratesByStayLength) {
-        sortable.push([stayLength, ratesByStayLength[stayLength]]);
+        sorted.push([stayLength, ratesByStayLength[stayLength]]);
     }
-    sortable.sort(function(a, b) {
+    sorted.sort(function(a, b) {
         return a[0] - b[0];
     });
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.ratesByStayLength]);
 
   return (
     <Bar data={{

--- a/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
@@ -2,50 +2,29 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const ReincarcerationRateByTransitionalFacility = () => {
+const ReincarcerationRateByTransitionalFacility = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const ratesByFacility = responseData.ratesByTransitionalFacility;
+  const processResponse = () => {
+    const ratesByFacility = props.ratesByTransitionalFacility;
 
-    var sortable = [];
+    var sorted = [];
     for (var facility in ratesByFacility) {
-        sortable.push([facility, ratesByFacility[facility]]);
+        sorted.push([facility, ratesByFacility[facility]]);
     }
-    sortable.sort(function(a, b) {
+    sorted.sort(function(a, b) {
         return a[1] - b[1];
     });
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.ratesByTransitionalFacility]);
 
   return (
     <Bar data={{

--- a/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
@@ -14,6 +14,7 @@ const ReincarcerationRateByTransitionalFacility = (props) => {
     for (var facility in ratesByFacility) {
         sorted.push([facility, ratesByFacility[facility]]);
     }
+    // Sort the facilities in ascending order by rate
     sorted.sort(function(a, b) {
         return a[1] - b[1];
     });

--- a/src/components/charts/reincarcerations/ReleasesVsAdmissions.js
+++ b/src/components/charts/reincarcerations/ReleasesVsAdmissions.js
@@ -2,47 +2,30 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS_GOOD_BAD } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const ReleasesVsAdmissions = () => {
+const ReleasesVsAdmissions = (props) => {
   const [apiMessage, setApiMessage] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const admissions = responseData.admissions;
-    const releases = responseData.releases;
+  const processResponse = () => {
+    const admissions = props.admissions;
+    const releases = props.releases;
+
+    if (!admissions || !releases) {
+      return;
+    }
 
     const deltas = [];
-
     var i;
     for (i = 0; i < admissions.length; i += 1) {
       deltas[i] = admissions[i] - releases[i];
     }
-    return deltas;
+
+    setApiMessage(deltas);
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const deltas = processResponse(responseData);
-
-      setApiMessage(deltas);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.admissions, props.releases]);
 
   return (
     <Bar data={{

--- a/src/components/charts/revocations/AdmissionTypeProportions.js
+++ b/src/components/charts/revocations/AdmissionTypeProportions.js
@@ -2,47 +2,26 @@ import React, { useState, useEffect } from "react";
 
 import { Pie } from 'react-chartjs-2';
 import { COLORS_FIVE_VALUES } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const AdmissionTypeProportions = () => {
+const AdmissionTypeProportions = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByAdmissionType = responseData.admissionCountsByType;
+  const processResponse = () => {
+    const countsByAdmissionType = props.admissionCountsByType;
 
-    var sortable = [];
+    var sorted = [];
     for (var admissionType in countsByAdmissionType) {
-        sortable.push([admissionType, countsByAdmissionType[admissionType]]);
+        sorted.push([admissionType, countsByAdmissionType[admissionType]]);
     }
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.admissionCountsByType]);
 
   return (
     <Pie data={{

--- a/src/components/charts/revocations/RevocationCountByOfficer.js
+++ b/src/components/charts/revocations/RevocationCountByOfficer.js
@@ -2,54 +2,33 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS_STACKED_TWO_VALUES } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const RevocationCountByOfficer = () => {
+const RevocationCountByOfficer = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [technicalDataPoints, setTechnicalDataPoints] = useState([]);
   const [nonTechnicalDataPoints, setNonTechnicalDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByOfficer = responseData.revocationCountsByOfficer;
+  const processResponse = () => {
+    const countsByOfficer = props.revocationCountsByOfficer;
 
-    var sortable = [];
+    var sorted = [];
     for (var officer in countsByOfficer) {
-        sortable.push([officer, countsByOfficer[officer]]);
+        sorted.push([officer, countsByOfficer[officer]]);
     }
-    sortable.sort(function(a, b) {
+    sorted.sort(function(a, b) {
       var aCounts = a[1];
       var bCounts = b[1];
       return (bCounts.technical + bCounts.nonTechnical) - (aCounts.technical + aCounts.nonTechnical);
     });
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setTechnicalDataPoints(sorted.map(element => element[1].technical));
+    setNonTechnicalDataPoints(sorted.map(element => element[1].nonTechnical));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setTechnicalDataPoints(sorted.map(element => element[1].technical));
-      setNonTechnicalDataPoints(sorted.map(element => element[1].nonTechnical));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.revocationCountsByOfficer]);
 
   return (
     <Bar data={{

--- a/src/components/charts/revocations/RevocationCountBySupervisionType.js
+++ b/src/components/charts/revocations/RevocationCountBySupervisionType.js
@@ -2,49 +2,28 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS_STACKED_TWO_VALUES } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const RevocationCountBySupervisionType = () => {
+const RevocationCountBySupervisionType = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [paroleDataPoints, setParoleDataPoints] = useState([]);
   const [probationDataPoints, setProbationDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByMonth = responseData.revocationCountsByMonthBySupervisionType;
+  const processResponse = () => {
+    const countsByMonth = props.revocationCountsByMonthBySupervisionType;
 
-    var byMonth = [];
+    var sorted = [];
     for (var month in countsByMonth) {
-        byMonth.push([month, countsByMonth[month]]);
+        sorted.push([month, countsByMonth[month]]);
     }
 
-    return byMonth;
+    setChartLabels(sorted.map(element => element[0]));
+    setParoleDataPoints(sorted.map(element => element[1].parole));
+    setProbationDataPoints(sorted.map(element => element[1].probation));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setParoleDataPoints(sorted.map(element => element[1].parole));
-      setProbationDataPoints(sorted.map(element => element[1].probation));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.revocationCountsByMonthBySupervisionType]);
 
   return (
     <Bar data={{

--- a/src/components/charts/revocations/RevocationCountByViolationType.js
+++ b/src/components/charts/revocations/RevocationCountByViolationType.js
@@ -2,51 +2,30 @@ import React, { useState, useEffect } from "react";
 
 import { Bar } from 'react-chartjs-2';
 import { COLORS_FIVE_VALUES } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const RevocationCountByViolationType = () => {
+const RevocationCountByViolationType = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [absconsionDataPoints, setAbsconsionDataPoints] = useState([]);
   const [newOffenseDataPoints, setNewOffenseDataPoints] = useState([]);
   const [technicalDataPoints, setTechnicalDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByMonth = responseData.revocationCountsByMonthByViolationType;
+  const processResponse = () => {
+    const countsByMonth = props.revocationCountsByMonthByViolationType;
 
-    var byMonth = [];
+    var sorted = [];
     for (var month in countsByMonth) {
-        byMonth.push([month, countsByMonth[month]]);
+        sorted.push([month, countsByMonth[month]]);
     }
 
-    return byMonth;
+    setChartLabels(sorted.map(element => element[0]));
+    setAbsconsionDataPoints(sorted.map(element => element[1].absconsion));
+    setNewOffenseDataPoints(sorted.map(element => element[1].newOffense));
+    setTechnicalDataPoints(sorted.map(element => element[1].technical));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setAbsconsionDataPoints(sorted.map(element => element[1].absconsion));
-      setNewOffenseDataPoints(sorted.map(element => element[1].new_offense));
-      setTechnicalDataPoints(sorted.map(element => element[1].technical));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.revocationCountsByMonthByViolationType]);
 
   return (
     <Bar data={{

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -3,47 +3,26 @@ import React, { useState, useEffect } from "react";
 import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from "../../../assets/scripts/charts/chartJS/downloads";
 import { COLORS } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const RevocationCountOverTime = () => {
+const RevocationCountOverTime = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByMonth = responseData.revocationCountsByMonth;
+  const processResponse = () => {
+    const countsByMonth = props.revocationCountsByMonth;
 
-    var sortable = [];
+    var sorted = [];
     for (var month in countsByMonth) {
-        sortable.push([month, countsByMonth[month]]);
+        sorted.push([month, countsByMonth[month]]);
     }
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.revocationCountsByMonth]);
 
   const chart =
     <Line id="revocation-drivers-chart" data={{

--- a/src/components/charts/revocations/RevocationProportionByRace.js
+++ b/src/components/charts/revocations/RevocationProportionByRace.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 
 import { HorizontalBar } from 'react-chartjs-2';
 import { COLORS_FIVE_VALUES, COLORS } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
 const ND_RACE_PROPORTIONS = {
   'American Indian Alaskan Native': 5.4,
@@ -12,47 +11,27 @@ const ND_RACE_PROPORTIONS = {
   'Other': 2.3,
 }
 
-const RevocationProportionByRace = () => {
+const RevocationProportionByRace = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartProportions, setChartProportions] = useState([]);
   const [statePopulationProportions, setStateProportions] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const proportionsByRace = responseData.revocationProportionByRace;
+  const processResponse = () => {
+    const proportionsByRace = props.revocationProportionByRace;
 
-    var sortable = [];
+    var sorted = [];
     for (var race in proportionsByRace) {
-        sortable.push([race, proportionsByRace[race]]);
+        sorted.push([race, proportionsByRace[race]]);
     }
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartProportions(sorted.map(element => element[1]));
+    setStateProportions(sorted.map(element => ND_RACE_PROPORTIONS[element[0]]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartProportions(sorted.map(element => element[1]));
-      setStateProportions(sorted.map(element => ND_RACE_PROPORTIONS[element[0]]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.revocationProportionByRace]);
 
   return (
     <HorizontalBar data={{

--- a/src/components/charts/snapshots/RevocationCountSnapshot.js
+++ b/src/components/charts/snapshots/RevocationCountSnapshot.js
@@ -3,47 +3,26 @@ import React, { useState, useEffect } from "react";
 import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from "../../../assets/scripts/charts/chartJS/downloads";
 import { COLORS, COLORS_THREE_VALUES } from "../../../assets/scripts/constants/colors";
-import { useAuth0 } from "../../../react-auth0-spa";
 
-const RevocationCountSnapshot = () => {
+const RevocationCountSnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
-  const { getTokenSilently } = useAuth0();
 
-  const processResponse = (responseData) => {
-    const countsByMonth = responseData.revocationCountsByMonth;
+  const processResponse = () => {
+    const countsByMonth = props.revocationCountsByMonth;
 
-    var sortable = [];
+    var sorted = [];
     for (var month in countsByMonth) {
-        sortable.push([month, countsByMonth[month]]);
+        sorted.push([month, countsByMonth[month]]);
     }
 
-    return sortable;
+    setChartLabels(sorted.map(element => element[0]));
+    setChartDataPoints(sorted.map(element => element[1]));
   }
 
-  const fetchChartData = async () => {
-    try {
-      const token = await getTokenSilently();
-      // Likely needs to point to app engine URL
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
-      const sorted = processResponse(responseData);
-
-      setChartLabels(sorted.map(element => element[0]));
-      setChartDataPoints(sorted.map(element => element[1]));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   useEffect(() => {
-    fetchChartData();
-  }, []);
+    processResponse();
+  }, [props.revocationCountsByMonth]);
 
   const chart =
     <Line id='revocation-snapshot-chart'  data={{

--- a/src/views/ProgramEvaluation.js
+++ b/src/views/ProgramEvaluation.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import Loading from "../components/Loading";
 import "../assets/styles/index.scss";
@@ -113,6 +113,9 @@ const CARDS = {
 }
 
 const ProgramEvaluation = () => {
+  const { loading, user, getTokenSilently } = useAuth0();
+  const [apiData, setApiData] = useState({});
+
   const [reportCardTitle, setReportCardTitle] = useState(REPORT_CARD_A.title);
   const [reportCardDescription, setReportCardDescription] = useState(REPORT_CARD_A.description);
   const [reportCardType, setReportCardType] = useState(REPORT_CARD_A.type);
@@ -144,7 +147,25 @@ const ProgramEvaluation = () => {
     setReportCardRevocation3(card.thirdYearRevocation);
   }
 
-  const { loading, user } = useAuth0();
+  const fetchChartData = async () => {
+    try {
+      const token = await getTokenSilently();
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      const responseData = await response.json();
+      setApiData(responseData);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchChartData();
+  }, []);
 
   if (loading || !user) {
     return <Loading />;
@@ -154,7 +175,7 @@ const ProgramEvaluation = () => {
     <main className="main-content bgc-grey-100">
       <script src="../../assets/scripts/metrics/programReportCards.js" />
       <div id="mainContent">
-        <h5 class="lh-1 font-weight-bold pB-20">Note: The following charts describe fake programs with fake data.</h5>
+        <h5 className="lh-1 font-weight-bold pB-20">Note: The following charts describe fake programs with fake data.</h5>
 
         <div className="row gap-20 masonry pos-r">
           <div className="masonry-sizer col-md-6" />
@@ -167,7 +188,7 @@ const ProgramEvaluation = () => {
                   <h4 className="lh-1">Recidivism rate for <b>Program A</b> was <b>4.2%</b> below baseline</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <RecidivismRateByProgram />
+                  <RecidivismRateByProgram recidivismRateByProgram={apiData.recidivismRateByProgram} />
                 </div>
                 <div className="layer bdT p-20 w-100">
                   <div className="peers ai-c jc-c gapX-20">
@@ -197,7 +218,7 @@ const ProgramEvaluation = () => {
                   <h4 className="lh-1"><b>Program B</b> saved ND <b>$704,000</b> per 100 participants</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <ProgramCostEffectiveness />
+                  <ProgramCostEffectiveness programCostEffectiveness={apiData.programCostEffectiveness} />
                 </div>
                 <div className="layer bdT p-20 w-100">
                   <div className="peers ai-c jc-c gapX-20">

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Loading from "../components/Loading";
 import "../assets/styles/index.scss";
@@ -11,9 +11,32 @@ import ReincarcerationRateByStayLength from "../components/charts/reincarceratio
 import ReincarcerationCountOverTime from "../components/charts/reincarcerations/ReincarcerationCountOverTime";
 
 const Reincarcerations = () => {
-  const { loading, user } = useAuth0();
+  const { loading, user, getTokenSilently } = useAuth0();
+  const [apiData, setApiData] = useState({});
+  const [awaitingApi, setAwaitingApi] = useState(true);
 
-  if (loading || !user) {
+  const fetchChartData = async () => {
+    try {
+      const token = await getTokenSilently();
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      const responseData = await response.json();
+      setApiData(responseData);
+      setAwaitingApi(false);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchChartData();
+  }, []);
+
+  if (loading || !user || awaitingApi) {
     return <Loading />;
   }
 
@@ -46,7 +69,7 @@ const Reincarcerations = () => {
                 <div className="layer w-100 pX-20 pT-20 row">
                   <div className="col-md-12">
                     <div className="layer w-100 p-20">
-                      <ReincarcerationCountOverTime />
+                      <ReincarcerationCountOverTime reincarcerationCountsByMonth={apiData.reincarcerationCountsByMonth} />
                     </div>
                   </div>
                 </div>
@@ -80,7 +103,7 @@ const Reincarcerations = () => {
                   <h4 className="lh-1">The ND facilities <span className="font-weight-bold">grew</span> by <span className="font-weight-bold">22</span> people this month</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <ReleasesVsAdmissions />
+                  <ReleasesVsAdmissions admissions={apiData.admissions} releases={apiData.releases} />
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyReleasesVsAdmissions">
                   <div className="mb-0" id="methodologyHeadingReleasesVsAdmissions">
@@ -114,7 +137,7 @@ const Reincarcerations = () => {
                 <div className="layer w-100 p-20">
                   <div className="ai-c jc-c gapX-20">
                     <div className="col-md-12">
-                      <ReincarcerationRateByReleaseFacility />
+                      <ReincarcerationRateByReleaseFacility ratesByReleaseFacility={apiData.ratesByReleaseFacility} />
                     </div>
                   </div>
                 </div>
@@ -166,7 +189,7 @@ const Reincarcerations = () => {
                 <div className="layer w-100 p-20">
                   <div className="ai-c jc-c gapX-20">
                     <div className="col-md-12">
-                      <ReincarcerationRateByTransitionalFacility />
+                      <ReincarcerationRateByTransitionalFacility ratesByTransitionalFacility={apiData.ratesByTransitionalFacility} />
                     </div>
                   </div>
                 </div>
@@ -216,7 +239,7 @@ const Reincarcerations = () => {
                   <h4 className="lh-1">Reincarceration rate by previous stay length</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <ReincarcerationRateByStayLength />
+                  <ReincarcerationRateByStayLength ratesByStayLength={apiData.ratesByStayLength} />
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyReincarcerationsByStayLength">
                   <div className="mb-0" id="methodologyHeadingReincarcerationsByStayLength">

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Loading from "../components/Loading";
 import "../assets/styles/index.scss";
@@ -12,9 +12,32 @@ import AdmissionTypeProportions from "../components/charts/revocations/Admission
 import RevocationProportionByRace from "../components/charts/revocations/RevocationProportionByRace";
 
 const Revocations = () => {
-  const { loading, user } = useAuth0();
+  const { loading, user, getTokenSilently } = useAuth0();
+  const [apiData, setApiData] = useState({});
+  const [awaitingApi, setAwaitingApi] = useState(true);
 
-  if (loading || !user) {
+  const fetchChartData = async () => {
+    try {
+      const token = await getTokenSilently();
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      const responseData = await response.json();
+      setApiData(responseData);
+      setAwaitingApi(false);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchChartData();
+  }, []);
+
+  if (loading || !user || awaitingApi) {
     return <Loading />;
   }
 
@@ -47,7 +70,7 @@ const Revocations = () => {
                 <div className="layer w-100 pX-20 pT-20 row">
                   <div className="col-md-12">
                     <div className="layer w-100 p-20">
-                      <RevocationCountOverTime />
+                      <RevocationCountOverTime revocationCountsByMonth={apiData.revocationCountsByMonth} />
                     </div>
                   </div>
                 </div>
@@ -82,7 +105,7 @@ const Revocations = () => {
                   <h4 className="lh-1">Revocations by supervision type</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <RevocationCountBySupervisionType />
+                  <RevocationCountBySupervisionType revocationCountsByMonthBySupervisionType={apiData.revocationCountsByMonthBySupervisionType} />
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationBySupervisionType">
                   <div className="mb-0" id="methodologyHeadingRevocationBySupervisiontype">
@@ -122,7 +145,7 @@ const Revocations = () => {
                   <h4 className="lh-1">Revocations by violation type</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <RevocationCountByViolationType />
+                  <RevocationCountByViolationType revocationCountsByMonthByViolationType={apiData.revocationCountsByMonthByViolationType} />
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationsByViolationType">
                   <div className="mb-0" id="methodologyHeadingRevocationsByViolationType">
@@ -162,7 +185,7 @@ const Revocations = () => {
                   <h4 className="lh-1">Revocations by officer</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <RevocationCountByOfficer />
+                  <RevocationCountByOfficer revocationCountsByOfficer={apiData.revocationCountsByOfficer} />
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationByOfficer">
                   <div className="mb-0" id="methodologyHeadingRevocationByOfficer">
@@ -202,7 +225,7 @@ const Revocations = () => {
                   <h4 className="lh-1">Admission type proportions</h4>
                 </div>
                 <div className="layer w-100 p-20">
-                  <AdmissionTypeProportions />
+                  <AdmissionTypeProportions admissionCountsByType={apiData.admissionCountsByType} />
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyAdmissionProportions">
                   <div className="mb-0" id="methodologyHeadingAdmissionProportions">
@@ -244,7 +267,7 @@ const Revocations = () => {
                 </div>
                 <div className="layer w-100 pX-20 pT-20 row">
                   <div className="layer w-100 p-20">
-                    <RevocationProportionByRace />
+                    <RevocationProportionByRace revocationProportionByRace={apiData.revocationProportionByRace} />
                   </div>
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationsByRace">

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
 import Loading from "../components/Loading";
@@ -10,7 +10,30 @@ import RevocationCountSnapshot from "../components/charts/snapshots/RevocationCo
 import ReincarcerationCountSnapshot from "../components/charts/snapshots/ReincarcerationCountSnapshot";
 
 const Snapshots = () => {
-  const { loading, user } = useAuth0();
+  const { loading, user, getTokenSilently } = useAuth0();
+  const [apiData, setApiData] = useState({});
+  const [awaitingApi, setAwaitingApi] = useState(true);
+
+  const fetchChartData = async () => {
+    try {
+      const token = await getTokenSilently();
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/external`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      const responseData = await response.json();
+      setApiData(responseData);
+      setAwaitingApi(false);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchChartData();
+  }, []);
 
   if (loading || !user) {
     return <Loading />;
@@ -139,7 +162,7 @@ const Snapshots = () => {
                 <div className="layer w-100 p-20">
                   <div className="ai-c jc-c gapX-20">
                     <div className="col-md-12">
-                      <ReincarcerationCountSnapshot />
+                      <ReincarcerationCountSnapshot admissions={apiData.admissions} reincarcerationCountsByMonth={apiData.reincarcerationCountsByMonth} />
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This goes towards #28 but does not complete it.

This change makes it so that API calls to the backend originate from the view logic, e.g. `views/reincarcerations`, instead of from each individual chart component. This is not only a nice reduction in duplication and thinning of the chart contract, but it is important in that it will align much neater with the live API calls when we are ready to cut over.

The pattern here is that all of the `fetchChartData` calls have been extracted out of the many `src/components/charts` files into the 4 `src/views` files. Those files then break apart the larger API response to pass down portions to individual charts, where chart-specific processing continues.