### PR TITLE
Updates methodological text in several places to increase clarity.

### DIFF
--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -151,7 +151,7 @@ const ReincarcerationCountOverTime = (props) => {
   const header = document.getElementById(props.header);
 
   if (header && mostRecentValue) {
-    const title = `There have been <b style='color:#809AE5'>${mostRecentValue} reincarcerations</b> this month so far.`;
+    const title = `There have been <b style='color:#809AE5'>${mostRecentValue} reincarcerations</b> to a DOCR facility this month so far.`;
     header.innerHTML = title;
   }
 

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -151,7 +151,7 @@ const RevocationCountOverTime = (props) => {
   const header = document.getElementById(props.header);
 
   if (header && mostRecentValue) {
-    const title = `There have been <b style='color:#809AE5'>${mostRecentValue} revocations</b> this month so far.`;
+    const title = `There have been <b style='color:#809AE5'>${mostRecentValue} revocations</b> that led to incarceration in a DOCR facility this month so far.`;
     header.innerHTML = title;
   }
 

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -97,7 +97,7 @@ const Reincarcerations = () => {
                         </li>
                         <li>
                         Reincarcerations are included regardless of when the initial incarceration
-                        took place. There is no upper bound on the follow up period in this chart.
+                        took place. There is no upper bound on the follow up period in this metric.
                         </li>
                       </ul>
                     </div>

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -95,6 +95,10 @@ const Reincarcerations = () => {
                         the person has been incarcerated previously in a North
                         Dakota prison.
                         </li>
+                        <li>
+                        Reincarcerations are included regardless of when the initial incarceration
+                        took place. There is no upper bound on the follow up period in this chart.
+                        </li>
                       </ul>
                     </div>
                   </div>

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -92,7 +92,7 @@ const Revocations = () => {
                   <div id="collapseMethodologyRevocationCountsByMonth" className="collapse" aria-labelledby="methodologyHeadingRevocationCountsByMonth" data-parent="#methodologyRevocationCountsByMonth">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
                         <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
                       </ul>
                     </div>
@@ -123,7 +123,7 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationBySupervisionType" aria-labelledby="methodologyHeadingRevocationBySupervisiontype" data-parent="#methodologyRevocationBySupervisionType">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
                         <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
                       </ul>
                     </div>
@@ -154,7 +154,7 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationsByViolationType" aria-labelledby="methodologyHeadingRevocationsByViolationType" data-parent="#methodologyRevocationsByViolationType">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
                         <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
                         <li>Violations of "Unknown Type" indicate individuals who were admitted to prison for a supervision revocation where the violation that caused the revocation cannot yet be determined.</li>
                         <li>"Technical" revocations include only those revocations which result solely from a technical violation. If there is a violation that includes a new offense or an absconsion, it is considered a non-technical revocation.</li>
@@ -189,8 +189,9 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationsByCounty" aria-labelledby="methodologyHeadingRevocationsByCounty" data-parent="#methodologyRevocationsByCounty">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
                         <li>Revocations are attributed to the county where the person&apos;s supervision was terminated.</li>
+                        <li>Revocations are included based on the date that the person&apos;s supervision was officially revoked, not the date of the causal violation or offense.</li>
                       </ul>
                     </div>
                   </div>
@@ -231,8 +232,8 @@ const Revocations = () => {
                     <div>
                       <ul>
                         <li>This chart lists the 10 officers with the highest revocation counts in the state over the period.</li>
-                        <li>Revocations are counted towards an officer if that officer is flagged as the terminating officer at the time of a person's revocation.</li>
-                        <li>Revocations are included based on the date that the revocation was officially sanctioned, not the date of the causal violation or offense.</li>
+                        <li>Revocations are counted towards an officer if that officer is flagged as the terminating officer at the time of a person&apos;s revocation.</li>
+                        <li>Revocations are included based on the date that the person&apos;s supervision was officially revoked, not the date of the causal violation or offense.</li>
                       </ul>
                     </div>
                   </div>
@@ -271,7 +272,7 @@ const Revocations = () => {
                     <div>
                       <ul>
                         <li>New admissions include unique people admitted to any DOCR facility during a particular time frame, regardless of whether they were previously incarcerated.</li>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
                         <li>"Technical Revocations" include only those revocations which result solely from a technical violation. If there is a violation that includes a new offense or an absconsion, it is considered a "Non-Technical Revocation".</li>
                         <li>Revocations of "Unknown Type" indicate individuals who were admitted to prison for a supervision revocation where the violation that caused the revocation cannot yet be determined.</li>
                       </ul>
@@ -315,7 +316,7 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationsByRace" aria-labelledby="methodologyHeadingRevocationsByRace" data-parent="#methodologyRevocationsByRace">
                     <div>
                       <ul>
-                        <li>Revocations include all instances of a person being incarcerated because their supervision was revoked for a behavioral violation.</li>
+                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
                         <li>The race proportions for the population of North Dakota were taken from the U.S. Census Bureau.</li>
                       </ul>
                     </div>

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -94,13 +94,13 @@ const Snapshots = () => {
                       <ul>
                         <li>
                         A supervision is considered successfully completed
-                        if the individual was discharged from supervision or if
-                        their supervision period expired.
+                        if the individual was discharged from supervision positively
+                        or if their supervision period expired.
                         </li>
                         <li>
                         Unsuccessful completions of supervision occur when the
                         supervision ends due to absconsion, a revocation, or a
-                        suspension.
+                        negative termination.
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
These are the updates I made based on talk with Tom@ND. Feel free to wordsmith!

* Increase precision of supervision success versus non-success in the snapshot methodology
* Updated the narrative headlines for the top-line revocation and reincarceration counts to note that it's specifically when a person goes back to a DOCR facility (as opposed to, say, being revoked and winding up in a county jail)
* Made explicit in the reincarceration count methodology that there's no follow up period upper bound as currently implemented
* Updated the line that appears in several revocation charts to highlight that it's person-based, not case-based (I know this is only an implicit constraint right now, but it's effectively true except in really rare cases, to be addressed in #2191 on the platform side)
* Tweaked some text about revocation dates to be more clear