### PR TITLE
Updating revocation by race chart to include ethnicity

### DIFF
--- a/server/core/metricsApi.js
+++ b/server/core/metricsApi.js
@@ -36,7 +36,7 @@ const FILES_BY_METRIC_TYPE = {
     'revocations_by_officer_60_days.json',
     'admissions_by_type_60_days.json',
     'revocations_by_month.json',
-    'revocations_by_race_60_days.json',
+    'revocations_by_race_and_ethnicity_60_days.json',
     'revocations_by_supervision_type_by_month.json',
     'revocations_by_violation_type_by_month.json',
   ],

--- a/src/components/charts/revocations/RevocationProportionByRace.js
+++ b/src/components/charts/revocations/RevocationProportionByRace.js
@@ -8,6 +8,7 @@ const labelStringConversion = {
   AMERICAN_INDIAN_ALASKAN_NATIVE: 'American Indian Alaskan Native',
   ASIAN: 'Asian',
   BLACK: 'Black',
+  HISPANIC: 'Hispanic',
   NATIVE_HAWAIIAN_PACIFIC_ISLANDER: 'Native Hawaiian Pacific Islander',
   WHITE: 'White',
   OTHER: 'Other',
@@ -17,9 +18,10 @@ const ND_RACE_PROPORTIONS = {
   'American Indian Alaskan Native': 5.5,
   'Asian': 1.8,
   'Black': 3.4,
+  'Hispanic': 3.9,
   'Native Hawaiian Pacific Islander': 0.1,
-  'White': 87.0,
-  'Other': 2.2,
+  'White': 84.0,
+  'Other': 1.3,
 };
 
 const RevocationProportionByRace = (props) => {
@@ -32,7 +34,7 @@ const RevocationProportionByRace = (props) => {
 
     const dataPoints = [];
     proportionsByRace.forEach((data) => {
-      const { race } = data;
+      const { race_or_ethnicity: race } = data;
       const count = parseInt(data.revocation_count, 10);
       dataPoints.push([labelStringConversion[race], count]);
     });
@@ -87,8 +89,12 @@ const RevocationProportionByRace = (props) => {
           data: [chartProportions[4], statePopulationProportions[4]],
         }, {
           label: chartLabels[5],
-          backgroundColor: COLORS['blue-standard'],
+          backgroundColor: COLORS['blue-standard-2'],
           data: [chartProportions[5], statePopulationProportions[5]],
+        }, {
+          label: chartLabels[6],
+          backgroundColor: COLORS['blue-standard'],
+          data: [chartProportions[6], statePopulationProportions[6]],
         },
         ],
       }}

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -302,7 +302,7 @@ const Revocations = () => {
                 </div>
                 <div className="layer w-100 pX-20 pT-20 row">
                   <div className="layer w-100 p-20">
-                    <RevocationProportionByRace revocationProportionByRace={apiData.revocations_by_race_60_days} />
+                    <RevocationProportionByRace revocationProportionByRace={apiData.revocations_by_race_and_ethnicity_60_days} />
                   </div>
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationsByRace">


### PR DESCRIPTION
Updates the API call and the chart values to display `Hispanic` as a race category in the revocations by race proportion chart.