### PR TITLE
Fixes data exports to ensure values are numbers instead of strings.

### DIFF
--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -50,7 +50,7 @@ function configureDownloadButtons(
           const values = {};
           let i = 0;
           dataset.data.forEach((dataPoint) => {
-            values[chartLabels[i]] = dataPoint;
+            values[chartLabels[i]] = Number(dataPoint);
             i += 1;
           });
 


### PR DESCRIPTION
In most export files, the values are strings. In some files, where there are gaps that are being filled by new logic, the present values are strings and the gap-filled values are integer 0s. (In some files the gaps may be nulls, and that should be investigated.) This changes values to integers or floats, as necessary. Never strings.