### PR TITLE
Adding supervision population by race to revocation race chart

### DIFF
--- a/server/core/demoData/revocations_by_race_60_days.json
+++ b/server/core/demoData/revocations_by_race_60_days.json
@@ -1,5 +1,0 @@
-{"state_code":"US_DEMO","race":"OTHER","revocation_count":"7"}
-{"state_code":"US_DEMO","race":"AMERICAN_INDIAN_ALASKAN_NATIVE","revocation_count":"35"}
-{"state_code":"US_DEMO","race":"BLACK","revocation_count":"10"}
-{"state_code":"US_DEMO","race":"NATIVE_HAWAIIAN_PACIFIC_ISLANDER","revocation_count":"4"}
-{"state_code":"US_DEMO","race":"WHITE","revocation_count":"53"}

--- a/server/core/demoData/revocations_by_race_and_ethnicity_60_days.json
+++ b/server/core/demoData/revocations_by_race_and_ethnicity_60_days.json
@@ -1,0 +1,5 @@
+{"state_code":"US_DEMO","race_or_ethnicity":"OTHER","revocation_count":"7"}
+{"state_code":"US_DEMO","race_or_ethnicity":"AMERICAN_INDIAN_ALASKAN_NATIVE","revocation_count":"35"}
+{"state_code":"US_DEMO","race_or_ethnicity":"BLACK","revocation_count":"10"}
+{"state_code":"US_DEMO","race_or_ethnicity":"NATIVE_HAWAIIAN_PACIFIC_ISLANDER","revocation_count":"4"}
+{"state_code":"US_DEMO","race_or_ethnicity":"WHITE","revocation_count":"53"}

--- a/server/core/demoData/supervision_population_by_race_and_ethnicity_60_days.json
+++ b/server/core/demoData/supervision_population_by_race_and_ethnicity_60_days.json
@@ -1,0 +1,6 @@
+{"state_code":"US_DEMO","race_or_ethnicity":"OTHER","count":"10"}
+{"state_code":"US_DEMO","race_or_ethnicity":"AMERICAN_INDIAN_ALASKAN_NATIVE","count":"50"}
+{"state_code":"US_DEMO","race_or_ethnicity":"BLACK","count":"10"}
+{"state_code":"US_DEMO","race_or_ethnicity":"NATIVE_HAWAIIAN_PACIFIC_ISLANDER","count":"4"}
+{"state_code":"US_DEMO","race_or_ethnicity":"WHITE","count":"53"}
+{"state_code":"US_DEMO","race_or_ethnicity":"HISPANIC","count":"31"}

