### PR TITLE
Redirects to the Snapshots view instead of the home page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,41 +1,42 @@
-import React, { useEffect, useState } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
+import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
 
 import * as $ from 'jquery';
 import Masonry from 'masonry-layout';
 
-import PrivateRoute from "./components/PrivateRoute";
-import Loading from "./components/Loading";
-import SideBar from "./components/SideBar";
-import TopBar from "./components/TopBar";
-import Footer from "./components/Footer";
-import Home from "./views/Home";
-import NotFound from "./views/NotFound";
-import Profile from "./views/Profile";
-import Revocations from "./views/Revocations";
-import Reincarcerations from "./views/Reincarcerations";
-import Snapshots from "./views/Snapshots";
-import ExternalApi from "./views/ExternalApi";
-import { useAuth0 } from "./react-auth0-spa";
-import "./assets/scripts/index.js";
+import PrivateRoute from './components/PrivateRoute';
+import Loading from './components/Loading';
+import SideBar from './components/SideBar';
+import TopBar from './components/TopBar';
+import Footer from './components/Footer';
+import Home from './views/Home';
+import NotFound from './views/NotFound';
+import Profile from './views/Profile';
+import Revocations from './views/Revocations';
+import Reincarcerations from './views/Reincarcerations';
+import Snapshots from './views/Snapshots';
+import ExternalApi from './views/ExternalApi';
+import { useAuth0 } from './react-auth0-spa';
+import './assets/scripts/index.js';
 
 // styles
-import "./assets/styles/index.scss";
+import './assets/styles/index.scss';
 
 // fontawesome
-import initFontAwesome from "./utils/initFontAwesome";
+import initFontAwesome from './utils/initFontAwesome';
+
 initFontAwesome();
 
 const App = () => {
-  const [sideBarCollapsed, setSideBarCollapsed] = useState("");
+  const [sideBarCollapsed, setSideBarCollapsed] = useState('');
   const { loading, isAuthenticated } = useAuth0();
 
   function toggleCollapsed() {
-    const currentlyCollapsed = sideBarCollapsed === "is-collapsed";
+    const currentlyCollapsed = sideBarCollapsed === 'is-collapsed';
     if (currentlyCollapsed) {
-      setSideBarCollapsed("");
+      setSideBarCollapsed('');
     } else {
-      setSideBarCollapsed("is-collapsed");
+      setSideBarCollapsed('is-collapsed');
     }
   }
 
@@ -64,9 +65,9 @@ const App = () => {
     return <Loading />;
   }
 
-  let containerClass = "wide-page-container";
+  let containerClass = 'wide-page-container';
   if (isAuthenticated) {
-    containerClass = "page-container";
+    containerClass = 'page-container';
   }
 
   return (
@@ -83,7 +84,9 @@ const App = () => {
             <div className={containerClass}>
               <TopBar pathname={window.location.pathname} />
               <Switch>
-                <Route path="/" exact component={Home} />
+                <Route exact path="/">
+                  {isAuthenticated ? <Redirect to="/snapshots" /> : <Home />}
+                </Route>
                 <PrivateRoute path="/snapshots" component={Snapshots} />
                 <PrivateRoute path="/revocations" component={Revocations} />
                 <PrivateRoute path="/reincarcerations" component={Reincarcerations} />

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,6 +1,6 @@
-import React from "react";
+import React from 'react';
 
-import { useAuth0 } from "../react-auth0-spa";
+import { useAuth0 } from '../react-auth0-spa';
 
 const Home = () => {
   const { isAuthenticated, loginWithRedirect } = useAuth0();


### PR DESCRIPTION
When authenticated, it redirects to the Snapshots view. When you log in at the home page, it already successfully redirected to the Snapshots view on successful login. But you could still navigate directly back `dashboard.recidiviz.org/` and it would take you back to the home page, which is also what happens when you just open the dashboard naturally (no particular view) in your browser. Now if you attempt to do either of these, it will redirect to Snapshots successfully.