### PR TITLE
Enhances demo mode to not require authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The development servers will remain active until you either close your terminal 
 
 ### Demo mode
 
-When running locally, you can run the app in demo mode to point the app to static data contained in `server/core/demoData`. This is useful for debugging issues that materialize under specific data circumstances, for demonstrating the tool without exposing real data, and other use cases.
+When running locally, you can run the app in demo mode to point the app to static data contained in `server/core/demoData`. This is useful for debugging issues that materialize under specific data circumstances, for demonstrating the tool without exposing real data, for development when you don't have Internet access, and other use cases.
 
 You can launch in demo mode locally via: `./run_in_demo_mode.sh`
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For the frontend: copy the `.env.frontend.example` file and set variables accord
 Expected frontend environment variables include:
 * `REACT_APP_API_URL` - the base URL of the backend API server.
 * `REACT_APP_AUTH_ENV` - a string indicating the "auth environment" used to point to the correct Auth0 tenant. Either "development" or "production". Must match the backend `AUTH_ENV` variable.
+* `REACT_APP_IS_DEMO (OPTIONAL)` - whether or not to run the backend in demo mode, which will retrieve static fixture data from the `server/core/demoData` directory instead of pulling data from dynamic, live sources. This should only be set when running locally and should be provided through the command line, along with the backend sibling below. Use the following command: `./run_in_demo_mode.sh`
 
 The build process, as described below, ensures that the proper values are compiled and included in the static bundle at build time, for the right environment.
 
@@ -44,7 +45,7 @@ Expected backend environment variables include:
 * `AUTH_ENV` - a string indicating the "auth environment" used to point to the correct Auth0 tenant. Either "development" or "production". Must match the frontend `REACT_APP_AUTH_ENV` variable.
 * `GOOGLE_APPLICATION_CREDENTIALS` - a relative path pointing to the JSON file containing the credentials of the service account used to communicate with Google Cloud Storage, for metric retrieval.
 * `METRIC_BUCKET` - the name of the Google Cloud Storage bucket where the metrics reside.
