### PR TITLE
Changes data export to be CSV

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "highlight.js": "^9.15.6",
     "http-errors": "~1.6.2",
     "jquery": "^3.2.1",
+    "jsonexport": "^2.4.1",
     "jwks-rsa": "^1.4.0",
     "lodash": "^4.17.4",
     "lokijs": "^1.5.6",

--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import downloadjs from 'downloadjs';
-import * as jsonexport from 'jsonexport/dist';
+import * as csvExport from 'jsonexport/dist';
 import { timeStamp } from './time';
 
 function downloadCanvasImage(canvas, filename, chartTitle) {
@@ -40,14 +40,11 @@ function downloadCanvasImage(canvas, filename, chartTitle) {
 }
 
 function downloadObjectAsCsv(exportObj, exportName) {
-  const jsonString = JSON.stringify(exportObj.series);
-  const jsonObj = [JSON.parse(jsonString)];
-
   const options = {
     mapHeaders: (header) => header.replace(/label|values./, ''),
   };
 
-  jsonexport(jsonObj, options, (err, csv) => {
+  csvExport(exportObj.series, options, (err, csv) => {
     if (err) throw err;
     const dataStr = `data:text/csv;charset=utf-8,${csv}`;
     const filename = `${exportName}.csv`;

--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import downloadjs from 'downloadjs';
+import * as jsonexport from 'jsonexport/dist';
 import { timeStamp } from './time';
 
 function downloadCanvasImage(canvas, filename, chartTitle) {
@@ -36,6 +37,22 @@ function downloadCanvasImage(canvas, filename, chartTitle) {
 
   const data = temporaryCanvas.toDataURL('image/png;base64');
   downloadjs(data, filename, 'image/png;base64');
+}
+
+function downloadObjectAsCsv(exportObj, exportName) {
+  const jsonString = JSON.stringify(exportObj.series);
+  const jsonObj = [JSON.parse(jsonString)];
+
+  const options = {
+    mapHeaders: (header) => header.replace(/label|values./, ''),
+  };
+
+  jsonexport(jsonObj, options, (err, csv) => {
+    if (err) throw err;
+    const dataStr = `data:text/csv;charset=utf-8,${csv}`;
+    const filename = `${exportName}.csv`;
+    downloadjs(dataStr, filename, 'text/plain');
+  });
 }
 
 function downloadObjectAsJson(exportObj, exportName) {
@@ -81,13 +98,14 @@ function configureDownloadButtons(
       });
 
       const filename = `${chartId}-${timeStamp()}`;
-      downloadObjectAsJson(exportData, filename);
+      downloadObjectAsCsv(exportData, filename);
     };
   }
 }
 
 export {
   downloadCanvasImage,
+  downloadObjectAsCsv,
   downloadObjectAsJson,
   configureDownloadButtons,
 };

--- a/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralCountByMonth.js
+++ b/src/components/charts/program_evaluation/us_nd/free_through_recovery/FtrReferralCountByMonth.js
@@ -57,7 +57,7 @@ const FtrReferralCountByMonth = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'Total',
+          label: 'Referral count',
           backgroundColor: COLORS['grey-500'],
           borderColor: COLORS['grey-500'],
           pointBackgroundColor: COLORS['grey-500'],

--- a/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
+++ b/src/components/charts/reincarcerations/ReincarcerationCountOverTime.js
@@ -65,6 +65,7 @@ const ReincarcerationCountOverTime = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
+          label: 'Reincarceration count',
           backgroundColor: COLORS['grey-500'],
           borderColor: COLORS['grey-500'],
           pointBackgroundColor: COLORS['grey-500'],

--- a/src/components/charts/revocations/AdmissionCountsByType.js
+++ b/src/components/charts/revocations/AdmissionCountsByType.js
@@ -67,7 +67,7 @@ const AdmissionCountsByType = (props) => {
       id={chartId}
       data={{
         datasets: [{
-          label: 'Count',
+          label: 'Admission count',
           data: chartDataPoints,
           // Note: these colors are intentionally set in this order so that
           // the colors for technical and unknown revocations match those of

--- a/src/components/charts/revocations/AdmissionCountsByType.js
+++ b/src/components/charts/revocations/AdmissionCountsByType.js
@@ -23,11 +23,11 @@ import { sortByLabel } from '../../../utils/dataOrganizing';
 import { configureDownloadButtons } from '../../../assets/scripts/utils/downloads';
 import { toInt } from '../../../utils/variableConversion';
 
-const AdmissionTypeProportions = (props) => {
+const AdmissionCountsByType = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
   const [chartDataPoints, setChartDataPoints] = useState([]);
 
-  const chartId = 'admissionTypeProportions';
+  const chartId = 'admissionCountsByType';
 
   const processResponse = () => {
     const { admissionCountsByType } = props;
@@ -67,6 +67,7 @@ const AdmissionTypeProportions = (props) => {
       id={chartId}
       data={{
         datasets: [{
+          label: 'Count',
           data: chartDataPoints,
           // Note: these colors are intentionally set in this order so that
           // the colors for technical and unknown revocations match those of
@@ -132,4 +133,4 @@ const AdmissionTypeProportions = (props) => {
   return chart;
 };
 
-export default AdmissionTypeProportions;
+export default AdmissionCountsByType;

--- a/src/components/charts/revocations/RevocationCountOverTime.js
+++ b/src/components/charts/revocations/RevocationCountOverTime.js
@@ -65,7 +65,7 @@ const RevocationCountOverTime = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'Total',
+          label: 'Revocation count',
           backgroundColor: COLORS['grey-500'],
           borderColor: COLORS['grey-500'],
           pointBackgroundColor: COLORS['grey-500'],

--- a/src/components/charts/revocations/RevocationRateByCounty.js
+++ b/src/components/charts/revocations/RevocationRateByCounty.js
@@ -96,7 +96,7 @@ class RevocationsByCounty extends Component {
 
     const downloadableDataFormat = [{
       data: Object.values(this.chartDataPoints),
-      label: chartId,
+      label: 'Revocation rate',
     }];
 
     configureDownloadButtons(chartId,

--- a/src/components/charts/revocations/RevocationsByOffice.js
+++ b/src/components/charts/revocations/RevocationsByOffice.js
@@ -160,7 +160,7 @@ class RevocationsByOffice extends Component {
 
     const downloadableDataFormat = [{
       data: revocationsByOffice,
-      label: chartId,
+      label: 'Revocation count',
     }];
 
     configureDownloadButtons(chartId, 'REVOCATIONS BY P&P OFFICE - 60 DAYS',

--- a/src/components/charts/snapshots/DaysAtLibertySnapshot.js
+++ b/src/components/charts/snapshots/DaysAtLibertySnapshot.js
@@ -70,7 +70,7 @@ const DaysAtLibertySnapshot = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'data',
+          label: 'Days at liberty (average)',
           backgroundColor: COLORS['blue-standard'],
           borderColor: COLORS['blue-standard'],
           pointBackgroundColor: COLORS['blue-standard'],

--- a/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/snapshots/LsirScoreChangeSnapshot.js
@@ -72,7 +72,7 @@ const LsirScoreChangeSnapshot = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'data',
+          label: 'LSI-R score changes (average)',
           backgroundColor: COLORS['blue-standard'],
           borderColor: COLORS['blue-standard'],
           pointBackgroundColor: COLORS['blue-standard'],

--- a/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/snapshots/RevocationAdmissionsSnapshot.js
@@ -78,7 +78,7 @@ const RevocationAdmissionsSnapshot = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'data',
+          label: 'Percent of prison admissions from revocations',
           backgroundColor: COLORS['blue-standard'],
           borderColor: COLORS['blue-standard'],
           pointBackgroundColor: COLORS['blue-standard'],

--- a/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/snapshots/SupervisionSuccessSnapshot.js
@@ -84,7 +84,7 @@ const SupervisionSuccessSnapshot = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'data',
+          label: 'Supervision success rate',
           backgroundColor: COLORS['blue-standard'],
           borderColor: COLORS['blue-standard'],
           pointBackgroundColor: COLORS['blue-standard'],

--- a/src/views/Revocations.js
+++ b/src/views/Revocations.js
@@ -26,7 +26,7 @@ import RevocationCountOverTime from '../components/charts/revocations/Revocation
 import RevocationCountBySupervisionType from '../components/charts/revocations/RevocationCountBySupervisionType';
 import RevocationCountByViolationType from '../components/charts/revocations/RevocationCountByViolationType';
 import RevocationCountByOfficer from '../components/charts/revocations/RevocationCountByOfficer';
-import AdmissionTypeProportions from '../components/charts/revocations/AdmissionTypeProportions';
+import AdmissionCountsByType from '../components/charts/revocations/AdmissionCountsByType';
 import RevocationProportionByRace from '../components/charts/revocations/RevocationProportionByRace';
 import RevocationRateByCounty from '../components/charts/revocations/RevocationRateByCounty';
 import RevocationsByOffice from '../components/charts/revocations/RevocationsByOffice';
@@ -493,31 +493,31 @@ const Revocations = () => {
                     ADMISSIONS BY TYPE
                     <span className="fa-pull-right">
                       <div className="dropdown show">
-                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-admissionTypeProportions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-admissionCountsByType" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Export
                         </a>
-                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-admissionTypeProportions">
-                          <a className="dropdown-item" id="downloadChartAsImage-admissionTypeProportions" href="javascript:void(0);">Export image</a>
-                          <a className="dropdown-item" id="downloadChartData-admissionTypeProportions" href="javascript:void(0);">Export data</a>
+                        <div className="dropdown-menu" aria-labelledby="exportDropdownMenuButton-admissionCountsByType">
+                          <a className="dropdown-item" id="downloadChartAsImage-admissionCountsByType" href="javascript:void(0);">Export image</a>
+                          <a className="dropdown-item" id="downloadChartData-admissionCountsByType" href="javascript:void(0);">Export data</a>
                         </div>
                       </div>
                     </span>
                   </h6>
                 </div>
                 <div className="layer w-100 p-20">
-                  <AdmissionTypeProportions
+                  <AdmissionCountsByType
                     admissionCountsByType={apiData.admissions_by_type_60_days}
                   />
                 </div>
-                <div className="layer bdT p-20 w-100 accordion" id="methodologyAdmissionTypeProportions">
-                  <div className="mb-0" id="methodologyHeadingAdmissionTypeProportions">
+                <div className="layer bdT p-20 w-100 accordion" id="methodologyAdmissionCountsByType">
+                  <div className="mb-0" id="methodologyHeadingAdmissionCountsByType">
                     <div className="mb-0">
-                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyAdmissionTypeProportions" aria-expanded="true" aria-controls="collapseMethodologyAdmissionTypeProportions">
+                      <button className="btn btn-link collapsed pL-0" type="button" data-toggle="collapse" data-target="#collapseMethodologyAdmissionCountsByType" aria-expanded="true" aria-controls="collapseMethodologyAdmissionCountsByType">
                         <h6 className="lh-1 c-blue-500 mb-0">Methodology</h6>
                       </button>
                     </div>
                   </div>
-                  <div id="collapseMethodologyAdmissionTypeProportions" className="collapse" aria-labelledby="methodologyHeadingRevocationByOfficer" data-parent="#methodologyAdmissionTypeProportions">
+                  <div id="collapseMethodologyAdmissionCountsByType" className="collapse" aria-labelledby="methodologyHeadingRevocationByOfficer" data-parent="#methodologyAdmissionCountsByType">
                     <div>
                       <ul>
                         <li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5913,6 +5913,11 @@ json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+jsonexport@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/jsonexport/-/jsonexport-2.4.1.tgz#2148920875c6e0049d188e5e2da356a79cca947e"
+  integrity sha512-8O+yka4X6KxVMJDnzQh7NaoqgNX96gMbX7jb2JMb3CfxXfEvPpRpYyb+2/HpKjxR7Abr7zlvqxV4/cpqmExPSw==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"


### PR DESCRIPTION
## Description of the change

- Changes the `Export data` button to download as a .csv instead of .json
- Updates to the `label` value in a bunch of datasets to make the CSV labels meaningful
- Renames `AdmissionTypeProportions` component to `AdmissionCountsByType` to be more accurate
- Re-organizes how the officer violation data was being downloaded so that it's optimized for CSV

I've tested the `Export data` for every chart and it is working as expected. It should also be noted that this does not break the existing functionality to download as a JSON. So, we could support multiple download file types if we wanted to. 

## Type of change
- [X] New feature (non-breaking change that adds functionality)

## Related issues

Closes #96 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Lint rules pass locally
- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
