### PR TITLE
Updates to charts with goal lines, adding methodology to snapshots

### DIFF
--- a/src/components/charts/reincarcerations/AdmissionsVsReleases.js
+++ b/src/components/charts/reincarcerations/AdmissionsVsReleases.js
@@ -15,13 +15,13 @@ const AdmissionsVsReleases = (props) => {
     const dataPoints = [];
     admissionsVsReleases.forEach((data) => {
       const { year, month, population_change: delta } = data;
-      dataPoints.push([year, month, delta]);
+      dataPoints.push({ year, month, delta });
     });
 
     const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
 
-    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), false));
-    setChartDataPoints(sorted.map((element) => element[2]));
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), false));
+    setChartDataPoints(sorted.map((element) => element.delta));
   };
 
   useEffect(() => {

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -22,14 +22,14 @@ const ReincarcerationCountOverTime = (props) => {
     const dataPoints = [];
     countsByMonth.forEach((data) => {
       const { year, month, returns: count } = data;
-      dataPoints.push([year, month, count]);
+      dataPoints.push({ year, month, count });
     });
 
     const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
-    const chartDataValues = (sorted.map((element) => element[2]));
+    const chartDataValues = (sorted.map((element) => element.count));
     const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
-    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), false));
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), false));
     setChartDataPoints(chartDataValues);
     setChartMinValue(0);
     setChartMaxValue(max);

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -5,7 +5,7 @@ import { configureDownloadButtons } from '../../../assets/scripts/charts/chartJS
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
-import { getGoalForChart, getMaxForGoalAndData } from '../../../utils/metricGoal';
+import { getGoalForChart, getMaxForGoalAndData, goalLabelContentString } from '../../../utils/metricGoal';
 
 const ReincarcerationCountOverTime = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
@@ -102,7 +102,7 @@ const ReincarcerationCountOverTime = (props) => {
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: '.concat(GOAL.label),
+              content: goalLabelContentString(GOAL),
               position: 'right',
 
               // Background color of label, default below

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -5,10 +5,16 @@ import { configureDownloadButtons } from '../../../assets/scripts/charts/chartJS
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { getGoalForChart, getMaxForGoalAndData } from '../../../utils/metricGoal';
 
 const ReincarcerationCountOverTime = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
+  const [chartMinValue, setChartMinValue] = useState();
+  const [chartMaxValue, setChartMaxValue] = useState();
+
+  const GOAL = getGoalForChart('US_ND', 'reincarceration-counts-by-month-chart');
+  const stepSize = 10;
 
   const processResponse = () => {
     const { reincarcerationCountsByMonth: countsByMonth } = props;
@@ -20,9 +26,13 @@ const ReincarcerationCountOverTime = (props) => {
     });
 
     const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
+    const chartDataValues = (sorted.map((element) => element[2]));
+    const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
     setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), false));
