### PR TITLE
Matrix Cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,9 +30,10 @@ import PrivateTenantRoute from './components/PrivateTenantRoute';
 import SideBar from './components/SideBar';
 import TopBar from './components/TopBar';
 import { getUserStateCode } from './utils/authentication/user';
+import { hasSideBar } from './utils/layout/filters';
 import NotFound from './views/NotFound';
 import Profile from './views/Profile';
-import { hasSideBar, isLanternState } from './views/stateViews';
+import { getLandingViewForState } from './views/stateViews';
 import './assets/scripts/index';
 
 // styles
@@ -45,7 +46,7 @@ initFontAwesome();
 
 const App = () => {
   const [sideBarCollapsed, setSideBarCollapsed] = useState('');
-  const { user, loading, isAuthenticated} = useAuth0();
+  const { user, loading, isAuthenticated } = useAuth0();
   const stateCode = getUserStateCode(user);
 
   function toggleCollapsed() {
@@ -102,11 +103,7 @@ const App = () => {
               <TopBar pathname={window.location.pathname} />
               <Switch>
                 <Route exact path="/">
-                  {isLanternState(stateCode) ? (
-                    <PrivateTenantRoute path="/" />
-                  ) : (
-                    <Redirect to="/snapshots" />
-                  )}
+                  <Redirect to={getLandingViewForState(stateCode)} />
                 </Route>
                 <PrivateTenantRoute path="/snapshots" />
                 <PrivateTenantRoute path="/revocations" />

--- a/src/assets/styles/spec/utils/layout/utils/modal.scss
+++ b/src/assets/styles/spec/utils/layout/utils/modal.scss
@@ -2,7 +2,7 @@
   position: fixed;
   display: block;
   width: 600px;
-  height: auto;
+  max-height: 400px;
   background: white;
   border: 1px solid $border-color;
   top: 20%;

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -25,7 +25,8 @@ import { getUserStateCode, getUserStateName } from '../utils/authentication/user
 import {
   canShowAuthenticatedView, getDemoUser,
 } from '../utils/authentication/viewAuthentication';
-import { hasSideBar, isLanternState } from '../views/stateViews';
+import { hasSideBar } from '../utils/layout/filters';
+import { isLanternState } from '../views/stateViews';
 
 const TopBar = (props) => {
   const { pathname } = props;
@@ -38,7 +39,7 @@ const TopBar = (props) => {
   const {
     user, isAuthenticated, loginWithRedirect, logout,
   } = useAuth0();
-  const stateCode = getUserStateCode(user)
+  const stateCode = getUserStateCode(user);
 
   const logoutWithRedirect = () => logout({ returnTo: window.location.origin });
 

--- a/src/components/charts/ExportMenu.js
+++ b/src/components/charts/ExportMenu.js
@@ -38,16 +38,17 @@ const ExportMenu = (props) => {
           <a className="dropdown-item" id={`downloadChartData-${props.chartId}`} href="javascript:void(0);">Export data</a>
         </div>
       </div>
-      {showAdditionalInfo &&
-        <div className="modal-container p-20">
+
+      {showAdditionalInfo && (
+        <div className="modal-container overflow-auto p-20">
           <h5>About this chart</h5>
           {additionalInfo.length > 0 ? (
             <ul>
-              {additionalInfo.map((info, i) =>
-                <li key={i} className="mY-20" >
+              {additionalInfo.map((info, i) => (
+                <li key={i} className="mY-20">
                   {info}
                 </li>
-              )}
+              ))}
             </ul>
           ) : (
             <p>
@@ -58,7 +59,7 @@ const ExportMenu = (props) => {
             <button className="btn btn-link" onClick={() => toggleAdditionalInfoModal()}>Close</button>
           </div>
         </div>
-      }
+      )}
     </span>
   );
 

--- a/src/components/charts/new_revocations/CaseTable.js
+++ b/src/components/charts/new_revocations/CaseTable.js
@@ -88,7 +88,6 @@ const CaseTable = (props) => {
           <tr>
             <th>State ID</th>
             <th>District</th>
-            <th>Supervisor</th>
             <th>Officer</th>
             <th>Risk level</th>
             <th>Officer rec.</th>
@@ -100,7 +99,6 @@ const CaseTable = (props) => {
             <tr key={i}>
               <td>{details.state_id}</td>
               <td>{details.district}</td>
-              <td>{details.supervisor}</td>
               <td>{details.officer}</td>
               <td>{normalizeLabel(details.risk_level)}</td>
               <td>{normalizeLabel(details.officer_recommendation)}</td>

--- a/src/utils/charts/info.js
+++ b/src/utils/charts/info.js
@@ -16,24 +16,56 @@
 // =============================================================================
 
 const chartIdToInfo = {
-  "revocationMatrix": [
-    "This is a measurement of the percent of admissions to Missouri prisons that were due to parole or probation revocations.",
-    "Revocations count all people who were incarcerated because their supervision was revoked.",
+  revocationMatrix: [
+    'This chart shows the number of people revoked to prison from probation and parole, broken down by their most severe violation and the number of violation reports filed before revocation.',
+    'Revocations count all people who were incarcerated in a DOC-operated facility because their supervision was revoked.',
+    'Revocations are included based on the date that the person was admitted to a DOC facility because their supervision was revoked, not the date of the causal violation or offense.',
+    'Each individual number in the chart has been deduplicated by person. However, a person can be counted in multiple numbers in the chart if they had multiple distinct terms of supervision that ended in revocation in the measurement window.',
+    'The y-axis shows the "most severe" violation recorded during the person\'s term of supervision, where severity is ordered as follows: Felony, Misdemeanor, Absconsion, Municipal, Substance Abuse, Technical Violation.',
+    'The x-axis shows the number of violation reports and/or notices of citation that were officially filed prior to the revocation, including the final one which led to the revocation taking place.',
+    'Clicking on a violation type label along the y-axis will filter all other charts and tables in the view to only display information which also included that violation type as its most severe.',
+    'Clicking on a specific cell in the chart will filter all other charts by both the most severe violation and also the number of violation reports or notices of citation filed.',
   ],
-  "revocationsOverTime": [
+  revocationsOverTime: [
+    'This chart shows the number of people revoked to prison from probation and parole by month.',
+    'Revocations count all people who were incarcerated in a DOC-operated facility because their supervision was revoked.',
+    'Revocations are included based on the date that the person was admitted to a DOC facility because their supervision was revoked, not the date of the causal violation or offense.',
+    'Each month in the chart has been deduplicated by person. However, a person can be counted in multiple months in the chart if they had multiple distinct terms of supervision that ended in revocation in the measurement window.',
   ],
-  "revocationsByDistrict": [
+  revocationsByDistrict: [
+    'This chart shows the number of people revoked to prison from probation and parole, broken down by the district that they were being supervised in at the time of revocation.',
+    'The chart can be toggled to show either revocation counts or revocation rates. The revocation rate is defined as the number of revocations that occurred within that district divided by the number of people supervised within that district at some point in the course of the measurement window.',
+    'Revocations count all people who were incarcerated in a DOC-operated facility because their supervision was revoked.',
+    'Revocations are included based on the date that the person was admitted to a DOC facility because their supervision was revoked, not the date of the causal violation or offense.',
+    'Each district in the chart has been deduplicated by person. However, a person can be counted in multiple districts in the chart if they had multiple distinct terms of supervision that ended in revocation in the measurement window.',
   ],
-  "revocationsByGender": [
+  revocationsByGender: [
+    'This chart shows the number of people revoked to prison from probation and parole, broken down by both gender and risk level, as determined by recorded assessments from the Ohio Risk Assessment System (ORAS).',
+    'If an individual has more than one gender recorded from different ingested data tables, then they are counted towards the gender from the particular ingested data table which is considered to be closest to a "source of truth."',
+    'Revocations count all people who were incarcerated in a DOC-operated facility because their supervision was revoked.',
+    'Revocations are included based on the date that the person was admitted to a DOC facility because their supervision was revoked, not the date of the causal violation or offense.',
+    'Each risk level and gender combination in the chart has been deduplicated by person. However, a person can be counted in multiple such combinations if they had multiple distinct terms of supervision that ended in revocation in the measurement window.',
   ],
-  "revocationsByRace": [
+  revocationsByRace: [
+    'This chart shows the number of people revoked to prison from probation and parole, broken down by both race and risk level, as determined by recorded assessments from the Ohio Risk Assessment System (ORAS).',
+    'If an individual has more than one race or ethnicity recorded from different ingested data tables, then they are counted once for each unique race and ethnicity. This means that the total count in this chart may be larger than the total number of individuals it describes.',
+    'Revocations count all people who were incarcerated in a DOC-operated facility because their supervision was revoked.',
+    'Revocations are included based on the date that the person was admitted to a DOC facility because their supervision was revoked, not the date of the causal violation or offense.',
+    'Each risk level and race combination in the chart has been deduplicated by person. However, a person can be counted in multiple such combinations if they had multiple distinct terms of supervision that ended in revocation in the measurement window.',
   ],
-  "revocationsByRiskLevel": [
+  revocationsByRiskLevel: [
+    'This chart shows the number of people revoked to prison from probation and parole, broken down by risk level, as determined by recorded assessments from the Ohio Risk Assessment System (ORAS).',
+    'Revocations count all people who were incarcerated in a DOC-operated facility because their supervision was revoked.',
+    'Revocations are included based on the date that the person was admitted to a DOC facility because their supervision was revoked, not the date of the causal violation or offense.',
+    'Each risk level in the chart has been deduplicated by person. However, a person can be counted in multiple risk levels if they had multiple distinct terms of supervision that ended in revocation in the measurement window.',
   ],
-  "revocationsByViolationType": [
+  revocationsByViolationType: [
+    'This chart shows the relative frequency of each type of violation for individuals who were revoked to prison, over the measurement window.',
+    'This is calculated by looking at all notices of citation and violation reports filed for these individuals during that time period, counting the number of times each type of violation was reported, and dividing this by the total number of reported violations.',
+    'If multiple conditions violated are listed on one report or one notice of citation, they are all counted.',
   ],
-}
+};
 
 export {
-  chartIdToInfo
-}
+  chartIdToInfo,
+};

--- a/src/utils/layout/filters.js
+++ b/src/utils/layout/filters.js
@@ -1,0 +1,31 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { canShowAuthenticatedView } from '../authentication/viewAuthentication';
+import { isLanternState } from '../../views/stateViews';
+
+/**
+ * Returns, based on the stateCode and if the user is authenticated,
+ * if the view has a side bar.
+ */
+function hasSideBar(stateCode, isAuthenticated) {
+  return !isLanternState(stateCode) && canShowAuthenticatedView(isAuthenticated);
+}
+
+export {
+  hasSideBar,
+};

--- a/src/views/stateViews.js
+++ b/src/views/stateViews.js
@@ -15,19 +15,16 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { canShowAuthenticatedView } from '../utils/authentication/viewAuthentication';
-
 import UsNdFreeThroughRecovery from './tenants/us_nd/FreeThroughRecovery';
 import UsNdReincarcerations from './tenants/us_nd/Reincarcerations';
 import UsNdRevocations from './tenants/us_nd/Revocations';
 import UsNdSnapshots from './tenants/us_nd/Snapshots';
 
 import UsMoRevocations from './tenants/us_mo/Revocations';
-import UsMoSnapshots from './tenants/us_mo/Snapshots';
 
 const STATE_VIEW_COMPONENTS = {
   us_mo: {
-    '/': UsMoRevocations
+    '/revocations': UsMoRevocations,
   },
   us_nd: {
     '/programevaluation/freethroughrecovery': UsNdFreeThroughRecovery,
@@ -37,25 +34,12 @@ const STATE_VIEW_COMPONENTS = {
   },
 };
 
+const STATE_LANDING_VIEWS = {
+  us_mo: '/revocations',
+  us_nd: '/snapshots',
+};
+
 const LANTERN_STATE_CODES = ['us_mo'];
-
-/**
- * Returns whether the given stateCode is a lantern state
- */
-function isLanternState(stateCode) {
-  if (stateCode === 'recidiviz') {
-    stateCode = getCurrentStateForRecidivizUsers()
-  }
-  return LANTERN_STATE_CODES.includes(stateCode);
-}
-
-/**
- * Returns, based on the stateCode and if the user is authenticated,
- * if the view has a side bar
- */
-function hasSideBar(stateCode, isAuthenticated) {
-  return !isLanternState(stateCode) && canShowAuthenticatedView(isAuthenticated);
-}
 
 /**
  * Returns the list of states which are available to view data for.
@@ -129,12 +113,35 @@ function getComponentForStateView(stateCode, view) {
   return component;
 }
 
+/**
+ * Returns whether the given stateCode is a lantern state
+ */
+function isLanternState(stateCode) {
+  let normalizedStateCode = stateCode;
+  if (stateCode === 'recidiviz') {
+    normalizedStateCode = getCurrentStateForRecidivizUsers();
+  }
+  return LANTERN_STATE_CODES.includes(normalizedStateCode);
+}
+
+/**
+ * Returns what should be the landing view, i.e. what you first see after login
+ * or when you navigate to '/', for a given state.
+ */
+function getLandingViewForState(stateCode) {
+  let normalizedStateCode = stateCode;
+  if (stateCode === 'recidiviz') {
+    normalizedStateCode = getCurrentStateForRecidivizUsers();
+  }
+  return STATE_LANDING_VIEWS[normalizedStateCode] || '/';
+}
+
 export {
-  hasSideBar,
   isLanternState,
   getAvailableStates,
   getFirstAvailableState,
   getAvailableViewsForState,
+  getLandingViewForState,
   getComponentForStateView,
   getCurrentStateForRecidivizUsers,
   setCurrentStateForRecidivizUsers,

--- a/src/views/tenants/us_mo/Revocations.js
+++ b/src/views/tenants/us_mo/Revocations.js
@@ -47,7 +47,6 @@ const CHARGE_CATEGORIES = [
   { value: 'GENERAL', label: 'General' },
   { value: 'SEX_OFFENSE', label: 'Sex offense' },
   { value: 'DOMESTIC_VIOLENCE', label: 'Domestic Violence' },
-  { value: 'SIS', label: 'SIS/SES' },
 ];
 const SUPERVISION_TYPES = [
   { value: '', label: 'All' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,6 +2159,10 @@ bootstrap@^4.0.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.3.1.tgz#280ca8f610504d99d7b6b4bfc4b68cec601704ac"
 
+bowser@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.8.1.tgz#35b74165e17b80ba8af6aa4736c2861b001fc09e"
+
 boxen@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
@@ -2803,9 +2807,9 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-security-policy-builder@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz#8749a1d542fcbe82237281ea9f716ce68b394dd2"
+content-security-policy-builder@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz#0a2364d769a3d7014eec79ff7699804deb8cfcbb"
 
 content-type@~1.0.4:
   version "1.0.4"
@@ -4794,18 +4798,18 @@ helmet-crossdomain@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz#5f1fe5a836d0325f1da0a78eaa5fd8429078894e"
 
-helmet-csp@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-2.7.1.tgz#e8e0b5186ffd4db625cfcce523758adbfadb9dca"
+helmet-csp@2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-2.9.4.tgz#801382bac98f2f88706dc5c89d95c7e31af3a4a9"
   dependencies:
+    bowser "^2.7.0"
     camelize "1.0.0"
-    content-security-policy-builder "2.0.0"
+    content-security-policy-builder "2.1.0"
     dasherize "2.0.0"
-    platform "1.3.5"
 
-helmet@^3.18.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.19.0.tgz#02c524dd69e03b0af20dce7bc9929ff951081a29"
+helmet@^3.21.2:
+  version "3.21.2"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.21.2.tgz#7e2a19d5f6d898a77b5d2858e8e4bb2cda59f19f"
   dependencies:
     depd "2.0.0"
     dns-prefetch-control "0.2.0"
@@ -4814,14 +4818,14 @@ helmet@^3.18.0:
     feature-policy "0.3.0"
     frameguard "3.1.0"
     helmet-crossdomain "0.4.0"
-    helmet-csp "2.7.1"
+    helmet-csp "2.9.4"
     hide-powered-by "1.1.0"
     hpkp "2.0.0"
     hsts "2.2.0"
     ienoopen "1.1.0"
     nocache "2.1.0"
     referrer-policy "1.2.0"
-    x-xss-protection "1.2.0"
+    x-xss-protection "1.3.0"
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -6938,7 +6942,7 @@ node-releases@^1.1.13, node-releases@^1.1.25:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.12.0:
+node-sass@4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
   dependencies:
@@ -7555,10 +7559,6 @@ pkg-up@2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
     find-up "^2.1.0"
-
-platform@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -10595,9 +10595,9 @@ ws@^6.1.2:
   dependencies:
     async-limiter "~1.0.0"
 
-x-xss-protection@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/x-xss-protection/-/x-xss-protection-1.2.0.tgz#3170498ff8e7e8159f4896b27fa4d4810c2ff486"
+x-xss-protection@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/x-xss-protection/-/x-xss-protection-1.3.0.tgz#3e3a8dd638da80421b0e9fff11a2dbe168f6d52c"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description of the change

This applies a handful of small cleanup fixes for the new revocation matrix feature:
- Lint fixes
- Removes a cyclic dependency by shifting the `hasSideBar` tool into a new `utils/layouts/filters` file
- Generalizing how the landing view is selected for each state, and in the process ensuring that users will not get accustomed to a specific view living at '/' if it needs to change as more views are added for a state
- Removes SIS from the charge category filter and the supervisor column from the case table (not yet supported)
- Adds initial copy for the "Additional info" modals
- Adds scrollability to these modals and caps their max height
- Updates `yarn.lock` as it apparently had some uncommitted changes after updates in `package.json`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Contributes to #133 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
