### PR TITLE
Handful of small dashboard changes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,6 @@ import SideBar from './components/SideBar';
 import TopBar from './components/TopBar';
 import Footer from './components/Footer';
 import { canShowAuthenticatedView } from './utils/viewAuthentication';
-import Home from './views/Home';
 import NotFound from './views/NotFound';
 import Profile from './views/Profile';
 import FreeThroughRecovery from './views/FreeThroughRecovery';
@@ -104,7 +103,7 @@ const App = () => {
               <TopBar pathname={window.location.pathname} />
               <Switch>
                 <Route exact path="/">
-                  {canShowAuthenticatedView(isAuthenticated) ? <Redirect to="/snapshots" /> : <Home />}
+                  {<Redirect to="/snapshots" />}
                 </Route>
                 <PrivateRoute path="/snapshots" component={Snapshots} />
                 <PrivateRoute path="/revocations" component={Revocations} />

--- a/src/App.js
+++ b/src/App.js
@@ -94,7 +94,7 @@ const App = () => {
         <div>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-          <title>North Dakota</title>
+          <title>Recidiviz Dashboard</title>
           <div>
             {canShowAuthenticatedView(isAuthenticated) && (
             <SideBar />

--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -18,8 +18,23 @@
 import downloadjs from 'downloadjs';
 import { timeStamp } from './time';
 
-function downloadCanvasImage(canvas, filename) {
-  const data = canvas.toDataURL('image/png;base64');
+function downloadCanvasImage(canvas, filename, chartTitle) {
+  const topPadding = 100;
+  const temporaryCanvas = document.createElement('canvas');
+  temporaryCanvas.width = canvas.width;
+  temporaryCanvas.height = canvas.height + topPadding;
+
+  // Fill the canvas with a white background and the original image
+  const destinationCtx = temporaryCanvas.getContext('2d');
+  destinationCtx.fillStyle = '#FFFFFF';
+  destinationCtx.fillRect(0, 0, canvas.width, canvas.height + topPadding);
+  destinationCtx.fillStyle = '#616161';
+  destinationCtx.textAlign = 'center';
+  destinationCtx.font = '30px Helvetica Neue';
+  destinationCtx.fillText(chartTitle, canvas.width / 2, topPadding / 2);
+  destinationCtx.drawImage(canvas, 0, topPadding);
+
+  const data = temporaryCanvas.toDataURL('image/png;base64');
   downloadjs(data, filename, 'image/png;base64');
 }
 
@@ -30,13 +45,13 @@ function downloadObjectAsJson(exportObj, exportName) {
 }
 
 function configureDownloadButtons(
-  chartId, chartDatasets, chartLabels, chartBox,
+  chartId, chartTitle, chartDatasets, chartLabels, chartBox,
   exportedStructureCallback, convertValuesToNumbers,
 ) {
   const downloadChartAsImageButton = document.getElementById(`downloadChartAsImage-${chartId}`);
   if (downloadChartAsImageButton) {
     downloadChartAsImageButton.onclick = function downloadChartImage() {
-      downloadCanvasImage(chartBox, `${chartId}-${timeStamp()}.png`);
+      downloadCanvasImage(chartBox, `${chartId}-${timeStamp()}.png`, chartTitle);
     };
   }
 

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -53,7 +53,7 @@ const SideBar = () => {
                     </div>
                   </div>
                   <div className="col-md-9 my-auto peer peer-greed">
-                    <h5 className="lh-1 mB-0 logo-text recidiviz-dark-green-text">North Dakota</h5>
+                    <h5 className="lh-1 mB-0 logo-text recidiviz-dark-green-text">Dashboard</h5>
                   </div>
                 </div>
               </a>

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -45,7 +45,7 @@ const SideBar = () => {
         <div className="sidebar-logo" style={{ height: '65px' }}>
           <div className="peers ai-c fxw-nw">
             <div className="peer peer-greed">
-              <a className="sidebar-link td-n" href="https://www.recidiviz.org/">
+              <a className="sidebar-link td-n" href="/">
                 <div className="peers ai-c fxw-nw pT-15">
                   <div className="peer">
                     <div className="col-md-3 my-auto peer">

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -20,6 +20,7 @@ import React, { useState } from 'react';
 import { useAuth0 } from '../react-auth0-spa';
 import { capitalizeWords, normalizeAppPathToTitle, replaceAll } from '../assets/scripts/utils/strings';
 import { canShowAuthenticatedView, isDemoMode, getDemoUser } from '../utils/viewAuthentication';
+import { getStateFromEmail } from '../utils/user';
 
 const TopBar = (props) => {
   let normalizedPath = normalizeAppPathToTitle(props.pathname);
@@ -82,7 +83,8 @@ const TopBar = (props) => {
                   <img className="w-2r bdrs-50p" src={displayUser.picture} alt="" />
                 </div>
                 <div className="peer">
-                  <span className="fsz-sm c-grey-900">{displayUser.name}</span>
+                  <li className="fsz-sm c-grey-900">{displayUser.name}</li>
+                  <li className="fsz-sm pT-3 c-grey-600">{getStateFromEmail(displayUser.email)}</li>
                 </div>
               </a>
               <ul className="dropdown-menu fsz-sm">

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -20,7 +20,7 @@ import React, { useState } from 'react';
 import { useAuth0 } from '../react-auth0-spa';
 import { capitalizeWords, normalizeAppPathToTitle, replaceAll } from '../assets/scripts/utils/strings';
 import { canShowAuthenticatedView, isDemoMode, getDemoUser } from '../utils/viewAuthentication';
-import { getStateFromEmail } from '../utils/user';
+import { getUserStateCode } from '../utils/user';
 
 const TopBar = (props) => {
   let normalizedPath = normalizeAppPathToTitle(props.pathname);
@@ -84,7 +84,7 @@ const TopBar = (props) => {
                 </div>
                 <div className="peer">
                   <li className="fsz-sm c-grey-900">{displayUser.name}</li>
-                  <li className="fsz-sm pT-3 c-grey-600">{getStateFromEmail(displayUser.email)}</li>
+                  <li className="fsz-sm pT-3 c-grey-600">{getUserStateCode(displayUser)}</li>
                 </div>
               </a>
               <ul className="dropdown-menu fsz-sm">

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralCountByMonth.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralCountByMonth.js
@@ -107,9 +107,9 @@ const FtrReferralCountByMonth = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'FTR REFERRAL COUNT BY MONTH',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralCountByMonth.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralCountByMonth.js
@@ -84,6 +84,9 @@ const FtrReferralCountByMonth = (props) => {
             },
           }],
           yAxes: [{
+            ticks: {
+              min: 0,
+            },
             scaleLabel: {
               display: true,
               labelString: 'Referral count',

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByAge.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByAge.js
@@ -194,9 +194,9 @@ const FtrReferralsByAge = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'FTR REFERRALS BY AGE - 60 DAYS',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByGender.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByGender.js
@@ -178,9 +178,9 @@ const FtrReferralsByGender = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'FTR REFERRALS BY GENDER - 60 DAYS',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByLsir.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByLsir.js
@@ -177,9 +177,9 @@ const FtrReferralsByLsir = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'FTR REFERRALS BY LSI-R - 60 DAYS',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByRace.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralsByRace.js
@@ -254,9 +254,9 @@ const FtrReferralsByRace = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'FTR REFERRALS BY RACE - 60 DAYS',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/reincarcerations/AdmissionsVsReleases.js
+++ b/src/components/charts/reincarcerations/AdmissionsVsReleases.js
@@ -109,9 +109,9 @@ const AdmissionsVsReleases = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'ADMISSIONS VERSUS RELEASES',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -162,7 +162,7 @@ const ReincarcerationCountOverTime = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId,
+  configureDownloadButtons(chartId, 'REINCARCERATIONS BY MONTH',
     chart.props.data.datasets, chart.props.data.labels,
     document.getElementById(chartId),
     exportedStructureCallback);

--- a/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByReleaseFacility.js
@@ -124,9 +124,9 @@ const ReincarcerationRateByReleaseFacility = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REINCARCERATION RATE BY RELEASE FACILITY',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/reincarcerations/ReincarcerationRateByStayLength.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByStayLength.js
@@ -122,9 +122,9 @@ const ReincarcerationRateByStayLength = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REINCARCERATION RATE BY PREVIOUS STAY LENGTH',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
+++ b/src/components/charts/reincarcerations/ReincarcerationRateByTransitionalFacility.js
@@ -123,9 +123,9 @@ const ReincarcerationRateByTransitionalFacility = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REINCARCERATION RATE BY TRANSITIONAL FACILITY',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/revocations/AdmissionTypeProportions.js
+++ b/src/components/charts/revocations/AdmissionTypeProportions.js
@@ -125,7 +125,7 @@ const AdmissionTypeProportions = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'ADMISSIONS BY TYPE - 60 DAYS', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/components/charts/revocations/RevocationCountByOfficer.js
+++ b/src/components/charts/revocations/RevocationCountByOfficer.js
@@ -118,9 +118,12 @@ const RevocationCountByOfficer = (props) => {
       downloadableDataFormat = [];
     }
 
+    const officeReadable = toHumanReadable(visibleOffice).toUpperCase();
+    const chartTitle = `REVOCATIONS BY OFFICER - ${officeReadable} - 60 DAYS`;
+
     const convertValuesToNumbers = false;
-    configureDownloadButtons(chartId, downloadableDataFormat,
-      officerIds, document.getElementById(chartId),
+    configureDownloadButtons(chartId, chartTitle,
+      downloadableDataFormat, officerIds, document.getElementById(chartId),
       exportedStructureCallback, convertValuesToNumbers);
   }
 

--- a/src/components/charts/revocations/RevocationCountBySupervisionType.js
+++ b/src/components/charts/revocations/RevocationCountBySupervisionType.js
@@ -117,9 +117,9 @@ const RevocationCountBySupervisionType = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REVOCATIONS BY SUPERVISION TYPE',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/revocations/RevocationCountByViolationType.js
+++ b/src/components/charts/revocations/RevocationCountByViolationType.js
@@ -159,9 +159,9 @@ const RevocationCountByViolationType = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REVOCATIONS BY VIOLATION TYPE',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -163,9 +163,9 @@ const RevocationCountOverTime = (props) => {
       series: [],
     });
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById(chartId),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REVOCATIONS BY MONTH',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById(chartId), exportedStructureCallback);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/revocations/RevocationProportionByRace.js
+++ b/src/components/charts/revocations/RevocationProportionByRace.js
@@ -31,6 +31,8 @@ const RevocationProportionByRace = (props) => {
   const [revocationCounts, setRevocationCounts] = useState([]);
   const [stateSupervisionCounts, setStateSupervisionCounts] = useState([]);
 
+  const chartId = 'revocationsByRace';
+
   const processResponse = () => {
     const {
       revocationProportionByRace,
@@ -117,7 +119,7 @@ const RevocationProportionByRace = (props) => {
 
   const chart = (
     <HorizontalBar
-      id="revocationsByRace"
+      id={chartId}
       data={{
         labels: ['Revocations', 'Supervision Population', 'ND Population'],
         datasets: [{
@@ -238,9 +240,9 @@ const RevocationProportionByRace = (props) => {
       series: [],
     });
 
-  configureDownloadButtons('revocationsByRace', chart.props.data.datasets,
-    chart.props.data.labels, document.getElementById('revocationsByRace'),
-    exportedStructureCallback);
+  configureDownloadButtons(chartId, 'REVOCATIONS BY RACE - 60 DAYS',
+    chart.props.data.datasets, chart.props.data.labels,
+    document.getElementById('revocationsByRace'), exportedStructureCallback);
 
   return chart;
 };

--- a/src/components/charts/revocations/RevocationRateByCounty.js
+++ b/src/components/charts/revocations/RevocationRateByCounty.js
@@ -99,7 +99,9 @@ class RevocationsByCounty extends Component {
       label: chartId,
     }];
 
-    configureDownloadButtons(chartId, downloadableDataFormat,
+    configureDownloadButtons(chartId,
+      'REVOCATION RATE BY COUNTY OF RESIDENCE - 60 DAYS',
+      downloadableDataFormat,
       Object.keys(this.chartDataPoints),
       document.getElementById(chartId), exportedStructureCallback);
 

--- a/src/components/charts/revocations/RevocationsByCounty.js
+++ b/src/components/charts/revocations/RevocationsByCounty.js
@@ -85,7 +85,8 @@ class RevocationsByCounty extends Component {
       label: 'revocationsByCounty',
     }];
 
-    configureDownloadButtons(chartId, downloadableDataFormat,
+    configureDownloadButtons(chartId, 'REVOCATIONS BY COUNTY - 60 DAYS',
+      downloadableDataFormat,
       Object.keys(this.chartDataPoints),
       document.getElementById(chartId), exportedStructureCallback);
 

--- a/src/components/charts/revocations/RevocationsByOffice.js
+++ b/src/components/charts/revocations/RevocationsByOffice.js
@@ -163,8 +163,8 @@ class RevocationsByOffice extends Component {
       label: chartId,
     }];
 
-    configureDownloadButtons(chartId, downloadableDataFormat,
-      officeNames,
+    configureDownloadButtons(chartId, 'REVOCATIONS BY P&P OFFICE - 60 DAYS',
+      downloadableDataFormat, officeNames,
       document.getElementById(chartId), exportedStructureCallback);
 
     setTimeout(() => {

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -196,7 +196,7 @@ const DaysAtLibertySnapshot = (props) => {
       series: [],
     };
   };
-  configureDownloadButtons(chartId, chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'AVERAGE DAYS AT LIBERTY', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -196,7 +196,7 @@ const DaysAtLibertySnapshot = (props) => {
       series: [],
     };
   };
-  configureDownloadButtons(chartId, 'AVERAGE DAYS AT LIBERTY', chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'DAYS AT LIBERTY (AVERAGE)', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -198,7 +198,7 @@ const LsirScoreChangeSnapshot = (props) => {
       series: [],
     };
   };
-  configureDownloadButtons(chartId, 'AVERAGE CHANGE IN LSI-R SCORES', chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'LSI-R SCORE CHANGES (AVERAGE)', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -198,7 +198,7 @@ const LsirScoreChangeSnapshot = (props) => {
       series: [],
     };
   };
-  configureDownloadButtons(chartId, chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'AVERAGE CHANGE IN LSI-R SCORES', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -204,7 +204,7 @@ const RevocationAdmissionsSnapshot = (props) => {
       series: [],
     };
   };
-  configureDownloadButtons(chartId, chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'PRISON ADMISSIONS DUE TO REVOCATION', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -211,7 +211,7 @@ const SupervisionSuccessSnapshot = (props) => {
     };
   };
 
-  configureDownloadButtons(chartId, chart.props.data.datasets,
+  configureDownloadButtons(chartId, 'SUCCESSFUL COMPLETION OF SUPERVISION', chart.props.data.datasets,
     chart.props.data.labels, document.getElementById(chartId),
     exportedStructureCallback);
 

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -1,0 +1,32 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+function getStateFromEmail(email) {
+  if (email.includes('recidiviz.org')) {
+    return 'Recidiviz';
+  }
+
+  if (email.includes('nd.gov')) {
+    return 'North Dakota';
+  }
+
+  return '';
+}
+
+export {
+  getStateFromEmail,
+};

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -15,18 +15,17 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-function getStateFromEmail(email) {
-  if (email.includes('recidiviz.org')) {
-    return 'Recidiviz';
-  }
+const STATE_CODE_BY_DOMAIN = {
+  'recidiviz.org': 'Recidiviz',
+  'nd.gov': 'North Dakota',
+};
 
-  if (email.includes('nd.gov')) {
-    return 'North Dakota';
-  }
-
-  return '';
+function getUserStateCode(user) {
+  const emailSplit = user.email.split('@');
+  const domain = emailSplit[emailSplit.length - 1].toLowerCase();
+  return STATE_CODE_BY_DOMAIN[domain];
 }
 
 export {
-  getStateFromEmail,
+  getUserStateCode,
 };

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -22,6 +22,7 @@ import Highlight from '../components/Highlight';
 import Loading from '../components/Loading';
 import { useAuth0 } from '../react-auth0-spa';
 import { getDemoUser, isDemoMode } from '../utils/viewAuthentication';
+import { getStateFromEmail } from '../utils/user';
 
 const Profile = () => {
   const { loading, user } = useAuth0();
@@ -50,10 +51,8 @@ const Profile = () => {
             <Col md>
               <h2>{displayUser.name}</h2>
               <p className="lead text-muted">{displayUser.email}</p>
+              <p className="lead text-muted">{getStateFromEmail(displayUser.email)}</p>
             </Col>
-          </Row>
-          <Row>
-            <Highlight>{JSON.stringify(displayUser, null, 2)}</Highlight>
           </Row>
         </Container>
       </div>

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -22,7 +22,7 @@ import Highlight from '../components/Highlight';
 import Loading from '../components/Loading';
 import { useAuth0 } from '../react-auth0-spa';
 import { getDemoUser, isDemoMode } from '../utils/viewAuthentication';
-import { getStateFromEmail } from '../utils/user';
+import { getUserStateCode } from '../utils/user';
 
 const Profile = () => {
   const { loading, user } = useAuth0();
@@ -51,7 +51,7 @@ const Profile = () => {
             <Col md>
               <h2>{displayUser.name}</h2>
               <p className="lead text-muted">{displayUser.email}</p>
-              <p className="lead text-muted">{getStateFromEmail(displayUser.email)}</p>
+              <p className="lead text-muted">{getUserStateCode(displayUser)}</p>
             </Col>
           </Row>
         </Container>

--- a/src/views/Snapshots.js
+++ b/src/views/Snapshots.js
@@ -183,7 +183,7 @@ const Snapshots = () => {
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
                   <h6 className="lh-1">
-                    AVERAGE DAYS AT LIBERTY
+                    DAYS AT LIBERTY (AVERAGE)
                     <span className="fa-pull-right">
                       <div className="dropdown show">
                         <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-daysAtLibertySnapshot" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -245,7 +245,7 @@ const Snapshots = () => {
               <div className="layers">
                 <div className="layer w-100 pX-20 pT-20">
                   <h6 className="lh-1">
-                    AVERAGE CHANGE IN LSI-R SCORES
+                    LSI-R SCORE CHANGES (AVERAGE)
                     <span className="fa-pull-right">
                       <div className="dropdown show">
                         <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-lsirScoreChangeSnapshot" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Description of the change

- Redirects all un-authenticated traffic to login (effectively eliminates the home page)
- Removes the state name from the left sidebar and moves it under the user's name (dynamically finds state from the email domain)
- Cleans up the profile page
- Sidebar logo and title direct to app homepage instead of to recidiviz.org
- FTR referral count chart min set to 0
- Image downloads now have white background (no longer transparent PNGs) and have the chart title above the chart
- Chart title updates on the snapshot page per Andrew's suggestion

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)

## Related issues

Closes https://github.com/Recidiviz/pulse-dashboard/issues/86
Closes https://github.com/Recidiviz/pulse-dashboard/issues/91
Does work towards https://github.com/Recidiviz/pulse-dashboard/issues/93

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Lint rules pass locally
- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
