### PR TITLE
Revocations by P&P Office tooltip on hover

### DIFF
--- a/server/core/demo_data/ftr_referrals_by_age_60_days.json
+++ b/server/core/demo_data/ftr_referrals_by_age_60_days.json
@@ -1,5 +1,5 @@
-{"state_code":"US_DEMO","age":"<25","count":"4"}
-{"state_code":"US_DEMO","age":"25-29","count":"13"}
-{"state_code":"US_DEMO","age":"30-34","count":"33"}
-{"state_code":"US_DEMO","age":"35-39","count":"22"}
-{"state_code":"US_DEMO","age":"40<","count":"9"}
+{"state_code":"US_DEMO","age_bucket":"0-24","count":"4"}
+{"state_code":"US_DEMO","age_bucket":"25-29","count":"13"}
+{"state_code":"US_DEMO","age_bucket":"30-34","count":"33"}
+{"state_code":"US_DEMO","age_bucket":"35-39","count":"22"}
+{"state_code":"US_DEMO","age_bucket":"40+","count":"9"}

--- a/server/core/demo_data/supervision_population_by_age_60_days.json
+++ b/server/core/demo_data/supervision_population_by_age_60_days.json
@@ -1,5 +1,5 @@
-{"state_code":"US_DEMO","age":"<25","count":"55"}
-{"state_code":"US_DEMO","age":"25-29","count":"24"}
-{"state_code":"US_DEMO","age":"30-34","count":"70"}
-{"state_code":"US_DEMO","age":"35-39","count":"80"}
-{"state_code":"US_DEMO","age":"40<","count":"33"}
+{"state_code":"US_DEMO","age_bucket":"0-24","count":"55"}
+{"state_code":"US_DEMO","age_bucket":"25-29","count":"24"}
+{"state_code":"US_DEMO","age_bucket":"30-34","count":"70"}
+{"state_code":"US_DEMO","age_bucket":"35-39","count":"80"}
+{"state_code":"US_DEMO","age_bucket":"40+","count":"33"}

