### PR TITLE
Upgrades serialize-javascript dependency to resolved 2.1.1 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "node-sass": "^4.12.0",
     "nodemon": "^1.19.0"
   },
+  "resolutions": {
+    "serialize-javascript": "^2.1.1"
+  },
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9102,9 +9102,9 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
+serialize-javascript@^1.4.0, serialize-javascript@^1.7.0, serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
 
 serve-index@^1.7.2:
   version "1.9.1"


### PR DESCRIPTION
## Description of the change

Github identified a dependency vulnerability with `serialize-javascript`. It’s moderate severity and on further investigation is only vulnerable at build time and not at runtime. Our dependency is transitive and comes from `terser-webpack-plugin` through `create-react-apps`, ultimately. CRA has pushed an upgrade of `serialize-javascript` to master but not released yet. Instead of waiting for that, we use Yarn's resolutions feature to resolve the version installed here.

## Type of change
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