-* `IS_DEMO` (OPTIONAL) - whether or not to run the backend in demo mode, which will retrieve static fixture data from the `server/core/demoData` directory instead of pulling data from dynamic, live sources. This should only be set when running locally and should be provided through the command line, e.g. `IS_DEMO=true yarn dev`.
+* `IS_DEMO` (OPTIONAL) - whether or not to run the backend in demo mode, which will retrieve static fixture data from the `server/core/demoData` directory instead of pulling data from dynamic, live sources. This should only be set when running locally and should be provided through the command line, along with the frontend sibling above. Use the following command: `./run_in_demo_mode.sh`
 
 ### Authentication
 The backend API server and most frontend views in the app are authenticated via [Auth0](https://auth0.com/). You can control which views are authenticated by specifying `Route` versus `PrivateRoute` in `src/App.js`. If you are setting this app up completely fresh, you will need to create your own Auth0 account and set the relevant details in `src/auth_config_dev.json` and `src/auth_config_production.json`. See `src/auth_config.json.example`.
@@ -71,7 +72,7 @@ If you would like to get your TDD on and run Jest in watch mode, you can use:
 ```yarn test:watch```
 
 ### Running the application locally
-A yarn script is available for starting the development servers. The React frontend is served out of port `3000` and the Node/Express badend is served out of port 3001. This will also automatically open a browser to localhost on the appropriate port, pointing to the frontend.
+A yarn script is available for starting the development servers. The React frontend is served out of port `3000` and the Node/Express backend is served out of port 3001. This will also automatically open a browser to localhost on the appropriate port, pointing to the frontend.
 
 ```yarn dev```
 
@@ -83,7 +84,7 @@ The development servers will remain active until you either close your terminal 
 
 When running locally, you can run the app in demo mode to point the app to static data contained in `server/core/demoData`. This is useful for debugging issues that materialize under specific data circumstances, for demonstrating the tool without exposing real data, and other use cases.
 
-You can launch in demo mode locally by setting the `IS_DEMO` environment variable to true, e.g. `IS_DEMO=true yarn dev`.
+You can launch in demo mode locally via: `./run_in_demo_mode.sh`
 
 ## Deploys
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For the frontend: copy the `.env.frontend.example` file and set variables accord
 Expected frontend environment variables include:
 * `REACT_APP_API_URL` - the base URL of the backend API server.
 * `REACT_APP_AUTH_ENV` - a string indicating the "auth environment" used to point to the correct Auth0 tenant. Either "development" or "production". Must match the backend `AUTH_ENV` variable.
-* `REACT_APP_IS_DEMO (OPTIONAL)` - whether or not to run the backend in demo mode, which will retrieve static fixture data from the `server/core/demoData` directory instead of pulling data from dynamic, live sources. This should only be set when running locally and should be provided through the command line, along with the backend sibling below. Use the following command: `./run_in_demo_mode.sh`
+* `REACT_APP_IS_DEMO (OPTIONAL)` - whether or not to run the frontend in demo mode, which will run the app without requiring authentication. This should only be set when running locally and should be provided through the command line, along with the backend sibling below. To run the app in demo mode, use the following command: `./run_in_demo_mode.sh`
 
 The build process, as described below, ensures that the proper values are compiled and included in the static bundle at build time, for the right environment.
 
@@ -45,7 +45,7 @@ Expected backend environment variables include:
 * `AUTH_ENV` - a string indicating the "auth environment" used to point to the correct Auth0 tenant. Either "development" or "production". Must match the frontend `REACT_APP_AUTH_ENV` variable.
 * `GOOGLE_APPLICATION_CREDENTIALS` - a relative path pointing to the JSON file containing the credentials of the service account used to communicate with Google Cloud Storage, for metric retrieval.
 * `METRIC_BUCKET` - the name of the Google Cloud Storage bucket where the metrics reside.
-* `IS_DEMO` (OPTIONAL) - whether or not to run the backend in demo mode, which will retrieve static fixture data from the `server/core/demoData` directory instead of pulling data from dynamic, live sources. This should only be set when running locally and should be provided through the command line, along with the frontend sibling above. Use the following command: `./run_in_demo_mode.sh`
+* `IS_DEMO` (OPTIONAL) - whether or not to run the backend in demo mode, which will retrieve static fixture data from the `server/core/demoData` directory instead of pulling data from dynamic, live sources. This should only be set when running locally and should be provided through the command line, along with the frontend sibling above. To run the app in demo mode, use the following command: `./run_in_demo_mode.sh`
 
 ### Authentication
 The backend API server and most frontend views in the app are authenticated via [Auth0](https://auth0.com/). You can control which views are authenticated by specifying `Route` versus `PrivateRoute` in `src/App.js`. If you are setting this app up completely fresh, you will need to create your own Auth0 account and set the relevant details in `src/auth_config_dev.json` and `src/auth_config_production.json`. See `src/auth_config.json.example`.
@@ -85,6 +85,8 @@ The development servers will remain active until you either close your terminal 
 When running locally, you can run the app in demo mode to point the app to static data contained in `server/core/demoData`. This is useful for debugging issues that materialize under specific data circumstances, for demonstrating the tool without exposing real data, and other use cases.
 
 You can launch in demo mode locally via: `./run_in_demo_mode.sh`
+
+Running via that command is important because environment variables are required for both the frontend and backend servers. Running with only one or the other in demo mode produces a fairly broken experience.
 
 ## Deploys
 

--- a/run_in_demo_mode.sh
+++ b/run_in_demo_mode.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+IS_DEMO=true REACT_APP_IS_DEMO=true yarn dev

--- a/server.js
+++ b/server.js
@@ -34,6 +34,8 @@ app.use(cors());
 const port = process.env.PORT || 3001;
 app.set('port', port);
 
+const isDemoMode = (process.env.IS_DEMO === 'true');
+
 const authEnv = process.env.AUTH_ENV;
 let authConfig = null;
 if (authEnv === 'production') {
@@ -56,7 +58,7 @@ if (app.get('env') === 'production') {
   app.set('trust proxy', true);
 }
 
-const checkJwt = jwt({
+let checkJwt = jwt({
   secret: jwksRsa.expressJwtSecret({
     cache: true,
     rateLimit: true,
@@ -68,6 +70,10 @@ const checkJwt = jwt({
   issuer: `https://${authConfig.domain}/`,
   algorithm: ['RS256'],
 });
+
+if (isDemoMode) {
+  checkJwt = function (req, res, next) { next(); };
+}
 
 app.get('/api/programEval', checkJwt, api.programEval);
 app.get('/api/reincarcerations', checkJwt, api.reincarcerations);

--- a/server/core/metricsRefresh.js
+++ b/server/core/metricsRefresh.js
@@ -26,15 +26,17 @@
  */
 
 const metricsApi = require('./metricsApi');
+const demoMode = require('../utils/demoMode');
 
-const IS_DEMO = (process.env.IS_DEMO === 'true');
+const isDemoMode = demoMode.isDemoMode();
+
 const METRIC_REFRESH_INTERVAL_MS = 1000 * 60 * 30; // Refresh metrics every 30 minutes
 
 /**
  * Performs a refresh of the program evaluation metrics cache, logging success or failure.
  */
 function refreshProgramEvalMetrics() {
-  metricsApi.fetchProgramEvalMetrics(IS_DEMO, (err, data) => {
+  metricsApi.fetchProgramEvalMetrics(isDemoMode, (err, data) => {
     if (err) {
       console.log(`Encountered error during scheduled fetch-and-cache
         of program evaluation metrics: ${err}`);
@@ -48,7 +50,7 @@ function refreshProgramEvalMetrics() {
  * Performs a refresh of the reincarceration metrics cache, logging success or failure.
  */
 function refreshReincarcerationMetrics() {
-  metricsApi.fetchReincarcerationMetrics(IS_DEMO, (err, data) => {
+  metricsApi.fetchReincarcerationMetrics(isDemoMode, (err, data) => {
     if (err) {
       console.log(`Encountered error during scheduled fetch-and-cache
         of reincarceration metrics: ${err}`);
@@ -62,7 +64,7 @@ function refreshReincarcerationMetrics() {
  * Performs a refresh of the revocation metrics cache, logging success or failure.
  */
 function refreshRevocationMetrics() {
-  metricsApi.fetchRevocationMetrics(IS_DEMO, (err, data) => {
+  metricsApi.fetchRevocationMetrics(isDemoMode, (err, data) => {
     if (err) {
       console.log(`Encountered error during scheduled fetch-and-cache
         of revocation metrics: ${err}`);
@@ -76,7 +78,7 @@ function refreshRevocationMetrics() {
  * Performs a refresh of the snapshot metrics cache, logging success or failure.
  */
 function refreshSnapshotMetrics() {
-  metricsApi.fetchSnapshotMetrics(IS_DEMO, (err, data) => {
+  metricsApi.fetchSnapshotMetrics(isDemoMode, (err, data) => {
     if (err) {
       console.log(`Encountered error during scheduled fetch-and-cache of snapshot metrics: ${err}`);
     } else {
@@ -94,7 +96,7 @@ function executeAndSetInterval(fn, intervalMS) {
   setInterval(fn, intervalMS);
 }
 
-if (!IS_DEMO) {
+if (!isDemoMode) {
   executeAndSetInterval(refreshProgramEvalMetrics, METRIC_REFRESH_INTERVAL_MS);
   executeAndSetInterval(refreshReincarcerationMetrics, METRIC_REFRESH_INTERVAL_MS);
   executeAndSetInterval(refreshRevocationMetrics, METRIC_REFRESH_INTERVAL_MS);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -21,8 +21,9 @@
  */
 
 const metricsApi = require('../core/metricsApi');
+const demoMode = require('../utils/demoMode');
 
-const IS_DEMO = (process.env.IS_DEMO === 'true');
+const isDemoMode = demoMode.isDemoMode();
 
 /**
  * A callback which returns either either an error payload or a data payload.
@@ -38,19 +39,19 @@ function responder(res) {
 }
 
 function programEval(req, res) {
-  metricsApi.fetchProgramEvalMetrics(IS_DEMO, responder(res));
+  metricsApi.fetchProgramEvalMetrics(isDemoMode, responder(res));
 }
 
 function reincarcerations(req, res) {
-  metricsApi.fetchReincarcerationMetrics(IS_DEMO, responder(res));
+  metricsApi.fetchReincarcerationMetrics(isDemoMode, responder(res));
 }
 
 function revocations(req, res) {
-  metricsApi.fetchRevocationMetrics(IS_DEMO, responder(res));
+  metricsApi.fetchRevocationMetrics(isDemoMode, responder(res));
 }
 
 function snapshots(req, res) {
-  metricsApi.fetchSnapshotMetrics(IS_DEMO, responder(res));
+  metricsApi.fetchSnapshotMetrics(isDemoMode, responder(res));
 }
 
 module.exports = {

--- a/server/utils/demoMode.js
+++ b/server/utils/demoMode.js
@@ -1,0 +1,28 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+/**
+ * Utilities for running the backend in demo mode.
+ */
+
+function isDemoMode() {
+  return process.env.IS_DEMO === 'true';
+}
+
+module.exports = {
+  isDemoMode,
+};

--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ import Loading from './components/Loading';
 import SideBar from './components/SideBar';
 import TopBar from './components/TopBar';
 import Footer from './components/Footer';
+import { canShowAuthenticatedView } from './utils/viewAuthentication';
 import Home from './views/Home';
 import NotFound from './views/NotFound';
 import Profile from './views/Profile';
@@ -83,7 +84,7 @@ const App = () => {
   }
 
   let containerClass = 'wide-page-container';
-  if (isAuthenticated) {
+  if (canShowAuthenticatedView(isAuthenticated)) {
     containerClass = 'page-container';
   }
 
@@ -95,14 +96,14 @@ const App = () => {
           <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
           <title>North Dakota</title>
           <div>
-            {isAuthenticated && (
+            {canShowAuthenticatedView(isAuthenticated) && (
             <SideBar />
             )}
             <div className={containerClass}>
               <TopBar pathname={window.location.pathname} />
               <Switch>
                 <Route exact path="/">
-                  {isAuthenticated ? <Redirect to="/snapshots" /> : <Home />}
+                  {canShowAuthenticatedView(isAuthenticated) ? <Redirect to="/snapshots" /> : <Home />}
                 </Route>
                 <PrivateRoute path="/snapshots" component={Snapshots} />
                 <PrivateRoute path="/revocations" component={Revocations} />

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -36,12 +36,14 @@ import {
 } from 'reactstrap';
 
 import { useAuth0 } from '../react-auth0-spa';
+import { canShowAuthenticatedView } from '../utils/viewAuthentication';
 
 const NavBar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const {
     user, isAuthenticated, loginWithRedirect, logout,
   } = useAuth0();
+
   const toggle = () => setIsOpen(!isOpen);
 
   const logoutWithRedirect = () => logout({ returnTo: window.location.origin });
@@ -84,7 +86,7 @@ const NavBar = () => {
                   Reincarcerations
                 </NavLink>
               </NavItem>
-              {isAuthenticated && (
+              {canShowAuthenticatedView(isAuthenticated) && (
                 <NavItem>
                   <NavLink
                     tag={RouterNavLink}
@@ -98,7 +100,7 @@ const NavBar = () => {
               )}
             </Nav>
             <Nav className="d-none d-md-block" navbar>
-              {!isAuthenticated && (
+              {!canShowAuthenticatedView(isAuthenticated) && (
                 <NavItem>
                   <Button
                     id="qsLoginBtn"
@@ -110,7 +112,7 @@ const NavBar = () => {
                   </Button>
                 </NavItem>
               )}
-              {isAuthenticated && (
+              {canShowAuthenticatedView(isAuthenticated) && (
                 <UncontrolledDropdown nav inNavbar>
                   <DropdownToggle nav caret id="profileDropDown">
                     <img
@@ -142,7 +144,7 @@ const NavBar = () => {
                 </UncontrolledDropdown>
               )}
             </Nav>
-            {!isAuthenticated && (
+            {!canShowAuthenticatedView(isAuthenticated) && (
               <Nav className="d-md-none" navbar>
                 <NavItem>
                   <Button
@@ -156,7 +158,7 @@ const NavBar = () => {
                 </NavItem>
               </Nav>
             )}
-            {isAuthenticated && (
+            {canShowAuthenticatedView(isAuthenticated) && (
               <Nav
                 className="d-md-none justify-content-between"
                 navbar

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -18,14 +18,16 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
+
 import { useAuth0 } from '../react-auth0-spa';
+import { canShowAuthenticatedView, isDemoMode } from '../utils/viewAuthentication';
 
 const PrivateRoute = ({ component: Component, path, ...rest }) => {
   const { isAuthenticated, loginWithRedirect } = useAuth0();
 
   useEffect(() => {
     const fn = async () => {
-      if (!isAuthenticated) {
+      if (!canShowAuthenticatedView(isAuthenticated)) {
         await loginWithRedirect({
           appState: { targetUrl: path },
         });
@@ -34,9 +36,10 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     fn();
   }, [isAuthenticated, loginWithRedirect, path]);
 
-  if (!isAuthenticated) return null;
+  if (!canShowAuthenticatedView(isAuthenticated)) return null;
 
-  const render = (props) => (isAuthenticated === true ? <Component {...props} /> : null);
+  const render = (props) => (isAuthenticated === true || isDemoMode() === true
+    ? <Component {...props} /> : null);
   return <Route path={path} render={render} {...rest} />;
 };
 

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -19,6 +19,7 @@ import React, { useState } from 'react';
 
 import { useAuth0 } from '../react-auth0-spa';
 import { capitalizeWords, replaceAll } from '../assets/scripts/utils/strings';
+import { canShowAuthenticatedView, isDemoMode, getDemoUser } from '../utils/viewAuthentication';
 
 const TopBar = (props) => {
   const noDash = replaceAll(props.pathname, '-', ' ');
@@ -32,20 +33,26 @@ const TopBar = (props) => {
   const {
     user, isAuthenticated, loginWithRedirect, logout,
   } = useAuth0();
+
   const toggle = () => setIsOpen(!isOpen);
 
   const logoutWithRedirect = () => logout({ returnTo: window.location.origin });
 
   let navBarClass = 'header navbar';
-  if (!isAuthenticated) {
+  if (!canShowAuthenticatedView(isAuthenticated)) {
     navBarClass = 'header wide-navbar';
+  }
+
+  let displayUser = user;
+  if (isDemoMode()) {
+    displayUser = getDemoUser();
   }
 
   return (
     <div className={navBarClass}>
       <div className="header-container">
         <ul className="nav-left">
-          {isAuthenticated && (
+          {canShowAuthenticatedView(isAuthenticated) && (
           <li>
             <a id="sidebar-toggle" className="sidebar-toggle" href="javascript:void(0);">
               <i className="ti-menu" />
@@ -57,7 +64,7 @@ const TopBar = (props) => {
           </li>
         </ul>
         <ul className="nav-right">
-          {!isAuthenticated && (
+          {!canShowAuthenticatedView(isAuthenticated) && (
             <li className="dropdown">
               <a href="#" onClick={() => loginWithRedirect({ appState: { targetUrl: '/snapshots' } })} className="dropdown-toggle no-after peers fxw-nw ai-c lh-1" data-toggle="dropdown">
                 <div className="peer mR-10">
@@ -69,14 +76,14 @@ const TopBar = (props) => {
               </a>
             </li>
           )}
-          {isAuthenticated && (
+          {canShowAuthenticatedView(isAuthenticated) && (
             <li className="dropdown">
               <a href="#" className="dropdown-toggle no-after peers fxw-nw ai-c lh-1" data-toggle="dropdown">
                 <div className="peer mR-10">
-                  <img className="w-2r bdrs-50p" src={user.picture} alt="" />
+                  <img className="w-2r bdrs-50p" src={displayUser.picture} alt="" />
                 </div>
                 <div className="peer">
-                  <span className="fsz-sm c-grey-900">{user.name}</span>
+                  <span className="fsz-sm c-grey-900">{displayUser.name}</span>
                 </div>
               </a>
               <ul className="dropdown-menu fsz-sm">

--- a/src/utils/metricsClient.js
+++ b/src/utils/metricsClient.js
@@ -1,0 +1,58 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { isDemoMode } from './viewAuthentication';
+
+/**
+ * An asynchronous function that returns a promise which will eventually return the results from
+ * invoking the given API endpoint. Takes in the |endpoint| as a string and the |getTokenSilently|
+ * function, which will be used to authenticate the client against the API, if we are not in demo
+ * mode where authentication is not required.
+ */
+async function callMetricsApi(endpoint, getTokenSilently) {
+  try {
+    let token = '';
+    if (!isDemoMode()) {
+      token = await getTokenSilently();
+    }
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/${endpoint}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const responseData = await response.json();
+    return responseData;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+}
+
+/**
+ * A convenience function returning whether or not the client is still awaiting what it needs to
+ * display results to the user. We are ready if we are no longer loading the view, if we are no
+ * longer awaiting the API, and if we either have an authenticated user or we are in demo mode.
+ */
+function awaitingResults(loading, user, awaitingApi) {
+  return loading || (!user && !isDemoMode()) || awaitingApi;
+}
+
+export {
+  callMetricsApi,
+  awaitingResults,
+};

--- a/src/utils/viewAuthentication.js
+++ b/src/utils/viewAuthentication.js
@@ -1,0 +1,42 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+function isDemoMode() {
+  return process.env.REACT_APP_IS_DEMO === 'true';
+}
+
+function getDemoUser() {
+  return {
+    picture: 'https://ui-avatars.com/api/?name=Demo+Jones&background=0D8ABC&color=fff&rounded=true',
+    name: 'Demo Jones',
+    email: 'notarealemail@recidiviz.org',
+  };
+}
+
+/**
+ * A view that requires authentication can be shown if the user is authenticated
+ * or if we are in demo mode.
+ */
+function canShowAuthenticatedView(isAuthenticated) {
+  return isAuthenticated || isDemoMode();
+}
+
+export {
+  isDemoMode,
+  getDemoUser,
+  canShowAuthenticatedView,
+};

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -21,11 +21,17 @@ import { Container, Row, Col } from 'reactstrap';
 import Highlight from '../components/Highlight';
 import Loading from '../components/Loading';
 import { useAuth0 } from '../react-auth0-spa';
+import { getDemoUser, isDemoMode } from '../utils/viewAuthentication';
 
 const Profile = () => {
   const { loading, user } = useAuth0();
 
-  if (loading || !user) {
+  let displayUser = user;
+  if (isDemoMode()) {
+    displayUser = getDemoUser();
+  }
+
+  if (loading || (!user && !isDemoMode())) {
     return <Loading />;
   }
 
@@ -36,18 +42,18 @@ const Profile = () => {
           <Row className="align-items-center profile-header mb-5 text-center text-md-left">
             <Col md={2}>
               <img
-                src={user.picture}
+                src={displayUser.picture}
                 alt="Profile"
                 className="rounded-circle img-fluid profile-picture mb-3 mb-md-0"
               />
             </Col>
             <Col md>
-              <h2>{user.name}</h2>
-              <p className="lead text-muted">{user.email}</p>
+              <h2>{displayUser.name}</h2>
+              <p className="lead text-muted">{displayUser.email}</p>
             </Col>
           </Row>
           <Row>
-            <Highlight>{JSON.stringify(user, null, 2)}</Highlight>
+            <Highlight>{JSON.stringify(displayUser, null, 2)}</Highlight>
           </Row>
         </Container>
       </div>

--- a/src/views/ProgramEvaluation.js
+++ b/src/views/ProgramEvaluation.js
@@ -15,14 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from 'react';
 
-import Loading from "../components/Loading";
-import "../assets/styles/index.scss";
-import { useAuth0 } from "../react-auth0-spa";
+import Loading from '../components/Loading';
+import '../assets/styles/index.scss';
+import { useAuth0 } from '../react-auth0-spa';
+import { callMetricsApi, awaitingResults } from '../utils/metricsClient';
 
-import RecidivismRateByProgram from "../components/charts/programEvaluation/RecidivismRateByProgram";
-import ProgramCostEffectiveness from "../components/charts/programEvaluation/ProgramCostEffectiveness";
+import RecidivismRateByProgram from '../components/charts/programEvaluation/RecidivismRateByProgram';
+import ProgramCostEffectiveness from '../components/charts/programEvaluation/ProgramCostEffectiveness';
 
 const REPORT_CARD_A = {
   "title": "Program A",
@@ -121,17 +122,18 @@ const REPORT_CARD_F = {
 }
 
 const CARDS = {
-  "report-card-program-a": REPORT_CARD_A,
-  "report-card-program-b": REPORT_CARD_B,
-  "report-card-program-c": REPORT_CARD_C,
-  "report-card-program-d": REPORT_CARD_D,
-  "report-card-program-e": REPORT_CARD_E,
-  "report-card-program-f": REPORT_CARD_F,
+  'report-card-program-a': REPORT_CARD_A,
+  'report-card-program-b': REPORT_CARD_B,
+  'report-card-program-c': REPORT_CARD_C,
+  'report-card-program-d': REPORT_CARD_D,
+  'report-card-program-e': REPORT_CARD_E,
+  'report-card-program-f': REPORT_CARD_F,
 }
 
 const ProgramEvaluation = () => {
   const { loading, user, getTokenSilently } = useAuth0();
   const [apiData, setApiData] = useState({});
+  const [awaitingApi, setAwaitingApi] = useState(true);
 
   const [reportCardTitle, setReportCardTitle] = useState(REPORT_CARD_A.title);
   const [reportCardDescription, setReportCardDescription] = useState(REPORT_CARD_A.description);
@@ -166,15 +168,9 @@ const ProgramEvaluation = () => {
 
   const fetchChartData = async () => {
     try {
-      const token = await getTokenSilently();
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/programEval`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      const responseData = await response.json();
+      const responseData = await callMetricsApi('programEval', getTokenSilently);
       setApiData(responseData);
+      setAwaitingApi(false);
     } catch (error) {
       console.error(error);
     }
@@ -184,7 +180,7 @@ const ProgramEvaluation = () => {
     fetchChartData();
   }, []);
 
-  if (loading || !user) {
+  if (awaitingResults(loading, user, awaitingApi)) {
     return <Loading />;
   }
 

--- a/src/views/Reincarcerations.js
+++ b/src/views/Reincarcerations.js
@@ -20,6 +20,7 @@ import React, { useState, useEffect } from 'react';
 import Loading from '../components/Loading';
 import '../assets/styles/index.scss';
 import { useAuth0 } from '../react-auth0-spa';
+import { callMetricsApi, awaitingResults } from '../utils/metricsClient';
 
 import AdmissionsVsReleases from '../components/charts/reincarcerations/AdmissionsVsReleases';
 import ReincarcerationRateByReleaseFacility from '../components/charts/reincarcerations/ReincarcerationRateByReleaseFacility';
@@ -34,14 +35,7 @@ const Reincarcerations = () => {
 
   const fetchChartData = async () => {
     try {
-      const token = await getTokenSilently();
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/reincarcerations`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      const responseData = await response.json();
+      const responseData = await callMetricsApi('reincarcerations', getTokenSilently);
       setApiData(responseData);
       setAwaitingApi(false);
     } catch (error) {
@@ -53,7 +47,7 @@ const Reincarcerations = () => {
     fetchChartData();
   }, []);
 
-  if (loading || !user || awaitingApi) {
+  if (awaitingResults(loading, user, awaitingApi)) {
     return <Loading />;
   }
 

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -20,6 +20,7 @@ import React, { useState, useEffect } from 'react';
 import Loading from '../components/Loading';
 import '../assets/styles/index.scss';
 import { useAuth0 } from '../react-auth0-spa';
+import { callMetricsApi, awaitingResults } from '../utils/metricsClient';
 
 import RevocationCountOverTime from '../components/charts/revocations/RevocationCountOverTime';
 import RevocationCountBySupervisionType from '../components/charts/revocations/RevocationCountBySupervisionType';
@@ -37,14 +38,7 @@ const Revocations = () => {
 
   const fetchChartData = async () => {
     try {
-      const token = await getTokenSilently();
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/revocations`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      const responseData = await response.json();
+      const responseData = await callMetricsApi('revocations', getTokenSilently);
       setApiData(responseData);
       setAwaitingApi(false);
     } catch (error) {
@@ -56,7 +50,7 @@ const Revocations = () => {
     fetchChartData();
   }, []);
 
-  if (loading || !user || awaitingApi) {
+  if (awaitingResults(loading, user, awaitingApi)) {
     return <Loading />;
   }
 

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -20,12 +20,12 @@ import React, { useState, useEffect } from 'react';
 import Loading from '../components/Loading';
 import '../assets/styles/index.scss';
 import { useAuth0 } from '../react-auth0-spa';
+import { callMetricsApi, awaitingResults } from '../utils/metricsClient';
 
 import SupervisionSuccessSnapshot from '../components/charts/snapshots/SupervisionSuccessSnapshot';
 import RevocationAdmissionsSnapshot from '../components/charts/snapshots/RevocationAdmissionsSnapshot';
 import LsirScoreChangeSnapshot from '../components/charts/snapshots/LsirScoreChangeSnapshot';
 import DaysAtLibertySnapshot from '../components/charts/snapshots/DaysAtLibertySnapshot';
-
 
 const Snapshots = () => {
   const { loading, user, getTokenSilently } = useAuth0();
@@ -34,14 +34,7 @@ const Snapshots = () => {
 
   const fetchChartData = async () => {
     try {
-      const token = await getTokenSilently();
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/snapshots`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      const responseData = await response.json();
+      const responseData = await callMetricsApi('snapshots', getTokenSilently);
       setApiData(responseData);
       setAwaitingApi(false);
     } catch (error) {
@@ -53,7 +46,7 @@ const Snapshots = () => {
     fetchChartData();
   }, []);
 
-  if (loading || !user || awaitingApi) {
+  if (awaitingResults(loading, user, awaitingApi)) {
     return <Loading />;
   }
 


### PR DESCRIPTION
Now, demo mode runs without requiring authentication. This is triggered by environment variables on both the frontend and backend which should both be enabled or both be disabled -- thus, I've added a `./run_in_demo_mode.sh` script which runs the app locally with both variables set.

Test that the app still works as expected in terms of authentication when the variables are _not_ set.