### PR TITLE
Fixing release cohort year

### DIFF
--- a/src/views/tenants/us_nd/Reincarcerations.js
+++ b/src/views/tenants/us_nd/Reincarcerations.js
@@ -234,8 +234,9 @@ const Reincarcerations = () => {
                   <div className="peers ai-c jc-c gapX-20">
                     <div className="peer">
                       <span className="fsz-def fw-600 mR-10 c-grey-800">
+                        /* TODO(138): Make the release cohort year dynamic ==================== */
                         <small className="c-grey-500 fw-600">Release Cohort </small>
-                        2017
+                        2018
                       </span>
                     </div>
                     <div className="peer fw-600">


### PR DESCRIPTION
## Description of the change
The release cohort year on the `REINCARCERATION RATE BY PREVIOUS STAY LENGTH` chart is out of date as of Jan 1 of this year. Temporary fix to bring this up to date. Filed #138 to make this update dynamic in the future. 

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)

## Related issues

Temporary fix before #138 is done.

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Lint rules pass locally
- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
