### PR TITLE
Fixing CSV export issues on Windows and Firefox

### DIFF
--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -46,9 +46,16 @@ function downloadObjectAsCsv(exportObj, exportName) {
 
   csvExport(exportObj.series, options, (err, csv) => {
     if (err) throw err;
-    const dataStr = `data:text/csv;charset=utf-8,${csv}`;
     const filename = `${exportName}.csv`;
-    downloadjs(dataStr, filename, 'text/plain');
+
+    if (navigator.msSaveBlob) { // User is on Windows
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      navigator.msSaveBlob(blob, filename);
+    } else {
+      const encodedCsv = encodeURIComponent(csv);
+      const dataStr = `data:text/csv;charset=utf-8,${encodedCsv}`;
+      downloadjs(dataStr, filename, 'text/csv');
+    }
   });
 }
 


### PR DESCRIPTION
## Description of the change

Fix for an issue that was causing CSVs to improperly download for Windows users. Also fixes a bug that was causing Firefox CSV downloads to be all on one line. 

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)

## Related issues

Closes #128 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Lint rules pass locally
- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