--- a/src/components/charts/revocations/RevocationsByCounty.js
+++ b/src/components/charts/revocations/RevocationsByCounty.js
@@ -130,9 +130,9 @@ class RevocationsByCounty extends Component {
         >
           <ZoomableGroup center={[centerNDLong, centerNDLat]} zoom={7} disablePanning>
             <Geographies geography={geographyObject}>
-              {(geographies, projection) => geographies.map((geography, i) => (
+              {(geographies, projection) => geographies.map((geography) => (
                 <Geography
-                  key={i}
+                  key={geography.properties.NAME}
                   data-tip={geography.properties.NAME
                     + ': '.concat(revocationCountForCounty(this.chartDataPoints, geography.properties.NAME))}
                   geography={geography}

--- a/src/components/charts/revocations/RevocationsByOffice.js
+++ b/src/components/charts/revocations/RevocationsByOffice.js
@@ -24,6 +24,7 @@ import {
   Markers,
   Marker,
 } from 'react-simple-maps';
+import ReactTooltip from 'react-tooltip';
 import { geoAlbersUsa } from 'd3-geo';
 import { scaleLinear } from 'd3-scale';
 import geographyObject from '../../../assets/static/maps/us_nd.json';
@@ -42,8 +43,8 @@ const centerNDLat = 47.3;
  * will have a marker with the radius size of `maxMarkerRadius`.
  */
 function radiusOfMarker(office, maxValue) {
-  const minMarkerRadius = 3;
-  const maxMarkerRadius = 25;
+  const minMarkerRadius = 10;
+  const maxMarkerRadius = 35;
   const officeScale = scaleLinear()
     .domain([0, maxValue])
     .range([minMarkerRadius, maxMarkerRadius]);
@@ -51,50 +52,9 @@ function radiusOfMarker(office, maxValue) {
   return officeScale(office.revocationCount);
 }
 
-/**
- * Returns how far the title should be offset (in pixels) along the x-axis from
- * the center of the marker circle, given the location of the title, the
- * length of the office name, and the number of revocations.
- */
-function xOffsetForOfficeTitle(office, markerRadius) {
-  const offsetPerRevocationDigit = 10;
-  const offsetForParenthesis = 15;
-  const offsetForNameLetter = 8;
-  const digitsInRevocations = office.revocationCount.toString().length;
-  const revLabelOffset = offsetPerRevocationDigit * digitsInRevocations + offsetForParenthesis;
-  if (office.titleSide === 'left') {
-    return (-1 * markerRadius)
-      - (office.officeName.length * offsetForNameLetter) - revLabelOffset;
-  }
-
-  if (office.titleSide === 'right') {
-    return markerRadius
-     + (office.officeName.length * offsetForNameLetter) + revLabelOffset;
-  }
-
-  return 0;
-}
-
-/**
- * Returns how far the title should be offset (in pixels) along the y-axis from
- * the center of the marker circle given the location of the title.
- */
-function yOffsetForOfficeTitle(office, markerRadius) {
-  const offsetForBottomLabels = 25;
-  const offsetForAllLables = 10;
-  if (office.titleSide === 'bottom') {
-    return markerRadius + offsetForBottomLabels;
-  }
-
-  if (office.titleSide === 'top') {
-    return -1 * markerRadius - offsetForAllLables;
-  }
-
-  return offsetForAllLables;
-}
-
 function colorForMarker(office) {
-  return (office.revocationCount > 0) ? COLORS['red-standard'] : COLORS['grey-600'];
+  return COLORS['red-standard'];
+  // return (office.revocationCount > 0) ? COLORS['red-standard'] : COLORS['grey-600'];
 }
 
 const officeClicked = (office) => {
@@ -207,6 +167,10 @@ class RevocationsByOffice extends Component {
     configureDownloadButtons(chartId, downloadableDataFormat,
       officeNames,
       document.getElementById(chartId), exportedStructureCallback);
+
+    setTimeout(() => {
+      ReactTooltip.rebuild();
+    }, 100);
   }
 
   render() {
@@ -224,9 +188,9 @@ class RevocationsByOffice extends Component {
         >
           <ZoomableGroup center={[centerNDLong, centerNDLat]} zoom={8.2} disablePanning>
             <Geographies geography={geographyObject}>
-              {(geographies, projection) => geographies.map((geography, i) => (
+              {(geographies, projection) => geographies.map((geography) => (
                 <Geography
-                  key={i}
+                  key={geography.properties.NAME}
                   geography={geography}
                   projection={projection}
                   style={{
@@ -254,10 +218,10 @@ class RevocationsByOffice extends Component {
               }
             </Geographies>
             <Markers>
-              {this.chartDataPoints.map((office, i) => (
+              {this.chartDataPoints.map((office) => (
                 <Marker
                   onClick={officeClicked}
-                  key={i}
+                  key={office.officeName}
                   marker={office}
                   style={{
                     default: { fill: colorForMarker(office) },
@@ -266,28 +230,17 @@ class RevocationsByOffice extends Component {
                   }}
                 >
                   <circle
+                    data-tip={office.officeName.concat(': ', office.revocationCount)}
                     cx={0}
                     cy={0}
                     r={radiusOfMarker(office, this.maxValue)}
                   />
-                  <text
-                    textAnchor="middle"
-                    x={xOffsetForOfficeTitle(office, radiusOfMarker(office, this.maxValue))}
-                    y={yOffsetForOfficeTitle(office, radiusOfMarker(office, this.maxValue))}
-                    style={{
-                      fontFamily: 'Roboto, sans-serif',
-                      fontSize: '175%',
-                      fontWeight: '900',
-                      fill: '#607D8B',
-                    }}
-                  >
-                    {office.officeName.concat(' (', office.revocationCount, ')')}
-                  </text>
                 </Marker>
               ))}
             </Markers>
           </ZoomableGroup>
         </ComposableMap>
+        <ReactTooltip />
       </div>
     );
   }

--- a/src/components/charts/revocations/RevocationsByOffice.js
+++ b/src/components/charts/revocations/RevocationsByOffice.js
@@ -53,8 +53,7 @@ function radiusOfMarker(office, maxValue) {
 }
 
 function colorForMarker(office) {
-  return COLORS['red-standard'];
-  // return (office.revocationCount > 0) ? COLORS['red-standard'] : COLORS['grey-600'];
+  return (office.revocationCount > 0) ? COLORS['red-standard'] : COLORS['grey-400'];
 }
 
 const officeClicked = (office) => {


### PR DESCRIPTION
Closes #106

Removes the labels from the Revocations by P&P Office chart and changes the info to be in a tooltip on hover. Also includes some updates to the demo data for the FTR age chart that was broken locally.