### PR TITLE
Adds mistakenly ignored package.json file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,4 @@ yarn-debug.log*
 yarn-error.log*
 
 # Package files
-package.json
 package-lock.json


### PR DESCRIPTION
This file should not be git-ignored, just `package-lock.json`. If you have any local changes you've made, we should issue a PR to add those now.