### PR TITLE
Handles empty data in charts

### DIFF
--- a/src/components/charts/reincarcerations/AdmissionsVsReleases.js
+++ b/src/components/charts/reincarcerations/AdmissionsVsReleases.js
@@ -20,7 +20,7 @@ import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { COLORS, COLORS_GOOD_BAD } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
-import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/dataOrganizing';
 import { configureDownloadButtons } from '../../../assets/scripts/utils/downloads';
 
 const AdmissionsVsReleases = (props) => {
@@ -39,7 +39,7 @@ const AdmissionsVsReleases = (props) => {
       dataPoints.push({ year, month, delta });
     });
 
-    const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
+    const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'delta', 0);
 
     const colorsForValues = [];
     sorted.forEach((dataPoint) => {
@@ -114,12 +114,18 @@ const AdmissionsVsReleases = (props) => {
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];
-  const direction = (mostRecentValue > 0) ? 'grew' : 'shrank';
 
   const header = document.getElementById(props.header);
 
-  if (header && mostRecentValue) {
-    const title = `The ND facilities <b style='color:#809AE5'>${direction} by ${Math.abs(mostRecentValue)} people</b> this month.`;
+  if (header && (mostRecentValue !== null)) {
+    let title = '';
+    if (mostRecentValue === 0) {
+      title = `The ND facilities <b style='color:#809AE5'> have not changed in size</b> this month.`;
+    } else {
+      const direction = (mostRecentValue > 0) ? 'grew' : 'shrank';
+      title = `The ND facilities <b style='color:#809AE5'>${direction} by ${Math.abs(mostRecentValue)} people</b> this month.`;
+    }
+
     header.innerHTML = title;
   }
 

--- a/src/components/charts/reincarcerations/AdmissionsVsReleases.js
+++ b/src/components/charts/reincarcerations/AdmissionsVsReleases.js
@@ -34,11 +34,12 @@ const AdmissionsVsReleases = (props) => {
     const { admissionsVsReleases } = props;
 
     const dataPoints = [];
-    admissionsVsReleases.forEach((data) => {
-      const { year, month, population_change: delta } = data;
-      dataPoints.push({ year, month, delta });
-    });
-
+    if (admissionsVsReleases) {
+      admissionsVsReleases.forEach((data) => {
+        const { year, month, population_change: delta } = data;
+        dataPoints.push({ year, month, delta });
+      });
+    }
     const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'delta', 0);
 
     const colorsForValues = [];

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -38,10 +38,12 @@ const ReincarcerationCountOverTime = (props) => {
     const { reincarcerationCountsByMonth: countsByMonth } = props;
 
     const dataPoints = [];
-    countsByMonth.forEach((data) => {
-      const { year, month, returns: count } = data;
-      dataPoints.push({ year, month, count });
-    });
+    if (countsByMonth) {
+      countsByMonth.forEach((data) => {
+        const { year, month, returns: count } = data;
+        dataPoints.push({ year, month, count });
+      });
+    }
 
     const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'count', 0);
     const chartDataValues = (sorted.map((element) => element.count));

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -21,7 +21,7 @@ import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from '../../../assets/scripts/utils/downloads';
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
-import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/dataOrganizing';
 import { getGoalForChart, getMaxForGoalAndData, goalLabelContentString } from '../../../utils/metricGoal';
 
 const ReincarcerationCountOverTime = (props) => {
@@ -43,7 +43,7 @@ const ReincarcerationCountOverTime = (props) => {
       dataPoints.push({ year, month, count });
     });
 
-    const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
+    const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'count', 0);
     const chartDataValues = (sorted.map((element) => element.count));
     const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
@@ -170,7 +170,7 @@ const ReincarcerationCountOverTime = (props) => {
 
   const header = document.getElementById(props.header);
 
-  if (header && mostRecentValue) {
+  if (header && (mostRecentValue !== null)) {
     const title = `There have been <b style='color:#809AE5'>${mostRecentValue} reincarcerations</b> to a DOCR facility this month so far.`;
     header.innerHTML = title;
   }

--- a/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
@@ -32,14 +32,17 @@ const ReincarcerationRateByReleaseFacility = (props) => {
     const { ratesByReleaseFacility: ratesByFacility } = props;
 
     let dataPoints = [];
-    ratesByFacility.forEach((data) => {
-      const {
-        release_facility: facility,
-        recidivism_rate: recidivismRate,
-        state_code: stateCode,
-      } = data;
-      dataPoints.push([facility, recidivismRate, stateCode]);
-    });
+
+    if (ratesByFacility) {
+      ratesByFacility.forEach((data) => {
+        const {
+          release_facility: facility,
+          recidivism_rate: recidivismRate,
+          state_code: stateCode,
+        } = data;
+        dataPoints.push([facility, recidivismRate, stateCode]);
+      });
+    }
 
     if (dataPoints.length > 0) {
       const stateCode = dataPoints[0][2];

--- a/src/components/charts/reincarcerations/ReincarcerationRateByStayLength.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByStayLength.js
@@ -34,17 +34,19 @@ const ReincarcerationRateByStayLength = (props) => {
       '60-72', '72-84', '84-96', '96-108', '108-120', '120+'];
 
     const ratesByStayLengthData = [];
-    ratesByStayLength.forEach((data) => {
-      let { stay_length_bucket: stayLength } = data;
+    if (ratesByStayLength) {
+      ratesByStayLength.forEach((data) => {
+        let { stay_length_bucket: stayLength } = data;
 
-      if (stayLength === '<12') {
-        stayLength = '0-12';
-      } else if (stayLength === '120<') {
-        stayLength = '120+';
-      }
+        if (stayLength === '<12') {
+          stayLength = '0-12';
+        } else if (stayLength === '120<') {
+          stayLength = '120+';
+        }
 
-      ratesByStayLengthData[stayLength] = data.recidivism_rate;
-    });
+        ratesByStayLengthData[stayLength] = data.recidivism_rate;
+      });
+    }
 
     const rates = [];
     for (let i = 0; i < stayLengthLabels.length; i += 1) {

--- a/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
@@ -32,14 +32,16 @@ const ReincarcerationRateByTransitionalFacility = (props) => {
     const { ratesByTransitionalFacility: ratesByFacility } = props;
 
     let dataPoints = [];
-    ratesByFacility.forEach((data) => {
-      const {
-        release_facility: facility,
-        recidivism_rate: recidivismRate,
-        state_code: stateCode,
-      } = data;
-      dataPoints.push([facility, recidivismRate, stateCode]);
-    });
+    if (ratesByFacility) {
+      ratesByFacility.forEach((data) => {
+        const {
+          release_facility: facility,
+          recidivism_rate: recidivismRate,
+          state_code: stateCode,
+        } = data;
+        dataPoints.push([facility, recidivismRate, stateCode]);
+      });
+    }
 
     if (dataPoints.length > 0) {
       const stateCode = dataPoints[0][2];

--- a/src/components/charts/revocations/AdmissionTypeProportions.js
+++ b/src/components/charts/revocations/AdmissionTypeProportions.js
@@ -40,11 +40,17 @@ const AdmissionTypeProportions = (props) => {
     };
 
     const dataPoints = [];
-    admissionCountsByType.forEach((data) => {
-      const { admission_type: admissionType } = data;
-      const count = toInt(data.admission_count);
-      dataPoints.push({ type: labelStringConversion[admissionType], count });
-    });
+    if (admissionCountsByType) {
+      admissionCountsByType.forEach((data) => {
+        const { admission_type: admissionType } = data;
+        const count = toInt(data.admission_count);
+        dataPoints.push({ type: labelStringConversion[admissionType], count });
+      });
+    } else {
+      Object.values(labelStringConversion).forEach((type) => {
+        dataPoints.push({ type, count: 0 });
+      });
+    }
 
     const sorted = sortByLabel(dataPoints, 'type');
 

--- a/src/components/charts/revocations/RevocationCountByOfficer.js
+++ b/src/components/charts/revocations/RevocationCountByOfficer.js
@@ -111,44 +111,48 @@ const RevocationCountByOfficer = (props) => {
     const offices = {};
     const officeIds = [];
 
-    officeData.forEach((office) => {
-      const {
-        site_id: officeId,
-        site_name: officeName,
-      } = office;
+    if (officeData) {
+      officeData.forEach((office) => {
+        const {
+          site_id: officeId,
+          site_name: officeName,
+        } = office;
 
-      offices[officeId] = toHtmlFriendly(officeName);
-      officeIds.push(officeId);
-    });
+        offices[officeId] = toHtmlFriendly(officeName);
+        officeIds.push(officeId);
+      });
+    }
 
     const dataPoints = {};
-    revocationCountsByOfficer.forEach((data) => {
-      const {
-        officer_external_id: officerIDRaw, absconsion_count: absconsionCount,
-        felony_count: felonyCount, technical_count: technicalCount,
-        unknown_count: unknownCount, site_id: officeId,
-      } = data;
+    if (revocationCountsByOfficer) {
+      revocationCountsByOfficer.forEach((data) => {
+        const {
+          officer_external_id: officerIDRaw, absconsion_count: absconsionCount,
+          felony_count: felonyCount, technical_count: technicalCount,
+          unknown_count: unknownCount, site_id: officeId,
+        } = data;
 
-      const violationsByType = {
-        ABSCONDED: toInt(absconsionCount),
-        FELONY: toInt(felonyCount),
-        TECHNICAL: toInt(technicalCount),
-        UNKNOWN_VIOLATION_TYPE: toInt(unknownCount),
-      };
+        const violationsByType = {
+          ABSCONDED: toInt(absconsionCount),
+          FELONY: toInt(felonyCount),
+          TECHNICAL: toInt(technicalCount),
+          UNKNOWN_VIOLATION_TYPE: toInt(unknownCount),
+        };
 
-      let officeName = offices[toInt(officeId)];
-      if (officeName && officerIDRaw !== 'OFFICER_UNKNOWN') {
-        officeName = toHtmlFriendly(officeName);
-        const officerId = toInt(officerIDRaw);
-        if (dataPoints[officeName] == null) {
-          dataPoints[officeName] = [];
+        let officeName = offices[toInt(officeId)];
+        if (officeName && officerIDRaw !== 'OFFICER_UNKNOWN') {
+          officeName = toHtmlFriendly(officeName);
+          const officerId = toInt(officerIDRaw);
+          if (dataPoints[officeName] == null) {
+            dataPoints[officeName] = [];
+          }
+          dataPoints[officeName].push({
+            officerId,
+            violationsByType,
+          });
         }
-        dataPoints[officeName].push({
-          officerId,
-          violationsByType,
-        });
-      }
-    });
+      });
+    }
 
     // Disable any office name from the dropdown menu if there is no data
     // for that office

--- a/src/components/charts/revocations/RevocationCountBySupervisionType.js
+++ b/src/components/charts/revocations/RevocationCountBySupervisionType.js
@@ -35,13 +35,15 @@ const RevocationCountBySupervisionType = (props) => {
 
     const paroleData = [];
     const probationData = [];
-    countsByMonth.forEach((data) => {
-      const {
-        year, month, parole_count: paroleCount, probation_count: probationCount,
-      } = data;
-      paroleData.push({ year, month, paroleCount });
-      probationData.push({ year, month, probationCount });
-    });
+    if (countsByMonth) {
+      countsByMonth.forEach((data) => {
+        const {
+          year, month, parole_count: paroleCount, probation_count: probationCount,
+        } = data;
+        paroleData.push({ year, month, paroleCount });
+        probationData.push({ year, month, probationCount });
+      });
+    }
 
     const sortedParoleData = sortFilterAndSupplementMostRecentMonths(paroleData, 6, 'paroleCount', 0);
     const sortedProbationData = sortFilterAndSupplementMostRecentMonths(probationData, 6, 'probationCount', 0);

--- a/src/components/charts/revocations/RevocationCountBySupervisionType.js
+++ b/src/components/charts/revocations/RevocationCountBySupervisionType.js
@@ -20,7 +20,7 @@ import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { COLORS, COLORS_STACKED_TWO_VALUES } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
-import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/dataOrganizing';
 import { configureDownloadButtons } from '../../../assets/scripts/utils/downloads';
 
 const RevocationCountBySupervisionType = (props) => {
@@ -43,8 +43,8 @@ const RevocationCountBySupervisionType = (props) => {
       probationData.push({ year, month, probationCount });
     });
 
-    const sortedParoleData = sortAndFilterMostRecentMonths(paroleData, 6);
-    const sortedProbationData = sortAndFilterMostRecentMonths(probationData, 6);
+    const sortedParoleData = sortFilterAndSupplementMostRecentMonths(paroleData, 6, 'paroleCount', 0);
+    const sortedProbationData = sortFilterAndSupplementMostRecentMonths(probationData, 6, 'probationCount', 0);
 
     setChartLabels(monthNamesWithYearsFromNumbers(sortedParoleData.map(
       (element) => element.month,

--- a/src/components/charts/revocations/RevocationCountByViolationType.js
+++ b/src/components/charts/revocations/RevocationCountByViolationType.js
@@ -36,22 +36,24 @@ const RevocationCountByViolationType = (props) => {
     const { revocationCountsByMonthByViolationType: countsByMonth } = props;
 
     const dataPoints = [];
-    countsByMonth.forEach((data) => {
-      const {
-        year, month, absconsion_count: absconsionCount,
-        felony_count: felonyCount, technical_count: technicalCount,
-        unknown_count: unknownCount,
-      } = data;
+    if (countsByMonth) {
+      countsByMonth.forEach((data) => {
+        const {
+          year, month, absconsion_count: absconsionCount,
+          felony_count: felonyCount, technical_count: technicalCount,
+          unknown_count: unknownCount,
+        } = data;
 
-      const monthDict = {
-        ABSCONDED: absconsionCount,
-        FELONY: felonyCount,
-        TECHNICAL: technicalCount,
-        UNKNOWN_VIOLATION_TYPE: unknownCount,
-      };
+        const monthDict = {
+          ABSCONDED: absconsionCount,
+          FELONY: felonyCount,
+          TECHNICAL: technicalCount,
+          UNKNOWN_VIOLATION_TYPE: unknownCount,
+        };
 
-      dataPoints.push({ year, month, monthDict });
-    });
+        dataPoints.push({ year, month, monthDict });
+      });
+    }
 
     const emptyMonthDict = {
       ABSCONDED: 0,

--- a/src/components/charts/revocations/RevocationCountByViolationType.js
+++ b/src/components/charts/revocations/RevocationCountByViolationType.js
@@ -20,7 +20,7 @@ import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { COLORS, COLORS_FIVE_VALUES } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
-import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/dataOrganizing';
 import { configureDownloadButtons } from '../../../assets/scripts/utils/downloads';
 
 const RevocationCountByViolationType = (props) => {
@@ -53,8 +53,14 @@ const RevocationCountByViolationType = (props) => {
       dataPoints.push({ year, month, monthDict });
     });
 
-    const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
+    const emptyMonthDict = {
+      ABSCONDED: 0,
+      FELONY: 0,
+      TECHNICAL: 0,
+      UNKNOWN_VIOLATION_TYPE: 0,
+    };
 
+    const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'monthDict', emptyMonthDict);
     const monthsLabels = [];
     const violationArrays = {
       ABSCONDED: [],

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -21,7 +21,7 @@ import { Line } from 'react-chartjs-2';
 import { configureDownloadButtons } from '../../../assets/scripts/utils/downloads';
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/monthConversion';
-import { sortAndFilterMostRecentMonths } from '../../../utils/dataOrganizing';
+import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/dataOrganizing';
 import { getGoalForChart, getMaxForGoalAndData, goalLabelContentString } from '../../../utils/metricGoal';
 
 const RevocationCountOverTime = (props) => {
@@ -43,7 +43,7 @@ const RevocationCountOverTime = (props) => {
       dataPoints.push({ year, month, count });
     });
 
-    const sorted = sortAndFilterMostRecentMonths(dataPoints, 6);
+    const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'count', 0);
     const chartDataValues = (sorted.map((element) => element.count));
     const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
 
@@ -170,7 +170,7 @@ const RevocationCountOverTime = (props) => {
 
   const header = document.getElementById(props.header);
 
-  if (header && mostRecentValue) {
+  if (header && (mostRecentValue !== null)) {
     const title = `There have been <b style='color:#809AE5'>${mostRecentValue} revocations</b> that led to incarceration in a DOCR facility this month so far.`;
     header.innerHTML = title;
   }

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -38,10 +38,12 @@ const RevocationCountOverTime = (props) => {
     const { revocationCountsByMonth: countsByMonth } = props;
 
     const dataPoints = [];
-    countsByMonth.forEach((data) => {
-      const { year, month, revocation_count: count } = data;
-      dataPoints.push({ year, month, count });
-    });
+    if (countsByMonth) {
+      countsByMonth.forEach((data) => {
+        const { year, month, revocation_count: count } = data;
+        dataPoints.push({ year, month, count });
+      });
+    }
 
     const sorted = sortFilterAndSupplementMostRecentMonths(dataPoints, 6, 'count', 0);
     const chartDataValues = (sorted.map((element) => element.count));

--- a/src/components/charts/revocations/RevocationProportionByRace.js
+++ b/src/components/charts/revocations/RevocationProportionByRace.js
@@ -56,18 +56,22 @@ const RevocationProportionByRace = (props) => {
     const { supervisionPopulationByRace } = props;
 
     const revocationDataPoints = [];
-    revocationProportionByRace.forEach((data) => {
-      const { race_or_ethnicity: race } = data;
-      const count = toInt(data.revocation_count, 10);
-      revocationDataPoints.push({ race: labelStringConversion[race], count });
-    });
+    if (revocationProportionByRace) {
+      revocationProportionByRace.forEach((data) => {
+        const { race_or_ethnicity: race } = data;
+        const count = toInt(data.revocation_count, 10);
+        revocationDataPoints.push({ race: labelStringConversion[race], count });
+      });
+    }
 
     const supervisionDataPoints = [];
-    supervisionPopulationByRace.forEach((data) => {
-      const { race_or_ethnicity: race } = data;
-      const count = toInt(data.count);
-      supervisionDataPoints.push({ race: labelStringConversion[race], count });
-    });
+    if (supervisionPopulationByRace) {
+      supervisionPopulationByRace.forEach((data) => {
+        const { race_or_ethnicity: race } = data;
+        const count = toInt(data.count);
+        supervisionDataPoints.push({ race: labelStringConversion[race], count });
+      });
+    }
 
     const racesRepresentedRevocations = revocationDataPoints.map((element) => element.race);
     const racesRepresentedSupervision = supervisionDataPoints.map((element) => element.race);

--- a/src/components/charts/revocations/RevocationsByCounty.js
+++ b/src/components/charts/revocations/RevocationsByCounty.js
@@ -72,23 +72,26 @@ class RevocationsByCounty extends Component {
     this.revocationsByCounty = this.props.revocationsByCounty;
     this.chartDataPoints = {};
     this.maxValue = -1e100;
-    this.revocationsByCounty.forEach((data) => {
-      const {
-        state_code: stateCode,
-        county_code: countyCode,
-        revocation_count: revocationCount,
-      } = data;
 
-      const revocationCountNum = toInt(revocationCount);
+    if (this.revocationsByCounty) {
+      this.revocationsByCounty.forEach((data) => {
+        const {
+          state_code: stateCode,
+          county_code: countyCode,
+          revocation_count: revocationCount,
+        } = data;
 
-      if (countyCode !== 'UNKNOWN_COUNTY') {
-        if (revocationCountNum > this.maxValue) {
-          this.maxValue = revocationCountNum;
+        const revocationCountNum = toInt(revocationCount);
+
+        if (countyCode !== 'UNKNOWN_COUNTY') {
+          if (revocationCountNum > this.maxValue) {
+            this.maxValue = revocationCountNum;
+          }
+          const standardCountyName = countyNameFromCode(stateCode, countyCode);
+          this.chartDataPoints[standardCountyName] = revocationCountNum;
         }
-        const standardCountyName = countyNameFromCode(stateCode, countyCode);
-        this.chartDataPoints[standardCountyName] = revocationCountNum;
-      }
-    });
+      });
+    }
   }
 
   componentDidMount() {

--- a/src/components/charts/revocations/RevocationsByOffice.js
+++ b/src/components/charts/revocations/RevocationsByOffice.js
@@ -115,53 +115,57 @@ class RevocationsByOffice extends Component {
     this.officeIds = [];
     this.maxValue = -1e100;
 
-    // Load office metadata
-    this.officeData.forEach((officeData) => {
-      const {
-        site_id: officeId,
-        site_name: name,
-        long: longValue,
-        lat: latValue,
-        title_side: titleSideValue,
-      } = officeData;
+    if (this.officeData) {
+      // Load office metadata
+      this.officeData.forEach((officeData) => {
+        const {
+          site_id: officeId,
+          site_name: name,
+          long: longValue,
+          lat: latValue,
+          title_side: titleSideValue,
+        } = officeData;
 
-      const office = {
-        officeName: name,
-        coordinates: [longValue, latValue],
-        titleSide: titleSideValue,
-      };
+        const office = {
+          officeName: name,
+          coordinates: [longValue, latValue],
+          titleSide: titleSideValue,
+        };
 
-      this.offices[officeId] = office;
-      this.officeIds.push(officeId);
-    });
+        this.offices[officeId] = office;
+        this.officeIds.push(officeId);
+      });
+    }
 
     // Load revocation data for each office
     this.chartDataPoints = [];
     this.officeIdsWithData = [];
-    this.revocationsByOffice.forEach((data) => {
-      const {
-        site_id: officeId,
-        absconsion_count: absconsionCount,
-        felony_count: felonyCount,
-        technical_count: technicalCount,
-        unknown_count: unknownCount,
-      } = data;
+    if (this.revocationsByOffice) {
+      this.revocationsByOffice.forEach((data) => {
+        const {
+          site_id: officeId,
+          absconsion_count: absconsionCount,
+          felony_count: felonyCount,
+          technical_count: technicalCount,
+          unknown_count: unknownCount,
+        } = data;
 
-      const revocationCountNum = toInt(absconsionCount)
-        + toInt(felonyCount) + toInt(technicalCount) + toInt(unknownCount);
-      const officeIdInt = toInt(officeId);
-      const office = this.offices[officeIdInt];
-      if (office) {
-        office.revocationCount = revocationCountNum;
-        office.officerDropdownItemId = `${this.officerDropdownId}-${toHtmlFriendly(office.officeName)}`;
-        this.chartDataPoints.push(office);
-        this.officeIdsWithData.push(officeIdInt);
+        const revocationCountNum = toInt(absconsionCount)
+          + toInt(felonyCount) + toInt(technicalCount) + toInt(unknownCount);
+        const officeIdInt = toInt(officeId);
+        const office = this.offices[officeIdInt];
+        if (office) {
+          office.revocationCount = revocationCountNum;
+          office.officerDropdownItemId = `${this.officerDropdownId}-${toHtmlFriendly(office.officeName)}`;
+          this.chartDataPoints.push(office);
+          this.officeIdsWithData.push(officeIdInt);
 
-        if (office.revocationCount > this.maxValue) {
-          this.maxValue = office.revocationCount;
+          if (office.revocationCount > this.maxValue) {
+            this.maxValue = office.revocationCount;
+          }
         }
-      }
-    });
+      });
+    }
 
     // Set the revocation count to 0 for offices without data
     const officeIdsWithoutData = this.officeIds.filter((value) => (

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -41,25 +41,23 @@ const DaysAtLibertySnapshot = (props) => {
   const processResponse = () => {
     const { daysAtLibertyByMonth } = props;
 
+    const dataPoints = [];
     if (daysAtLibertyByMonth) {
-      const dataPoints = [];
-
       daysAtLibertyByMonth.forEach((data) => {
         const { year, month } = data;
         const average = parseFloat(data.avg_liberty).toFixed(2);
         dataPoints.push({ year, month, average });
       });
-
-      const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = sorted.map((element) => element.average);
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
-
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
-      setChartDataPoints(chartDataValues);
-      setChartMinValue(min);
-      setChartMaxValue(max);
     }
+    const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+    const chartDataValues = sorted.map((element) => element.average);
+    const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+    const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
+
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
+    setChartDataPoints(chartDataValues);
+    setChartMinValue(min);
+    setChartMaxValue(max);
   };
 
   useEffect(() => {

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -41,26 +41,25 @@ const LsirScoreChangeSnapshot = (props) => {
   const processResponse = () => {
     const { lsirScoreChangeByMonth: changeByMonth } = props;
 
+    const dataPoints = [];
     if (changeByMonth) {
-      const dataPoints = [];
-
       changeByMonth.forEach((data) => {
         const { termination_year: year, termination_month: month } = data;
         const change = parseFloat(data.average_change).toFixed(2);
 
         dataPoints.push({ year, month, change });
       });
-
-      const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = sorted.map((element) => element.change);
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
-
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
-      setChartDataPoints(chartDataValues);
-      setChartMinValue(min);
-      setChartMaxValue(max);
     }
+
+    const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+    const chartDataValues = sorted.map((element) => element.change);
+    const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+    const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
+
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
+    setChartDataPoints(chartDataValues);
+    setChartMinValue(min);
+    setChartMaxValue(max);
   };
 
   useEffect(() => {

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -42,9 +42,8 @@ const RevocationAdmissionsSnapshot = (props) => {
   const processResponse = () => {
     const { revocationAdmissionsByMonth: countsByMonth } = props;
 
+    const dataPoints = [];
     if (countsByMonth) {
-      const dataPoints = [];
-
       countsByMonth.forEach((data) => {
         const { year, month } = data;
         const newAdmissions = toInt(data.new_admissions);
@@ -56,17 +55,17 @@ const RevocationAdmissionsSnapshot = (props) => {
         const percentRevocations = (100 * (revocations / total)).toFixed(2);
         dataPoints.push({ year, month, percentRevocations });
       });
-
-      const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = sorted.map((element) => element.percentRevocations);
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
-
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
-      setChartDataPoints(chartDataValues);
-      setChartMinValue(min);
-      setChartMaxValue(max);
     }
+
+    const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+    const chartDataValues = sorted.map((element) => element.percentRevocations);
+    const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+    const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
+
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
+    setChartDataPoints(chartDataValues);
+    setChartMinValue(min);
+    setChartMaxValue(max);
   };
 
   useEffect(() => {

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -42,12 +42,12 @@ const SupervisionSuccessSnapshot = (props) => {
   const processResponse = () => {
     const { supervisionSuccessRates: countsByMonth } = props;
 
-    if (countsByMonth) {
-      const today = new Date();
-      const yearNow = today.getFullYear();
-      const monthNow = today.getMonth() + 1;
+    const today = new Date();
+    const yearNow = today.getFullYear();
+    const monthNow = today.getMonth() + 1;
 
-      const dataPoints = [];
+    const dataPoints = [];
+    if (countsByMonth) {
       countsByMonth.forEach((data) => {
         let { projected_year: year, projected_month: month } = data;
         const successful = toInt(data.successful_termination);
@@ -62,17 +62,16 @@ const SupervisionSuccessSnapshot = (props) => {
           dataPoints.push({ year, month, successRate });
         }
       });
-
-      const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
-      const chartDataValues = (sorted.map((element) => element.successRate));
-      const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
-      const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
-
-      setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
-      setChartDataPoints(chartDataValues);
-      setChartMinValue(min);
-      setChartMaxValue(max);
     }
+    const sorted = sortAndFilterMostRecentMonths(dataPoints, 13);
+    const chartDataValues = (sorted.map((element) => element.successRate));
+    const min = getMinForGoalAndData(GOAL.value, chartDataValues, stepSize);
+    const max = getMaxForGoalAndData(GOAL.value, chartDataValues, stepSize);
+
+    setChartLabels(monthNamesWithYearsFromNumbers(sorted.map((element) => element.month), true));
+    setChartDataPoints(chartDataValues);
+    setChartMinValue(min);
+    setChartMaxValue(max);
   };
 
   useEffect(() => {

--- a/src/utils/dataOrganizing.js
+++ b/src/utils/dataOrganizing.js
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { toInt } from './variableConversion'
-
 const TRANSITIONAL_FACILITY_FILTERS = {
   US_ND: ['FTPFAR', 'GFC', 'BTC', 'FTPMND', 'MTPFAR', 'LRRP', 'MTPMND'],
   US_DEMO: ['GHI', 'PQR', 'VWX'],
@@ -77,7 +75,7 @@ function sortAndFilterMostRecentMonths(unsortedDataPoints, monthCount) {
 }
 
 /**
- * Adds a dictionary for any months in the last `monthCount` number of months
+ * Adds a dictionary for any month in the last `monthCount` number of months
  * that is missing data, where the the value for the `valueKey` property is `emptyValue`.
  */
 function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
@@ -98,7 +96,7 @@ function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
     const month = (i === 0) ? 12 : ((i + 12) % 12);
     const year = (i <= 0) ? (thisYear - 1) : thisYear;
 
-    if (!representedMonths[year][month]) {
+    if (!representedMonths[year] || !representedMonths[year][month]) {
       const monthData = {
         year: year.toString(),
         month: month.toString(),

--- a/src/utils/dataOrganizing.js
+++ b/src/utils/dataOrganizing.js
@@ -75,8 +75,9 @@ function sortAndFilterMostRecentMonths(unsortedDataPoints, monthCount) {
 }
 
 /**
- * Adds a dictionary for any month in the last `monthCount` number of months
- * that is missing data, where the the value for the `valueKey` property is `emptyValue`.
+ * Returns a new list of data points consisting of the given data points and new
+ * data points appended for any month in the last `monthCount` number of months
+ * that is missing data, where the value for the `valueKey` property is `emptyValue`.
  */
 function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
   const now = new Date();

--- a/src/utils/dataOrganizing.js
+++ b/src/utils/dataOrganizing.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+import { toInt } from './variableConversion'
 
 const TRANSITIONAL_FACILITY_FILTERS = {
   US_ND: ['FTPFAR', 'GFC', 'BTC', 'FTPMND', 'MTPFAR', 'LRRP', 'MTPMND'],
@@ -75,9 +76,60 @@ function sortAndFilterMostRecentMonths(unsortedDataPoints, monthCount) {
   return filterMostRecentMonths(sortedData, monthCount);
 }
 
+/**
+ * Adds a dictionary for any months in the last `monthCount` number of months
+ * that is missing data, where the the value for the `valueKey` property is `emptyValue`.
+ */
+function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
+  const now = new Date();
+  const thisMonth = now.getMonth() + 1;
+  const thisYear = now.getFullYear();
+
+  const representedMonths = {};
+  dataPoints.forEach((monthData) => {
+    if (!representedMonths[monthData.year]) {
+      representedMonths[monthData.year] = {};
+    }
+    representedMonths[monthData.year][monthData.month] = true;
+  });
+
+  const newDataPoints = dataPoints;
+  for (let i = thisMonth - (monthCount - 1); i <= thisMonth; i += 1) {
+    const month = (i === 0) ? 12 : ((i + 12) % 12);
+    const year = (i <= 0) ? (thisYear - 1) : thisYear;
+
+    if (!representedMonths[year][month]) {
+      const monthData = {
+        year: year.toString(),
+        month: month.toString(),
+      };
+      monthData[valueKey] = emptyValue;
+      newDataPoints.push(monthData);
+    }
+  }
+
+  return newDataPoints;
+}
+
+/**
+ * Sorts the data points by year and month, ascending, and then returns the
+ * most recent `monthCount` number of months. Adds empty data for any months
+ * that are missing.
+ */
+function sortFilterAndSupplementMostRecentMonths(
+  unsortedDataPoints, monthCount, valueKey, emptyValue,
+) {
+  const updatedDataPoints = addEmptyMonthsToData(
+    unsortedDataPoints, monthCount, valueKey, emptyValue,
+  );
+  const sortedData = sortByYearAndMonth(updatedDataPoints);
+  return filterMostRecentMonths(sortedData, monthCount);
+}
+
 export {
   filterFacilities,
   filterMostRecentMonths,
+  sortFilterAndSupplementMostRecentMonths,
   sortAndFilterMostRecentMonths,
   sortByLabel,
   sortByYearAndMonth,


### PR DESCRIPTION
Closes: #80 

In this PR:
- Handles any case where a chart is sent empty data from the API so that an empty chart is displayed instead of the dashboard app crashing
- For charts that display count values over months, adds counts of 0 for any month that is missing data
- Does not add values to the snapshot charts if there are missing months, because those are not count charts and on those charts a value of 0 is significant

Filed: https://github.com/Recidiviz/recidiviz-data/issues/2513