-    setChartDataPoints(sorted.map((element) => element[2]));
+    setChartDataPoints(chartDataValues);
+    setChartMinValue(0);
+    setChartMaxValue(max);
   };
 
   useEffect(() => {
@@ -31,7 +41,7 @@ const ReincarcerationCountOverTime = (props) => {
 
   const chart = (
     <Line
-      id="reincarceration-drivers-chart"
+      id="reincarceration-counts-by-month-chart"
       data={{
         labels: chartLabels,
         datasets: [{
@@ -60,7 +70,9 @@ const ReincarcerationCountOverTime = (props) => {
           }],
           yAxes: [{
             ticks: {
-              min: 0,
+              min: chartMinValue,
+              max: chartMaxValue,
+              stepSize,
             },
             scaleLabel: {
               display: true,
@@ -76,21 +88,21 @@ const ReincarcerationCountOverTime = (props) => {
           annotations: [{
             type: 'line',
             mode: 'horizontal',
-            value: 40,
+            value: GOAL.value,
 
             // optional annotation ID (must be unique)
-            id: 'recidivism-drivers-goal-line',
+            id: 'reincarceration-counts-by-month-goal-line',
             scaleID: 'y-axis-0',
 
             drawTime: 'afterDatasetsDraw',
 
-            borderColor: 'red',
+            borderColor: COLORS['red-standard'],
             borderWidth: 2,
             borderDash: [2, 2],
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: 40',
+              content: 'goal: '.concat(GOAL.label),
               position: 'right',
 
               // Background color of label, default below
@@ -99,7 +111,7 @@ const ReincarcerationCountOverTime = (props) => {
               fontFamily: 'sans-serif',
               fontSize: 12,
               fontStyle: 'bold',
-              fontColor: COLORS['red-400'],
+              fontColor: COLORS['red-standard'],
 
               // Adjustment along x-axis (left-right) of label relative to above
               // number (can be negative). For horizontal lines positioned left

--- a/src/components/charts/revocations/RevocationCountBySupervisionType.js
+++ b/src/components/charts/revocations/RevocationCountBySupervisionType.js
@@ -19,18 +19,18 @@ const RevocationCountBySupervisionType = (props) => {
       const {
         year, month, parole_count: paroleCount, probation_count: probationCount,
       } = data;
-      paroleData.push([year, month, paroleCount]);
-      probationData.push([year, month, probationCount]);
+      paroleData.push({ year, month, paroleCount });
+      probationData.push({ year, month, probationCount });
     });
 
     const sortedParoleData = sortAndFilterMostRecentMonths(paroleData, 6);
     const sortedProbationData = sortAndFilterMostRecentMonths(probationData, 6);
 
     setChartLabels(monthNamesWithYearsFromNumbers(sortedParoleData.map(
-      (element) => element[1],
+      (element) => element.month,
     ), false));
-    setParoleDataPoints(sortedParoleData.map((element) => element[2]));
-    setProbationDataPoints(sortedProbationData.map((element) => element[2]));
+    setParoleDataPoints(sortedParoleData.map((element) => element.paroleCount));
+    setProbationDataPoints(sortedProbationData.map((element) => element.probationCount));
   };
 
   useEffect(() => {

--- a/src/components/charts/revocations/RevocationCountByViolationType.js
+++ b/src/components/charts/revocations/RevocationCountByViolationType.js
@@ -30,7 +30,7 @@ const RevocationCountByViolationType = (props) => {
         UNKNOWN_VIOLATION_TYPE: unknownCount,
       };
 
-      dataPoints.push([year, month, monthDict]);
+      dataPoints.push({ year, month, monthDict });
     });
 
     const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
@@ -44,8 +44,8 @@ const RevocationCountByViolationType = (props) => {
     };
 
     for (let i = 0; i < 6; i += 1) {
-      monthsLabels.push(sorted[i][1]);
-      const data = sorted[i][2];
+      monthsLabels.push(sorted[i].month);
+      const data = sorted[i].monthDict;
       Object.keys(data).forEach((violationType) => {
         violationArrays[violationType].push(data[violationType]);
       });

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -5,10 +5,16 @@ import { configureDownloadButtons } from '../../../assets/scripts/charts/chartJS
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { getGoalForChart, getMaxForGoalAndData } from '../../../utils/metricGoal';
 
 const RevocationCountOverTime = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
+  const [chartMinValue, setChartMinValue] = useState();
+  const [chartMaxValue, setChartMaxValue] = useState();
+
+  const GOAL = getGoalForChart('US_ND', 'revocation-counts-by-month-chart');
+  const stepSize = 10;
 
   const processResponse = () => {
     const { revocationCountsByMonth: countsByMonth } = props;
@@ -20,9 +26,13 @@ const RevocationCountOverTime = (props) => {
     });
 
     const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
+    const chartDataValues = (sorted.map((element) => element[2]));
+    const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
     setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), false));
-    setChartDataPoints(sorted.map((element) => element[2]));
+    setChartDataPoints(chartDataValues);
+    setChartMinValue(0);
+    setChartMaxValue(max);
   };
 
   useEffect(() => {
@@ -31,7 +41,7 @@ const RevocationCountOverTime = (props) => {
 
   const chart = (
     <Line
-      id="revocation-drivers-chart"
+      id="revocation-counts-by-month-chart"
       data={{
         labels: chartLabels,
         datasets: [{
@@ -60,7 +70,9 @@ const RevocationCountOverTime = (props) => {
           }],
           yAxes: [{
             ticks: {
-              min: 0,
+              min: chartMinValue,
+              max: chartMaxValue,
+              stepSize,
             },
             scaleLabel: {
               display: true,
@@ -76,21 +88,21 @@ const RevocationCountOverTime = (props) => {
           annotations: [{
             type: 'line',
             mode: 'horizontal',
-            value: 40,
+            value: GOAL.value,
 
             // optional annotation ID (must be unique)
-            id: 'revocation-drivers-goal-line',
+            id: 'revocation-counts-by-month-goal-line',
             scaleID: 'y-axis-0',
 
             drawTime: 'afterDatasetsDraw',
 
-            borderColor: 'red',
+            borderColor: COLORS['red-standard'],
             borderWidth: 2,
             borderDash: [2, 2],
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: 40',
+              content: 'goal: '.concat(GOAL.label),
               position: 'right',
 
               // Background color of label, default below
@@ -99,7 +111,7 @@ const RevocationCountOverTime = (props) => {
               fontFamily: 'sans-serif',
               fontSize: 12,
               fontStyle: 'bold',
-              fontColor: COLORS['red-400'],
+              fontColor: COLORS['red-standard'],
 
               // Adjustment along x-axis (left-right) of label relative to above
               // number (can be negative). For horizontal lines positioned left

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -22,14 +22,14 @@ const RevocationCountOverTime = (props) => {
     const dataPoints = [];
     countsByMonth.forEach((data) => {
       const { year, month, revocation_count: count } = data;
-      dataPoints.push([year, month, count]);
+      dataPoints.push({ year, month, count });
     });
 
     const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
-    const chartDataValues = (sorted.map((element) => element[2]));
+    const chartDataValues = (sorted.map((element) => element.count));
     const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
-    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), false));
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), false));
     setChartDataPoints(chartDataValues);
     setChartMinValue(0);
     setChartMaxValue(max);

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -5,7 +5,7 @@ import { configureDownloadButtons } from '../../../assets/scripts/charts/chartJS
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
-import { getGoalForChart, getMaxForGoalAndData } from '../../../utils/metricGoal';
+import { getGoalForChart, getMaxForGoalAndData, goalLabelContentString } from '../../../utils/metricGoal';
 
 const RevocationCountOverTime = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
@@ -102,7 +102,7 @@ const RevocationCountOverTime = (props) => {
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: '.concat(GOAL.label),
+              content: goalLabelContentString(GOAL),
               position: 'right',
 
               // Background color of label, default below

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -17,6 +17,7 @@ const DaysAtLibertySnapshot = (props) => {
   const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'days-at-liberty-snapshot-chart');
+  const stepSize = 200;
 
   const processResponse = () => {
     const { daysAtLibertyByMonth } = props;
@@ -32,8 +33,8 @@ const DaysAtLibertySnapshot = (props) => {
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
       const chartDataValues = sorted.map((element) => element[2]);
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 100);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 100);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
       setChartDataPoints(chartDataValues);
@@ -102,6 +103,7 @@ const DaysAtLibertySnapshot = (props) => {
               fontColor: COLORS['grey-600'],
               min: chartMinValue,
               max: chartMaxValue,
+              stepSize,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -28,15 +28,15 @@ const DaysAtLibertySnapshot = (props) => {
       daysAtLibertyByMonth.forEach((data) => {
         const { year, month } = data;
         const average = parseFloat(data.avg_liberty).toFixed(2);
-        dataPoints.push([year, month, average]);
+        dataPoints.push({ year, month, average });
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = sorted.map((element) => element[2]);
+      const chartDataValues = sorted.map((element) => element.average);
       const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
       const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
+      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
       setChartDataPoints(chartDataValues);
       setChartMinValue(min);
       setChartMaxValue(max);

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -8,6 +8,7 @@ import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
 import {
   getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+  goalLabelContentString,
 } from '../../../utils/metricGoal';
 
 const DaysAtLibertySnapshot = (props) => {
@@ -139,7 +140,7 @@ const DaysAtLibertySnapshot = (props) => {
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: '.concat(GOAL.label),
+              content: goalLabelContentString(GOAL),
               position: 'right',
 
               // Background color of label, default below

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -6,11 +6,15 @@ import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
-import { getGoalForChart, trendlineGoalText } from '../../../utils/metricGoal';
+import {
+  getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+} from '../../../utils/metricGoal';
 
 const DaysAtLibertySnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
+  const [chartMinValue, setChartMinValue] = useState();
+  const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'days-at-liberty-snapshot-chart');
 
@@ -27,9 +31,14 @@ const DaysAtLibertySnapshot = (props) => {
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+      const chartDataValues = sorted.map((element) => element[2]);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 100);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 100);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
-      setChartDataPoints(sorted.map((element) => element[2]));
+      setChartDataPoints(chartDataValues);
+      setChartMinValue(min);
+      setChartMaxValue(max);
     }
   };
 
@@ -91,8 +100,8 @@ const DaysAtLibertySnapshot = (props) => {
           yAxes: [{
             ticks: {
               fontColor: COLORS['grey-600'],
-              min: 500,
-              max: 1200,
+              min: chartMinValue,
+              max: chartMaxValue,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -29,15 +29,15 @@ const LsirScoreChangeSnapshot = (props) => {
         const { termination_year: year, termination_month: month } = data;
         const change = parseFloat(data.average_change).toFixed(2);
 
-        dataPoints.push([year, month, change]);
+        dataPoints.push({ year, month, change });
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = sorted.map((element) => element[2]);
+      const chartDataValues = sorted.map((element) => element.change);
       const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
       const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
+      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
       setChartDataPoints(chartDataValues);
       setChartMinValue(min);
       setChartMaxValue(max);

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -17,6 +17,7 @@ const LsirScoreChangeSnapshot = (props) => {
   const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'lsir-score-change-snapshot-chart');
+  const stepSize = 0.5;
 
   const processResponse = () => {
     const { lsirScoreChangeByMonth: changeByMonth } = props;
@@ -33,8 +34,8 @@ const LsirScoreChangeSnapshot = (props) => {
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
       const chartDataValues = sorted.map((element) => element[2]);
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 1);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 1);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
       setChartDataPoints(chartDataValues);
@@ -103,6 +104,7 @@ const LsirScoreChangeSnapshot = (props) => {
               fontColor: COLORS['grey-600'],
               min: chartMinValue,
               max: chartMaxValue,
+              stepSize,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -185,7 +185,7 @@ const LsirScoreChangeSnapshot = (props) => {
   const trendlineText = trendlineGoalText(trendlineValues, GOAL);
 
   if (header) {
-    const title = `The average change in LSIR scores between intake and termination of supervision has been <b style='color:#809AE5'> trending ${trendlineText}. </b>`;
+    const title = `The average change in LSIR scores between first reassessment and termination of supervision has been <b style='color:#809AE5'> trending ${trendlineText}. </b>`;
     header.innerHTML = title;
   }
 

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -6,11 +6,15 @@ import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
-import { getGoalForChart, trendlineGoalText } from '../../../utils/metricGoal';
+import {
+  getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+} from '../../../utils/metricGoal';
 
 const LsirScoreChangeSnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
+  const [chartMinValue, setChartMinValue] = useState();
+  const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'lsir-score-change-snapshot-chart');
 
@@ -28,9 +32,14 @@ const LsirScoreChangeSnapshot = (props) => {
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+      const chartDataValues = sorted.map((element) => element[2]);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 1);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 1);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
-      setChartDataPoints(sorted.map((element) => element[2]));
+      setChartDataPoints(chartDataValues);
+      setChartMinValue(min);
+      setChartMaxValue(max);
     }
   };
 
@@ -92,8 +101,8 @@ const LsirScoreChangeSnapshot = (props) => {
           yAxes: [{
             ticks: {
               fontColor: COLORS['grey-600'],
-              min: -1.5,
-              max: 1.5,
+              min: chartMinValue,
+              max: chartMaxValue,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -8,6 +8,7 @@ import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
 import {
   getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+  goalLabelContentString,
 } from '../../../utils/metricGoal';
 
 const LsirScoreChangeSnapshot = (props) => {
@@ -140,7 +141,7 @@ const LsirScoreChangeSnapshot = (props) => {
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: '.concat(GOAL.label),
+              content: goalLabelContentString(GOAL),
               position: 'right',
 
               // Background color of label, default below

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -8,6 +8,7 @@ import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
 import {
   getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+  goalLabelContentString,
 } from '../../../utils/metricGoal';
 
 const RevocationAdmissionsSnapshot = (props) => {
@@ -145,7 +146,7 @@ const RevocationAdmissionsSnapshot = (props) => {
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: '.concat(GOAL.label),
+              content: goalLabelContentString(GOAL),
               position: 'right',
 
               // Background color of label, default below

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -15,6 +15,7 @@ const RevocationAdmissionsSnapshot = (props) => {
   const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'revocation-admissions-snapshot-chart');
+  const stepSize = 10;
 
   const processResponse = () => {
     const { revocationAdmissionsByMonth: countsByMonth } = props;
@@ -36,8 +37,8 @@ const RevocationAdmissionsSnapshot = (props) => {
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
       const chartDataValues = sorted.map((element) => element[2]);
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 10);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 10);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
       setChartDataPoints(chartDataValues);
@@ -106,6 +107,7 @@ const RevocationAdmissionsSnapshot = (props) => {
               fontColor: COLORS['grey-600'],
               min: chartMinValue,
               max: chartMaxValue,
+              stepSize,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -34,15 +34,15 @@ const RevocationAdmissionsSnapshot = (props) => {
         const total = technicals + nonTechnicals + unknownRevocations + newAdmissions;
         const revocations = (technicals + nonTechnicals + unknownRevocations);
         const percentRevocations = (100 * (revocations / total)).toFixed(2);
-        dataPoints.push([year, month, percentRevocations]);
+        dataPoints.push({ year, month, percentRevocations });
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = sorted.map((element) => element[2]);
+      const chartDataValues = sorted.map((element) => element.percentRevocations);
       const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
       const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
+      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
       setChartDataPoints(chartDataValues);
       setChartMinValue(min);
       setChartMaxValue(max);

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -3,10 +3,12 @@ import React, { useState, useEffect } from 'react';
 import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from '../../../assets/scripts/charts/chartJS/downloads';
 import { COLORS } from '../../../assets/scripts/constants/colors';
-import { monthNamesWithYearsFromNumbers, monthNamesFromShortName } from '../../../utils/monthConversion';
+import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
-import { getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData } from '../../../utils/metricGoal';
+import {
+  getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+} from '../../../utils/metricGoal';
 
 const RevocationAdmissionsSnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
@@ -183,16 +185,12 @@ const RevocationAdmissionsSnapshot = (props) => {
   configureDownloadButtons('revocationAdmissions', 'Snapshot', chart.props,
     document.getElementById('revocation-admissions-snapshot-chart'), exportedStructureCallback);
 
-  const chartData = chart.props.data.datasets[0].data;
-  const mostRecentValue = chartData[chartData.length - 1];
-
-  const chartDataLabels = chart.props.data.labels;
-  const mostRecentMonth = monthNamesFromShortName(chartDataLabels[chartDataLabels.length - 1]);
-
   const header = document.getElementById(props.header);
+  const trendlineValues = chart.props.data.datasets[1].data;
+  const trendlineText = trendlineGoalText(trendlineValues, GOAL);
 
-  if (header && mostRecentValue && mostRecentMonth) {
-    const title = `<b style='color:#809AE5'>${mostRecentValue}% of prison admissions</b> in ${mostRecentMonth} were due to parole or probation revocations.`;
+  if (header) {
+    const title = `The percent of prison admissions due to revocations of probation and parole has been <b style='color:#809AE5'>trending ${trendlineText}.</b>`;
     header.innerHTML = title;
   }
 

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -6,11 +6,13 @@ import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers, monthNamesFromShortName } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
-import { getGoalForChart } from '../../../utils/metricGoal';
+import { getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData } from '../../../utils/metricGoal';
 
 const RevocationAdmissionsSnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
+  const [chartMinValue, setChartMinValue] = useState();
+  const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'revocation-admissions-snapshot-chart');
 
@@ -33,9 +35,14 @@ const RevocationAdmissionsSnapshot = (props) => {
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+      const chartDataValues = sorted.map((element) => element[2]);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 10);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 10);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
-      setChartDataPoints(sorted.map((element) => element[2]));
+      setChartDataPoints(chartDataValues);
+      setChartMinValue(min);
+      setChartMaxValue(max);
     }
   };
 
@@ -97,8 +104,8 @@ const RevocationAdmissionsSnapshot = (props) => {
           yAxes: [{
             ticks: {
               fontColor: COLORS['grey-600'],
-              min: 30,
-              max: 100,
+              min: chartMinValue,
+              max: chartMaxValue,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -39,16 +39,16 @@ const SupervisionSuccessSnapshot = (props) => {
 
         // Don't add completion rates for months in the future
         if (year < yearNow || (year === yearNow && month <= monthNow)) {
-          dataPoints.push([year, month, successRate]);
+          dataPoints.push({ year, month, successRate });
         }
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = (sorted.map((element) => element[2]));
+      const chartDataValues = (sorted.map((element) => element.successRate));
       const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
       const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
+      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
       setChartDataPoints(chartDataValues);
       setChartMinValue(min);
       setChartMaxValue(max);

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -6,11 +6,13 @@ import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers, monthNamesFromShortName } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
-import { getGoalForChart } from '../../../utils/metricGoal';
+import { getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData } from '../../../utils/metricGoal';
 
 const SupervisionSuccessSnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
+  const [chartMinValue, setChartMinValue] = useState();
+  const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'supervision-success-snapshot-chart');
 
@@ -39,9 +41,14 @@ const SupervisionSuccessSnapshot = (props) => {
       });
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+      const chartDataValues = (sorted.map((element) => element[2]));
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 10);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 10);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
-      setChartDataPoints(sorted.map((element) => element[2]));
+      setChartDataPoints(chartDataValues);
+      setChartMinValue(min);
+      setChartMaxValue(max);
     }
   };
 
@@ -103,7 +110,8 @@ const SupervisionSuccessSnapshot = (props) => {
           yAxes: [{
             ticks: {
               fontColor: COLORS['grey-600'],
-              max: 100,
+              min: chartMinValue,
+              max: chartMaxValue,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -8,6 +8,7 @@ import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
 import {
   getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+  goalLabelContentString,
 } from '../../../utils/metricGoal';
 
 const SupervisionSuccessSnapshot = (props) => {
@@ -151,7 +152,7 @@ const SupervisionSuccessSnapshot = (props) => {
             borderDashOffset: 5,
             label: {
               enabled: true,
-              content: 'goal: '.concat(GOAL.label),
+              content: goalLabelContentString(GOAL),
               position: 'right',
 
               // Background color of label, default below

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -15,6 +15,7 @@ const SupervisionSuccessSnapshot = (props) => {
   const [chartMaxValue, setChartMaxValue] = useState();
 
   const GOAL = getGoalForChart('US_ND', 'supervision-success-snapshot-chart');
+  const stepSize = 10;
 
   const processResponse = () => {
     const { supervisionSuccessRates: countsByMonth } = props;
@@ -42,8 +43,8 @@ const SupervisionSuccessSnapshot = (props) => {
 
       const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
       const chartDataValues = (sorted.map((element) => element[2]));
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, 10);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, 10);
+      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
       setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element[1]), true));
       setChartDataPoints(chartDataValues);
@@ -112,6 +113,7 @@ const SupervisionSuccessSnapshot = (props) => {
               fontColor: COLORS['grey-600'],
               min: chartMinValue,
               max: chartMaxValue,
+              stepSize,
             },
             scaleLabel: {
               display: true,

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -3,10 +3,12 @@ import React, { useState, useEffect } from 'react';
 import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from '../../../assets/scripts/charts/chartJS/downloads';
 import { COLORS } from '../../../assets/scripts/constants/colors';
-import { monthNamesWithYearsFromNumbers, monthNamesFromShortName } from '../../../utils/monthConversion';
+import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
 import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
 import { generateTrendlineDataset, getTooltipWithoutTrendline } from '../../../utils/trendline';
-import { getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData } from '../../../utils/metricGoal';
+import {
+  getGoalForChart, getMinForGoalAndData, getMaxForGoalAndData, trendlineGoalText,
+} from '../../../utils/metricGoal';
 
 const SupervisionSuccessSnapshot = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
@@ -190,16 +192,12 @@ const SupervisionSuccessSnapshot = (props) => {
   configureDownloadButtons('supervisionSuccess', 'Snapshot', chart.props,
     document.getElementById('supervision-success-snapshot-chart'), exportedStructureCallback);
 
-  const chartData = chart.props.data.datasets[0].data;
-  const mostRecentValue = chartData[chartData.length - 1];
-
-  const chartDataLabels = chart.props.data.labels;
-  const mostRecentMonth = monthNamesFromShortName(chartDataLabels[chartDataLabels.length - 1]);
-
   const header = document.getElementById(props.header);
+  const trendlineValues = chart.props.data.datasets[1].data;
+  const trendlineText = trendlineGoalText(trendlineValues, GOAL);
 
-  if (header && mostRecentValue && mostRecentMonth) {
-    const title = `<b style='color:#809AE5'>${mostRecentValue}% of people</b> whose supervision was scheduled to end in ${mostRecentMonth} <b style='color:#809AE5'>successfully completed their supervision without revocation.</b>`;
+  if (header) {
+    const title = `The rate of successful completion of supervision has been <b style='color:#809AE5'>trending ${trendlineText}.</b>`;
     header.innerHTML = title;
   }
 

--- a/src/utils/dataOrganizing.js
+++ b/src/utils/dataOrganizing.js
@@ -33,7 +33,8 @@ function filterFacilities(dataPoints, facilityType, stateCode) {
  * [[year, month, data], [year, month, data], ...]
  */
 function sortByYearAndMonth(dataPoints) {
-  return dataPoints.sort((a, b) => ((a[0] === b[0]) ? (a[1] - b[1]) : (a[0] - b[0])));
+  return dataPoints.sort((a, b) => (
+    (a.year === b.year) ? (a.month - b.month) : (a.year - b.year)));
 }
 
 /**

--- a/src/utils/metricGoal.js
+++ b/src/utils/metricGoal.js
@@ -12,10 +12,20 @@ const GOALS = {
       value: -1,
       label: '-1.0',
     },
+    'reincarceration-counts-by-month-chart': {
+      isUpward: false,
+      value: 30,
+      label: '30%',
+    },
     'revocation-admissions-snapshot-chart': {
       isUpward: false,
       value: 35,
       label: '35%',
+    },
+    'revocation-counts-by-month-chart': {
+      isUpward: false,
+      value: 30,
+      label: '30',
     },
     'supervision-success-snapshot-chart': {
       isUpward: true,

--- a/src/utils/metricGoal.js
+++ b/src/utils/metricGoal.js
@@ -55,20 +55,20 @@ function trendlineGoalText(trendlineValues, goal) {
   return trendlineText;
 }
 
-function getMinForGoalAndData(goalValue, dataPoints, tickScale) {
+function getMinForGoalAndData(goalValue, dataPoints, stepSize) {
   let minValue = Math.min(...dataPoints);
   if (goalValue < minValue) {
     minValue = goalValue;
   }
-  return (minValue - tickScale) - ((minValue - tickScale) % tickScale);
+  return (minValue - stepSize) - ((minValue - stepSize) % stepSize);
 }
 
-function getMaxForGoalAndData(goalValue, dataPoints, tickScale) {
+function getMaxForGoalAndData(goalValue, dataPoints, stepSize) {
   let maxValue = Math.max(...dataPoints);
   if (goalValue > maxValue) {
     maxValue = goalValue;
   }
-  return (maxValue + tickScale) + (tickScale - (maxValue % tickScale));
+  return (maxValue + stepSize) + (stepSize - (maxValue % stepSize));
 }
 
 export {

--- a/src/utils/metricGoal.js
+++ b/src/utils/metricGoal.js
@@ -14,13 +14,13 @@ const GOALS = {
     },
     'revocation-admissions-snapshot-chart': {
       isUpward: false,
-      value: 40,
-      label: '40%',
+      value: 35,
+      label: '35%',
     },
     'supervision-success-snapshot-chart': {
       isUpward: true,
-      value: 70,
-      label: '70%',
+      value: 75,
+      label: '75%',
     },
   },
 };
@@ -55,7 +55,25 @@ function trendlineGoalText(trendlineValues, goal) {
   return trendlineText;
 }
 
+function getMinForGoalAndData(goalValue, dataPoints, tickScale) {
+  let minValue = Math.min(...dataPoints);
+  if (goalValue < minValue) {
+    minValue = goalValue;
+  }
+  return (minValue - tickScale) - ((minValue - tickScale) % tickScale);
+}
+
+function getMaxForGoalAndData(goalValue, dataPoints, tickScale) {
+  let maxValue = Math.max(...dataPoints);
+  if (goalValue > maxValue) {
+    maxValue = goalValue;
+  }
+  return (maxValue + tickScale) + (tickScale - (maxValue % tickScale));
+}
+
 export {
   getGoalForChart,
+  getMaxForGoalAndData,
+  getMinForGoalAndData,
   trendlineGoalText,
 };

--- a/src/utils/metricGoal.js
+++ b/src/utils/metricGoal.js
@@ -1,5 +1,6 @@
 import { trendlineSlope } from './trendline';
 
+// TODO(75): Retrieve these dynamically using the API
 const GOALS = {
   US_ND: {
     'days-at-liberty-snapshot-chart': {
@@ -46,6 +47,10 @@ function getGoalForChart(stateCode, chartName) {
   return new Goal(goalDict.isUpward, goalDict.value, goalDict.label);
 }
 
+function goalLabelContentString(goal) {
+  return 'goal: '.concat(goal.label);
+}
+
 /**
  * Returns the string value describing whether the data is trending towards
  * or away from the goal.
@@ -65,6 +70,12 @@ function trendlineGoalText(trendlineValues, goal) {
   return trendlineText;
 }
 
+/**
+ * Returns a value that is at least one stepSize lower than either the minimum
+ * data point on the chart or the value of the goal line, whichever is lower,
+ * and that is a multiple of the stepSize on the chart.
+ * This ensures the chart has space to show all of the data and the goal line.
+ */
 function getMinForGoalAndData(goalValue, dataPoints, stepSize) {
   let minValue = Math.min(...dataPoints);
   if (goalValue < minValue) {
@@ -73,6 +84,12 @@ function getMinForGoalAndData(goalValue, dataPoints, stepSize) {
   return (minValue - stepSize) - ((minValue - stepSize) % stepSize);
 }
 
+/**
+ * Returns a value that is at least one stepSize higher than either the maximum
+ * data point on the chart or the value of the goal line, whichever is higher,
+ * and that is a multiple of the stepSize on the chart.
+ * This ensures the chart has space to show all of the data and the goal line.
+ */
 function getMaxForGoalAndData(goalValue, dataPoints, stepSize) {
   let maxValue = Math.max(...dataPoints);
   if (goalValue > maxValue) {
@@ -85,5 +102,6 @@ export {
   getGoalForChart,
   getMaxForGoalAndData,
   getMinForGoalAndData,
+  goalLabelContentString,
   trendlineGoalText,
 };

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -43,10 +43,10 @@ const Reincarcerations = () => {
   return (
     <main className="main-content bgc-grey-100">
       <div id="mainContent">
-        <div className="row gap-20 masonry pos-r">
+        <div className="row gap-20 pos-r">
 
           {/* #Reincarcerations by month chart ==================== */}
-          <div className="masonry-item col-md-12">
+          <div className="col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -104,7 +104,7 @@ const Reincarcerations = () => {
           </div>
 
           {/* #Releases vs admissions ==================== */}
-          <div className="masonry-item col-md-12">
+          <div className="col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -140,7 +140,7 @@ const Reincarcerations = () => {
           </div>
 
           {/* #Reincarcerations by release facility ==================== */}
-          <div className="masonry-item col-md-12">
+          <div className="col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -193,7 +193,7 @@ const Reincarcerations = () => {
           </div>
 
           {/* #Reincarcerations by transitional facility ==================== */}
-          <div className="masonry-item col-md-12">
+          <div className="col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -244,7 +244,7 @@ const Reincarcerations = () => {
           </div>
 
           {/* #Reincarcerations by previous stay length ==================== */}
-          <div className="masonry-item col-md-12">
+          <div className="col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -44,7 +44,6 @@ const Reincarcerations = () => {
     <main className="main-content bgc-grey-100">
       <div id="mainContent">
         <div className="row gap-20 masonry pos-r">
-          <div className="masonry-sizer col-md-6" />
 
           {/* #Recidivism driver top-line chart ==================== */}
           <div className="masonry-item col-md-12">
@@ -91,7 +90,11 @@ const Reincarcerations = () => {
                   <div id="collapseMethodologyRecidivismDriver" className="collapse" aria-labelledby="methodologyHeadingRecidivismDriver" data-parent="#methodologyRecidivismDriver">
                     <div>
                       <ul>
-                        <li>An admission to prison counts as a reincarceration if the person has been incarcerated previously and if they were released from their last incarceration within 10 years of the date of the new admission.</li>
+                        <li>
+                        An admission to prison counts as a reincarceration if
+                        the person has been incarcerated previously in a North
+                        Dakota prison.
+                        </li>
                       </ul>
                     </div>
                   </div>

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -45,7 +45,7 @@ const Reincarcerations = () => {
       <div id="mainContent">
         <div className="row gap-20 masonry pos-r">
 
-          {/* #Recidivism driver top-line chart ==================== */}
+          {/* #Reincarcerations by month chart ==================== */}
           <div className="masonry-item col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
@@ -54,19 +54,19 @@ const Reincarcerations = () => {
                     REINCARCERATIONS BY MONTH
                     <span className="fa-pull-right">
                       <div className="dropdown show">
-                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-reincarcerationDrivers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-reincarcerationCountsByMonth" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Export
                         </a>
-                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-reincarcerationDrivers">
-                          <a className="dropdown-item" id="downloadChartAsImage-reincarcerationDrivers" href="javascript:void(0);">Export image</a>
-                          <a className="dropdown-item" id="downloadChartData-reincarcerationDrivers" href="javascript:void(0);">Export data</a>
+                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-reincarcerationCountsByMonth">
+                          <a className="dropdown-item" id="downloadChartAsImage-reincarcerationCountsByMonth" href="javascript:void(0);">Export image</a>
+                          <a className="dropdown-item" id="downloadChartData-reincarcerationCountsByMonth" href="javascript:void(0);">Export data</a>
                         </div>
                       </div>
                     </span>
                   </h6>
                 </div>
                 <div className="layer w-100 pX-20 pT-20">
-                  <h4 style={{ height: '20px' }} className="lh-1" id="reincarcerationDrivers-header">
+                  <h4 style={{ height: '20px' }} className="lh-1" id="reincarcerationCountsByMonth-header">
                   </h4>
                 </div>
                 <div className="layer w-100 pX-20 pT-20 row">
@@ -74,20 +74,20 @@ const Reincarcerations = () => {
                     <div className="layer w-100 p-20">
                       <ReincarcerationCountOverTime
                         reincarcerationCountsByMonth={apiData.reincarcerations_by_month}
-                        header="reincarcerationDrivers-header"
+                        header="reincarcerationCountsByMonth-header"
                       />
                     </div>
                   </div>
                 </div>
-                <div className="layer bdT p-20 w-100 accordion" id="methodologyRecidivismDriver">
-                  <div className="mb-0" id="methodologyHeadingRecidivismDriver">
+                <div className="layer bdT p-20 w-100 accordion" id="methodologyReincarcerationCountsByMonth">
+                  <div className="mb-0" id="methodologyHeadingReincarcerationCountsByMonth">
                     <div className="mb-0">
-                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyRecidivismDriver" aria-expanded="true" aria-controls="collapseMethodologyRecidivismDriver">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyReincarcerationCountsByMonth" aria-expanded="true" aria-controls="collapseMethodologyReincarcerationCountsByMonth">
                         <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
                       </button>
                     </div>
                   </div>
-                  <div id="collapseMethodologyRecidivismDriver" className="collapse" aria-labelledby="methodologyHeadingRecidivismDriver" data-parent="#methodologyRecidivismDriver">
+                  <div id="collapseMethodologyReincarcerationCountsByMonth" className="collapse" aria-labelledby="methodologyHeadingReincarcerationCountsByMonth" data-parent="#methodologyReincarcerationCountsByMonth">
                     <div>
                       <ul>
                         <li>

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -45,10 +45,10 @@ const Revocations = () => {
   return (
     <main className="main-content bgc-grey-100">
       <div id="mainContent">
-        <div className="row gap-20 masonry pos-r">
+        <div className="row gap-20 pos-r">
 
           {/* #Revocation counts by month chart ==================== */}
-          <div className="masonry-item col-md-12">
+          <div className="col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -103,7 +103,7 @@ const Revocations = () => {
           </div>
 
           {/* #Revocations by supervision type ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -134,7 +134,7 @@ const Revocations = () => {
           </div>
 
           {/* #Revocations by violation type ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -167,7 +167,7 @@ const Revocations = () => {
           </div>
 
           {/* #Revocations by county chart ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -210,7 +210,7 @@ const Revocations = () => {
           </div>
 
           {/* #Revocations by officer id ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -250,7 +250,7 @@ const Revocations = () => {
           </div>
 
           {/* #Admission type proportions ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -293,7 +293,7 @@ const Revocations = () => {
           </div>
 
           {/* #Revocations by race chart ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -46,7 +46,6 @@ const Revocations = () => {
     <main className="main-content bgc-grey-100">
       <div id="mainContent">
         <div className="row gap-20 masonry pos-r">
-          <div className="masonry-sizer col-md-6" />
 
           {/* #Revocation driver top-line chart ==================== */}
           <div className="masonry-item col-md-12">

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -47,7 +47,7 @@ const Revocations = () => {
       <div id="mainContent">
         <div className="row gap-20 masonry pos-r">
 
-          {/* #Revocation driver top-line chart ==================== */}
+          {/* #Revocation counts by month chart ==================== */}
           <div className="masonry-item col-md-12">
             <div className="bd bgc-white p-20">
               <div className="layers">
@@ -56,19 +56,19 @@ const Revocations = () => {
                     REVOCATIONS BY MONTH
                     <span className="fa-pull-right">
                       <div className="dropdown show">
-                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-revocationDrivers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-revocationCountsByMonth" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Export
                         </a>
-                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-revocationDrivers">
-                          <a className="dropdown-item" id="downloadChartAsImage-revocationDrivers" href="javascript:void(0);">Export image</a>
-                          <a className="dropdown-item" id="downloadChartData-revocationDrivers" href="javascript:void(0);">Export data</a>
+                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-revocationCountsByMonth">
+                          <a className="dropdown-item" id="downloadChartAsImage-revocationCountsByMonth" href="javascript:void(0);">Export image</a>
+                          <a className="dropdown-item" id="downloadChartData-revocationCountsByMonth" href="javascript:void(0);">Export data</a>
                         </div>
                       </div>
                     </span>
                   </h6>
                 </div>
                 <div className="layer w-100 pX-20 pT-20">
-                  <h4 style={{ height: '20px' }} className="lh-1" id="revocationDrivers-header">
+                  <h4 style={{ height: '20px' }} className="lh-1" id="revocationCountsByMonth-header">
                   </h4>
                 </div>
                 <div className="layer w-100 pX-20 pT-20 row">
@@ -76,20 +76,20 @@ const Revocations = () => {
                     <div className="layer w-100 p-20">
                       <RevocationCountOverTime
                         revocationCountsByMonth={apiData.revocations_by_month}
-                        header="revocationDrivers-header"
+                        header="revocationCountsByMonth-header"
                       />
                     </div>
                   </div>
                 </div>
-                <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationDriver">
-                  <div className="mb-0" id="methodologyHeadingRevocationDriver">
+                <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationCountsByMonth">
+                  <div className="mb-0" id="methodologyHeadingRevocationCountsByMonth">
                     <div className="mb-0">
-                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyRevocationDriver" aria-expanded="true" aria-controls="collapseMethodologyRevocationDriver">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyRevocationCountsByMonth" aria-expanded="true" aria-controls="collapseMethodologyRevocationCountsByMonth">
                         <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
                       </button>
                     </div>
                   </div>
-                  <div id="collapseMethodologyRevocationDriver" className="collapse" aria-labelledby="methodologyHeadingRevocationDriver" data-parent="#methodologyRevocationDriver">
+                  <div id="collapseMethodologyRevocationCountsByMonth" className="collapse" aria-labelledby="methodologyHeadingRevocationCountsByMonth" data-parent="#methodologyRevocationCountsByMonth">
                     <div>
                       <ul>
                         <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -38,7 +38,7 @@ const Snapshots = () => {
     fetchChartData();
   }, []);
 
-  if (loading || !user) {
+  if (loading || !user || awaitingApi) {
     return <Loading />;
   }
 
@@ -46,7 +46,6 @@ const Snapshots = () => {
     <main className="main-content bgc-grey-100">
       <div id="mainContent">
         <div className="row gap-20 masonry pos-r">
-          <div className="masonry-sizer col-md-6" />
 
           {/* #Successful completion of supervision snapshot ==================== */}
           <div className="masonry-item col-md-6">
@@ -93,8 +92,16 @@ const Snapshots = () => {
                   <div className="collapse" id="collapseMethodologySupervisionSuccessSnapshot" aria-labelledby="methodologyHeadingSupervisionSuccessSnapshot" data-parent="#methodologySupervisionSuccessSnapshot">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
-                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                        <li>
+                        A supervision is considered successfully completed
+                        if the individual was discharged from supervision or if
+                        their supervision period expired.
+                        </li>
+                        <li>
+                        Unsuccessful completions of supervision occur when the
+                        supervision ends due to absconsion, a revocation, or a
+                        suspension.
+                        </li>
                       </ul>
                     </div>
                   </div>
@@ -148,8 +155,15 @@ const Snapshots = () => {
                   <div className="collapse" id="collapseMethodologyRevocationAdmissionsSnapshot" aria-labelledby="methodologyHeadingRevocationAdmissionsSnapshot" data-parent="#methodologyRevocationAdmissionsSnapshot">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
-                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                        <li>
+                        This is a measurement of the percent of admissions to
+                        North Dakota prisons that were due to parole or probation revocations.
+                        </li>
+                        <li>
+                        Revocations include all instances of a person being
+                        incarcerated because their supervision was revoked for
+                        a behavioral violation.
+                        </li>
                       </ul>
                     </div>
                   </div>
@@ -203,8 +217,16 @@ const Snapshots = () => {
                   <div className="collapse" id="collapseMethodologyDaysAtLibertySnapshot" aria-labelledby="methodologyHeadingDaysAtLibertySnapshot" data-parent="#methodologyDaysAtLibertySnapshot">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
-                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                        <li>
+                        An individual&apos;s days at liberty are the number of
+                        days between release from incarceration and readmission
+                        for someone who was reincarcerated in a given month.
+                        </li>
+                        <li>
+                        An admission to prison counts as a reincarceration if
+                        the person has been incarcerated previously in a North
+                        Dakota prison.
+                        </li>
                       </ul>
                     </div>
                   </div>
@@ -258,8 +280,12 @@ const Snapshots = () => {
                   <div className="collapse" id="collapseMethodologyLsirScoreChangeSnapshot" aria-labelledby="methodologyHeadingLsirScoreChangeSnapshot" data-parent="#methodologyLsirScoreChangeSnapshot">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
-                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                        <li>
+                        This is the average of the differences between the first
+                        reassessment score and the termination assessment score
+                        for all individuals whose supervision was scheduled to
+                        end in a given month.
+                        </li>
                       </ul>
                     </div>
                   </div>

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -82,6 +82,23 @@ const Snapshots = () => {
                     </div>
                   </div>
                 </div>
+                <div className="layer bdT p-20 w-100 accordion" id="methodologySupervisionSuccessSnapshot">
+                  <div className="mb-0" id="methodologyHeadingSupervisionSuccessSnapshot">
+                    <div className="mb-0">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologySupervisionSuccessSnapshot" aria-expanded="true" aria-controls="collapseMethodologySupervisionSuccessSnapshot">
+                        <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
+                      </button>
+                    </div>
+                  </div>
+                  <div className="collapse" id="collapseMethodologySupervisionSuccessSnapshot" aria-labelledby="methodologyHeadingSupervisionSuccessSnapshot" data-parent="#methodologySupervisionSuccessSnapshot">
+                    <div>
+                      <ul>
+                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -117,6 +134,23 @@ const Snapshots = () => {
                         revocationAdmissionsByMonth={apiData.admissions_by_type_by_month}
                         header="revocationAdmissionsSnapshot-header"
                       />
+                    </div>
+                  </div>
+                </div>
+                <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationAdmissionsSnapshot">
+                  <div className="mb-0" id="methodologyHeadingRevocationAdmissionsSnapshot">
+                    <div className="mb-0">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyRevocationAdmissionsSnapshot" aria-expanded="true" aria-controls="collapseMethodologyRevocationAdmissionsSnapshot">
+                        <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
+                      </button>
+                    </div>
+                  </div>
+                  <div className="collapse" id="collapseMethodologyRevocationAdmissionsSnapshot" aria-labelledby="methodologyHeadingRevocationAdmissionsSnapshot" data-parent="#methodologyRevocationAdmissionsSnapshot">
+                    <div>
+                      <ul>
+                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                      </ul>
                     </div>
                   </div>
                 </div>
@@ -158,6 +192,23 @@ const Snapshots = () => {
                     </div>
                   </div>
                 </div>
+                <div className="layer bdT p-20 w-100 accordion" id="methodologyDaysAtLibertySnapshot">
+                  <div className="mb-0" id="methodologyHeadingDaysAtLibertySnapshot">
+                    <div className="mb-0">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyDaysAtLibertySnapshot" aria-expanded="true" aria-controls="collapseMethodologyDaysAtLibertySnapshot">
+                        <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
+                      </button>
+                    </div>
+                  </div>
+                  <div className="collapse" id="collapseMethodologyDaysAtLibertySnapshot" aria-labelledby="methodologyHeadingDaysAtLibertySnapshot" data-parent="#methodologyDaysAtLibertySnapshot">
+                    <div>
+                      <ul>
+                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -193,6 +244,23 @@ const Snapshots = () => {
                         lsirScoreChangeByMonth={apiData.average_change_lsir_score_by_month}
                         header="lsirScoreChangeSnapshot-header"
                       />
+                    </div>
+                  </div>
+                </div>
+                <div className="layer bdT p-20 w-100 accordion" id="methodologyLsirScoreChangeSnapshot">
+                  <div className="mb-0" id="methodologyHeadingLsirScoreChangeSnapshot">
+                    <div className="mb-0">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyLsirScoreChangeSnapshot" aria-expanded="true" aria-controls="collapseMethodologyLsirScoreChangeSnapshot">
+                        <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
+                      </button>
+                    </div>
+                  </div>
+                  <div className="collapse" id="collapseMethodologyLsirScoreChangeSnapshot" aria-labelledby="methodologyHeadingLsirScoreChangeSnapshot" data-parent="#methodologyLsirScoreChangeSnapshot">
+                    <div>
+                      <ul>
+                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
+                      </ul>
                     </div>
                   </div>
                 </div>

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -45,10 +45,10 @@ const Snapshots = () => {
   return (
     <main className="main-content bgc-grey-100">
       <div id="mainContent">
-        <div className="row gap-20 masonry pos-r">
+        <div className="row gap-20 pos-r">
 
           {/* #Successful completion of supervision snapshot ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -111,7 +111,7 @@ const Snapshots = () => {
           </div>
 
           {/* #Prison admissions from revocations ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -173,7 +173,7 @@ const Snapshots = () => {
           </div>
 
           {/* #Average days at liberty ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
@@ -236,7 +236,7 @@ const Snapshots = () => {
           </div>
 
           {/* #Change in LSIR scores ==================== */}
-          <div className="masonry-item col-md-6">
+          <div className="col-md-6">
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">


### PR DESCRIPTION
Closes #61 
Closes #66 

In this PR:
-  Updates goal values for all snapshot charts and top-line revocation and reincarceration charts
- Makes min and max values dynamic for any chart with a goal line 
- Changes all snapshot header labels to describe the trendline instead of this month's values
- Adds methodology section to all snapshot charts