--- a/server/core/metricsApi.js
+++ b/server/core/metricsApi.js
@@ -38,6 +38,7 @@ const FILES_BY_METRIC_TYPE = {
     'revocations_by_race_and_ethnicity_60_days.json',
     'revocations_by_supervision_type_by_month.json',
     'revocations_by_violation_type_by_month.json',
+    'supervision_population_by_race_and_ethnicity_60_days.json',
   ],
   snapshot: [
     'admissions_by_type_by_month.json',

--- a/src/App.js
+++ b/src/App.js
@@ -41,27 +41,6 @@ const App = () => {
 
   // TODO: Replace this jQuery with actual React Masonry and toggle components
   useEffect(() => {
-    new Masonry('.masonry', {
-      itemSelector: '.masonry-item',
-      columnWidth: '.masonry-sizer',
-      percentPosition: true,
-    });
-
-    // Reinitialize masonry inside each panel after a collapsible accordion is expanded or collapsed
-    $('.accordion').each(function () {
-      const $this = $(this);
-
-      $this.on('shown.bs.collapse hidden.bs.collapse', () => {
-        if ($('.masonry').length > 0) {
-          new Masonry('.masonry', {
-            itemSelector: '.masonry-item',
-            columnWidth: '.masonry-sizer',
-            percentPosition: true,
-          });
-        }
-      });
-    });
-
     // ٍSidebar Toggle
     $('.sidebar-toggle').on('click', (e) => {
       toggleCollapsed();

--- a/src/components/charts/revocations/AdmissionTypeProportions.js
+++ b/src/components/charts/revocations/AdmissionTypeProportions.js
@@ -22,13 +22,13 @@ const AdmissionTypeProportions = (props) => {
     admissionCountsByType.forEach((data) => {
       const { admission_type: admissionType } = data;
       const count = parseInt(data.admission_count, 10);
-      dataPoints.push([labelStringConversion[admissionType], count]);
+      dataPoints.push({ type: labelStringConversion[admissionType], count });
     });
 
-    const sorted = sortByLabel(dataPoints, 0);
+    const sorted = sortByLabel(dataPoints, 'type');
 
-    setChartLabels(sorted.map((element) => element[0]));
-    setChartDataPoints(sorted.map((element) => element[1]));
+    setChartLabels(sorted.map((element) => element.type));
+    setChartDataPoints(sorted.map((element) => element.count));
   };
 
   useEffect(() => {

--- a/src/components/charts/revocations/RevocationCountBySupervisionType.js
+++ b/src/components/charts/revocations/RevocationCountBySupervisionType.js
@@ -74,7 +74,7 @@ const RevocationCountBySupervisionType = (props) => {
           yAxes: [{
             scaleLabel: {
               display: true,
-              labelString: 'Revocation counts',
+              labelString: 'Revocation count',
             },
             stacked: true,
           }],

--- a/src/components/charts/revocations/RevocationCountByViolationType.js
+++ b/src/components/charts/revocations/RevocationCountByViolationType.js
@@ -106,7 +106,7 @@ const RevocationCountByViolationType = (props) => {
           yAxes: [{
             scaleLabel: {
               display: true,
-              labelString: 'Revocation counts',
+              labelString: 'Revocation count',
             },
             stacked: true,
           }],

--- a/src/components/charts/revocations/RevocationProportionByRace.js
+++ b/src/components/charts/revocations/RevocationProportionByRace.js
@@ -27,74 +27,114 @@ const ND_RACE_PROPORTIONS = {
 const RevocationProportionByRace = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartProportions, setChartProportions] = useState([]);
-  const [statePopulationProportions, setStateProportions] = useState([]);
+  const [statePopulationProportions, setStatePopulationProportions] = useState([]);
+  const [stateSupervisionProportions, setStateSupervisionProportions] = useState([]);
 
   const processResponse = () => {
-    const { revocationProportionByRace: proportionsByRace } = props;
+    const { revocationProportionByRace } = props;
+    const { supervisionPopulationByRace } = props;
 
-    const dataPoints = [];
-    proportionsByRace.forEach((data) => {
+    const revocationDataPoints = [];
+    revocationProportionByRace.forEach((data) => {
       const { race_or_ethnicity: race } = data;
       const count = parseInt(data.revocation_count, 10);
-      dataPoints.push([labelStringConversion[race], count]);
+      revocationDataPoints.push([labelStringConversion[race], count]);
     });
 
-    const racesRepresented = dataPoints.map((element) => element[0]);
+    const supervisionDataPoints = [];
+    supervisionPopulationByRace.forEach((data) => {
+      const { race_or_ethnicity: race } = data;
+      const count = parseInt(data.count, 10);
+      supervisionDataPoints.push([labelStringConversion[race], count]);
+    });
+
+    const racesRepresentedRevocations = revocationDataPoints.map((element) => element[0]);
+    const racesRepresentedSupervision = supervisionDataPoints.map((element) => element[0]);
 
     Object.values(labelStringConversion).forEach((race) => {
-      if (!racesRepresented.includes(race)) {
-        dataPoints.push([race, 0]);
+      if (!racesRepresentedRevocations.includes(race)) {
+        revocationDataPoints.push([race, 0]);
+      }
+
+      if (!racesRepresentedSupervision.includes(race)) {
+        supervisionDataPoints.push([race, 0]);
       }
     });
 
-    const total = dataPoints.map((element) => element[1]).reduce(
+    const totalRevocations = revocationDataPoints.map((element) => element[1]).reduce(
+      (previousValue, currentValue) => (previousValue + currentValue),
+    );
+
+    const totalSupervisionPopulation = supervisionDataPoints.map((element) => element[1]).reduce(
       (previousValue, currentValue) => (previousValue + currentValue),
     );
 
     // Sort by race alphabetically
-    const sorted = sortByLabel(dataPoints, 0);
+    const sortedRevocationDataPoints = sortByLabel(revocationDataPoints, 0);
+    const sortedSupervisionDataPoints = sortByLabel(supervisionDataPoints, 0);
 
-    setChartLabels(sorted.map((element) => element[0]));
-    setChartProportions(sorted.map((element) => (100 * (element[1] / total))));
-    setStateProportions(sorted.map((element) => ND_RACE_PROPORTIONS[element[0]]));
+    setChartLabels(sortedRevocationDataPoints.map((element) => element[0]));
+    setChartProportions(sortedRevocationDataPoints.map(
+      (element) => (100 * (element[1] / totalRevocations)),
+    ));
+    setStatePopulationProportions(sortedRevocationDataPoints.map(
+      (element) => ND_RACE_PROPORTIONS[element[0]],
+    ));
+    setStateSupervisionProportions(sortedSupervisionDataPoints.map(
+      (element) => (100 * (element[1] / totalSupervisionPopulation)),
+    ));
   };
 
   useEffect(() => {
     processResponse();
-  }, [props.revocationProportionByRace]);
+  }, [props.revocationProportionByRace, props.supervisionPopulationByRace]);
 
   return (
     <HorizontalBar
       data={{
-        labels: ['Revocations', 'ND Population'],
+        labels: ['Revocations', 'Supervision Population', 'ND Population'],
         datasets: [{
           label: chartLabels[0],
           backgroundColor: COLORS_FIVE_VALUES[0],
-          data: [chartProportions[0], statePopulationProportions[0]],
+          data: [
+            chartProportions[0], stateSupervisionProportions[0], statePopulationProportions[0],
+          ],
         }, {
           label: chartLabels[1],
           backgroundColor: COLORS_FIVE_VALUES[1],
-          data: [chartProportions[1], statePopulationProportions[1]],
+          data: [
+            chartProportions[1], stateSupervisionProportions[1], statePopulationProportions[1],
+          ],
         }, {
           label: chartLabels[2],
           backgroundColor: COLORS_FIVE_VALUES[2],
-          data: [chartProportions[2], statePopulationProportions[2]],
+          data: [
+            chartProportions[2], stateSupervisionProportions[2], statePopulationProportions[2],
+          ],
         }, {
           label: chartLabels[3],
           backgroundColor: COLORS_FIVE_VALUES[3],
-          data: [chartProportions[3], statePopulationProportions[3]],
+          data: [
+            chartProportions[3], stateSupervisionProportions[3], statePopulationProportions[3],
+          ],
         }, {
           label: chartLabels[4],
           backgroundColor: COLORS_FIVE_VALUES[4],
-          data: [chartProportions[4], statePopulationProportions[4]],
+          data: [
+            chartProportions[4], stateSupervisionProportions[4], statePopulationProportions[4],
+          ],
         }, {
           label: chartLabels[5],
           backgroundColor: COLORS['blue-standard-2'],
-          data: [chartProportions[5], statePopulationProportions[5]],
+          data: [
+            chartProportions[5], stateSupervisionProportions[5], statePopulationProportions[5],
+          ],
         }, {
           label: chartLabels[6],
           backgroundColor: COLORS['blue-standard'],
-          data: [chartProportions[6], statePopulationProportions[6]],
+          data: [
+            chartProportions[6], stateSupervisionProportions[6], statePopulationProportions[6],
+          ],
         },
         ],
       }}

--- a/src/components/charts/revocations/RevocationProportionByRace.js
+++ b/src/components/charts/revocations/RevocationProportionByRace.js
@@ -38,50 +38,51 @@ const RevocationProportionByRace = (props) => {
     revocationProportionByRace.forEach((data) => {
       const { race_or_ethnicity: race } = data;
       const count = parseInt(data.revocation_count, 10);
-      revocationDataPoints.push([labelStringConversion[race], count]);
+      revocationDataPoints.push({ race: labelStringConversion[race], count });
     });
 
     const supervisionDataPoints = [];
     supervisionPopulationByRace.forEach((data) => {
       const { race_or_ethnicity: race } = data;
       const count = parseInt(data.count, 10);
-      supervisionDataPoints.push([labelStringConversion[race], count]);
+      supervisionDataPoints.push({ race: labelStringConversion[race], count });
     });
 
-    const racesRepresentedRevocations = revocationDataPoints.map((element) => element[0]);
-    const racesRepresentedSupervision = supervisionDataPoints.map((element) => element[0]);
+    const racesRepresentedRevocations = revocationDataPoints.map((element) => element.race);
+    const racesRepresentedSupervision = supervisionDataPoints.map((element) => element.race);
 
     Object.values(labelStringConversion).forEach((race) => {
       if (!racesRepresentedRevocations.includes(race)) {
-        revocationDataPoints.push([race, 0]);
+        revocationDataPoints.push({ race, count: 0 });
       }
 
       if (!racesRepresentedSupervision.includes(race)) {
-        supervisionDataPoints.push([race, 0]);
+        supervisionDataPoints.push({ race, count: 0 });
       }
     });
 
-    const totalRevocations = revocationDataPoints.map((element) => element[1]).reduce(
-      (previousValue, currentValue) => (previousValue + currentValue),
-    );
+    function totalSum(dataPoints) {
+      return dataPoints.map((element) => element.count).reduce(
+        (previousValue, currentValue) => (previousValue + currentValue),
+      );
+    }
 
-    const totalSupervisionPopulation = supervisionDataPoints.map((element) => element[1]).reduce(
-      (previousValue, currentValue) => (previousValue + currentValue),
-    );
+    const totalRevocations = totalSum(revocationDataPoints);
+    const totalSupervisionPopulation = totalSum(supervisionDataPoints);
 
     // Sort by race alphabetically
-    const sortedRevocationDataPoints = sortByLabel(revocationDataPoints, 0);
-    const sortedSupervisionDataPoints = sortByLabel(supervisionDataPoints, 0);
+    const sortedRevocationDataPoints = sortByLabel(revocationDataPoints, 'race');
+    const sortedSupervisionDataPoints = sortByLabel(supervisionDataPoints, 'race');
 
-    setChartLabels(sortedRevocationDataPoints.map((element) => element[0]));
+    setChartLabels(sortedRevocationDataPoints.map((element) => element.race));
     setChartProportions(sortedRevocationDataPoints.map(
-      (element) => (100 * (element[1] / totalRevocations)),
+      (element) => (100 * (element.count / totalRevocations)),
     ));
     setStatePopulationProportions(sortedRevocationDataPoints.map(
-      (element) => ND_RACE_PROPORTIONS[element[0]],
+      (element) => ND_RACE_PROPORTIONS[element.race],
     ));
     setStateSupervisionProportions(sortedSupervisionDataPoints.map(
-      (element) => (100 * (element[1] / totalSupervisionPopulation)),
+      (element) => (100 * (element.count / totalSupervisionPopulation)),
     ));
   };
 

--- a/src/utils/dataOrganizing.js
+++ b/src/utils/dataOrganizing.js
@@ -42,8 +42,8 @@ function sortByYearAndMonth(dataPoints) {
  *  -`labelIndex`: The index in the dataPoint array that contains the label
  *    to sort on
  */
-function sortByLabel(dataPoints, labelIndex) {
-  return dataPoints.sort((a, b) => (a[labelIndex].localeCompare(b[labelIndex])));
+function sortByLabel(dataPoints, labelKey) {
+  return dataPoints.sort((a, b) => (a[labelKey].localeCompare(b[labelKey])));
 }
 
 function filterMostRecentMonths(dataPoints, monthCount) {

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -298,7 +298,7 @@ const Revocations = () => {
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
-                  <h4 className="lh-1">Revocations and supervision by race compared to ND population</h4>
+                  <h4 className="lh-1">Revocations by race</h4>
                 </div>
                 <div className="layer w-100 pX-20 pT-20 row">
                   <div className="layer w-100 p-20">

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -92,7 +92,7 @@ const Revocations = () => {
                   <div id="collapseMethodologyRevocationCountsByMonth" className="collapse" aria-labelledby="methodologyHeadingRevocationCountsByMonth" data-parent="#methodologyRevocationCountsByMonth">
                     <div>
                       <ul>
-                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
+                        <li>Revocation counts include the number of people who were incarcerated because their supervision was revoked.</li>
                         <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
                       </ul>
                     </div>
@@ -123,7 +123,7 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationBySupervisionType" aria-labelledby="methodologyHeadingRevocationBySupervisiontype" data-parent="#methodologyRevocationBySupervisionType">
                     <div>
                       <ul>
-                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
+                        <li>Revocation counts include the number of people who were incarcerated because their supervision was revoked.</li>
                         <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
                       </ul>
                     </div>
@@ -154,7 +154,7 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationsByViolationType" aria-labelledby="methodologyHeadingRevocationsByViolationType" data-parent="#methodologyRevocationsByViolationType">
                     <div>
                       <ul>
-                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
+                        <li>Revocation counts include the number of people who were incarcerated because their supervision was revoked.</li>
                         <li>Violations include all behavioral violations officially recorded by a supervision officer, including new offenses, technical violations, and absconsion.</li>
                         <li>Violations of "Unknown Type" indicate individuals who were admitted to prison for a supervision revocation where the violation that caused the revocation cannot yet be determined.</li>
                         <li>"Technical" revocations include only those revocations which result solely from a technical violation. If there is a violation that includes a new offense or an absconsion, it is considered a non-technical revocation.</li>
@@ -189,7 +189,7 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationsByCounty" aria-labelledby="methodologyHeadingRevocationsByCounty" data-parent="#methodologyRevocationsByCounty">
                     <div>
                       <ul>
-                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
+                        <li>Revocation counts include the number of people who were incarcerated because their supervision was revoked.</li>
                         <li>Revocations are attributed to the county where the person&apos;s supervision was terminated.</li>
                         <li>Revocations are included based on the date that the person&apos;s supervision was officially revoked, not the date of the causal violation or offense.</li>
                       </ul>
@@ -322,8 +322,8 @@ const Revocations = () => {
                   <div className="collapse" id="collapseMethodologyRevocationsByRace" aria-labelledby="methodologyHeadingRevocationsByRace" data-parent="#methodologyRevocationsByRace">
                     <div>
                       <ul>
-                        <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
-                        <li>The supervision population includes anyone on probation or parole in North Dakota at any point during the time period.</li>
+                        <li>Revocation counts include the number of people who were incarcerated because their supervision was revoked.</li>
+                        <li>The supervision population counts people on probation or parole in North Dakota at any point during the time period.</li>
                         <li>The race proportions for the population of North Dakota were taken from the U.S. Census Bureau.</li>
                       </ul>
                     </div>

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -298,11 +298,17 @@ const Revocations = () => {
             <div className="bd bgc-white p-20">
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
-                  <h4 className="lh-1">Revocations by race compared to ND population</h4>
+                  <h4 className="lh-1">Revocations and supervision by race compared to ND population</h4>
                 </div>
                 <div className="layer w-100 pX-20 pT-20 row">
                   <div className="layer w-100 p-20">
-                    <RevocationProportionByRace revocationProportionByRace={apiData.revocations_by_race_and_ethnicity_60_days} />
+                    <RevocationProportionByRace
+                      revocationProportionByRace={
+                        apiData.revocations_by_race_and_ethnicity_60_days}
+                      supervisionPopulationByRace={
+                        apiData.supervision_population_by_race_and_ethnicity_60_days
+                      }
+                    />
                   </div>
                 </div>
                 <div className="layer bdT p-20 w-100 accordion" id="methodologyRevocationsByRace">
@@ -317,6 +323,7 @@ const Revocations = () => {
                     <div>
                       <ul>
                         <li>Revocations counts include the number of people incarcerated because their supervision period was revoked for a behavioral violation.</li>
+                        <li>The supervision population includes anyone on probation or parole in North Dakota at any point during the time period.</li>
                         <li>The race proportions for the population of North Dakota were taken from the U.S. Census Bureau.</li>
                       </ul>
                     </div>

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -160,9 +160,8 @@ const Snapshots = () => {
                         North Dakota prisons that were due to parole or probation revocations.
                         </li>
                         <li>
-                        Revocations include all instances of a person being
-                        incarcerated because their supervision was revoked for
-                        a behavioral violation.
+                        Revocations count all people who were incarcerated
+                        because their supervision was revoked.
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
Closes https://github.com/Recidiviz/pulse-dashboard/issues/62

Adds the breakdown of the current supervision population by race/ethnicity to the revocations by race chart.

Includes updates to the relevant demo data files.