### PR TITLE
Removing program evaluation tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,6 @@ import Footer from "./components/Footer";
 import Home from "./views/Home";
 import NotFound from "./views/NotFound";
 import Profile from "./views/Profile";
-import ProgramEvaluation from "./views/ProgramEvaluation";
 import Revocations from "./views/Revocations";
 import Reincarcerations from "./views/Reincarcerations";
 import Snapshots from "./views/Snapshots";
@@ -109,7 +108,6 @@ const App = () => {
                 <PrivateRoute path="/snapshots" component={Snapshots} />
                 <PrivateRoute path="/revocations" component={Revocations} />
                 <PrivateRoute path="/reincarcerations" component={Reincarcerations} />
-                <PrivateRoute path="/program-evaluation" component={ProgramEvaluation} />
                 <PrivateRoute path="/profile" component={Profile} />
                 <PrivateRoute path="/external-api" component={ExternalApi} />
                 <Route component={NotFound} />

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -77,14 +77,6 @@ const SideBar = () => {
               <span className="title">Reincarcerations</span>
             </a>
           </li>
-          <li className="nav-item">
-            <a className="sidebar-link" href="program-evaluation">
-              <span className="icon-holder">
-                <i className="c-orange-500 ti-ruler-alt" />
-              </span>
-              <span className="title">Program Evaluation</span>
-            </a>
-          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
In the next release of the dashboard, we are going to have all **real** and **live** data, so we want to remove any fake or non-updated data. Temporarily disabling the program evaluation tab until we have real program eval metrics to report.