### PR TITLE
Fixes broken export buttons for top-line revocations and reincarcerations charts

### DIFF
--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -143,7 +143,7 @@ const ReincarcerationCountOverTime = (props) => {
     });
 
   configureDownloadButtons('reincarceration', 'Drivers', chart.props,
-    document.getElementById('reincarceration-drivers-chart'), exportedStructureCallback);
+    document.getElementById('reincarceration-counts-by-month-chart'), exportedStructureCallback);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -143,7 +143,7 @@ const RevocationCountOverTime = (props) => {
     });
 
   configureDownloadButtons('revocation', 'Drivers', chart.props,
-    document.getElementById('revocation-drivers-chart'), exportedStructureCallback);
+    document.getElementById('revocation-counts-by-month-chart'), exportedStructureCallback);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -54,12 +54,12 @@ const Reincarcerations = () => {
                     REINCARCERATIONS BY MONTH
                     <span className="fa-pull-right">
                       <div className="dropdown show">
-                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-reincarcerationCountsByMonth" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-reincarcerationDrivers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Export
                         </a>
-                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-reincarcerationCountsByMonth">
-                          <a className="dropdown-item" id="downloadChartAsImage-reincarcerationCountsByMonth" href="javascript:void(0);">Export image</a>
-                          <a className="dropdown-item" id="downloadChartData-reincarcerationCountsByMonth" href="javascript:void(0);">Export data</a>
+                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-reincarcerationDrivers">
+                          <a className="dropdown-item" id="downloadChartAsImage-reincarcerationDrivers" href="javascript:void(0);">Export image</a>
+                          <a className="dropdown-item" id="downloadChartData-reincarcerationDrivers" href="javascript:void(0);">Export data</a>
                         </div>
                       </div>
                     </span>

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -56,12 +56,12 @@ const Revocations = () => {
                     REVOCATIONS BY MONTH
                     <span className="fa-pull-right">
                       <div className="dropdown show">
-                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-revocationCountsByMonth" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-revocationDrivers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Export
                         </a>
-                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-revocationCountsByMonth">
-                          <a className="dropdown-item" id="downloadChartAsImage-revocationCountsByMonth" href="javascript:void(0);">Export image</a>
-                          <a className="dropdown-item" id="downloadChartData-revocationCountsByMonth" href="javascript:void(0);">Export data</a>
+                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-revocationDrivers">
+                          <a className="dropdown-item" id="downloadChartAsImage-revocationDrivers" href="javascript:void(0);">Export image</a>
+                          <a className="dropdown-item" id="downloadChartData-revocationDrivers" href="javascript:void(0);">Export data</a>
                         </div>
                       </div>
                     </span>


### PR DESCRIPTION
The export functionality is a bit brittle in how it expects things to be named. We'll fix that later.