### PR TITLE
Fixes the erroneous listed period for revocation rate by county.

### DIFF
--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -186,7 +186,7 @@ const Revocations = () => {
                     <div className="peer fw-600">
                       <span className="fsz-def fw-600 mR-10 c-grey-800">
                         <small className="c-grey-500 fw-600">Period </small>
-                        Last 60 days
+                        Last 365 days
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
## Description of the change

Changed the period that is listed for the new revocation rate by county chart. It's 365 days, not 60. In time, this will be dynamically provided in the metric package, but for now it's static.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
