### PR TITLE
Applies more fixes for the revocation matrix feature

### DIFF
--- a/src/components/charts/new_revocations/CaseTable.js
+++ b/src/components/charts/new_revocations/CaseTable.js
@@ -26,6 +26,12 @@ const VIOLATION_SEVERITY = [
   'fel', 'misd', 'absc', 'muni', 'subs', 'tech',
 ];
 
+const unknownStyle = {
+  fontStyle: 'italic',
+  fontSize: '13px',
+  color: '#b9c2d0', // A light grey (grey-500 in COLORS.js)
+};
+
 const CaseTable = (props) => {
   const [index, setIndex] = useState(0);
 
@@ -53,11 +59,13 @@ const CaseTable = (props) => {
     ? (beginning + CASES_PER_PAGE) : data.length;
   const page = caseLoad.slice(beginning, end);
 
-  const normalizeLabel = (label) => {
-    if (!label) {
-      return '';
+  const normalizeLabel = (label) => (label ? humanReadableTitleCase(label) : '');
+  const nullSafeLabel = (label) => label || 'Unknown';
+  const nullSafeCell = (label) => {
+    if (label) {
+      return <td>{label}</td>;
     }
-    return humanReadableTitleCase(label);
+    return <td style={unknownStyle}>{nullSafeLabel(label)}</td>;
   };
 
   const indexOf = (element, array) => {
@@ -103,11 +111,11 @@ const CaseTable = (props) => {
           {page.map((details, i) => (
             <tr key={i}>
               <td>{details.state_id}</td>
-              <td>{details.district}</td>
-              <td>{nameFromOfficerId(details.officer)}</td>
-              <td>{riskLevelValuetoLabel[details.risk_level] || ''}</td>
-              <td>{normalizeLabel(details.officer_recommendation)}</td>
-              <td>{parseViolationRecord(details.violation_record)}</td>
+              {nullSafeCell(details.district)}
+              {nullSafeCell(nameFromOfficerId(details.officer))}
+              {nullSafeCell(riskLevelValuetoLabel[details.risk_level])}
+              {nullSafeCell(normalizeLabel(details.officer_recommendation))}
+              {nullSafeCell(parseViolationRecord(details.violation_record))}
             </tr>
           ))}
         </tbody>

--- a/src/components/charts/new_revocations/RevocationMatrix.js
+++ b/src/components/charts/new_revocations/RevocationMatrix.js
@@ -18,7 +18,9 @@
 import React, { useState, useEffect } from 'react';
 import ExportMenu from '../ExportMenu';
 
-import { getPeriodLabelFromMetricPeriodMonthsToggle } from '../../../utils/charts/toggles';
+import {
+  getPeriodLabelFromMetricPeriodMonthsToggle, getTrailingLabelFromMetricPeriodMonthsToggle
+} from '../../../utils/charts/toggles';
 import { toInt } from '../../../utils/transforms/labels';
 
 // These can also be defined from the data
@@ -181,7 +183,7 @@ const RevocationMatrix = (props) => {
         />
       </h4>
       <h6>
-        {getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)}
+        {`${getTrailingLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)} (${getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)})`}
       </h6>
       <div id="revocationMatrix" className="d-f">
         <div className="y-label" data-html2canvas-ignore>

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -25,7 +25,7 @@ import { toInt } from '../../../utils/transforms/labels';
 
 const CHART_LABELS = ['Overall', 'Low Risk', 'Moderate Risk', 'High Risk', 'Very High Risk'];
 const RISK_LEVELS = ['LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH'];
-const RACES = ['WHITE', 'BLACK', 'HISPANIC', 'ASIAN', 'NATIVE_AMERICAN', 'PACIFIC_ISLANDER'];
+const RACES = ['WHITE', 'BLACK', 'HISPANIC', 'ASIAN', 'AMERICAN_INDIAN_ALASKAN_NATIVE', 'PACIFIC_ISLANDER'];
 
 const chartId = 'revocationsByRace';
 

--- a/src/components/charts/new_revocations/RevocationsOverTime.js
+++ b/src/components/charts/new_revocations/RevocationsOverTime.js
@@ -22,6 +22,7 @@ import ExportMenu from '../ExportMenu';
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import {
   getMonthCountFromMetricPeriodMonthsToggle, getTrailingLabelFromMetricPeriodMonthsToggle,
+  centerSingleMonthDatasetIfNecessary,
 } from '../../../utils/charts/toggles';
 import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/transforms/datasets';
 import { toInt } from '../../../utils/transforms/labels';
@@ -54,6 +55,8 @@ const RevocationsOverTime = (props) => {
     const sortedChartData = sortFilterAndSupplementMostRecentMonths(chartData, months, 'count', 0);
     const labels = monthNamesWithYearsFromNumbers(sortedChartData.map((element) => element.month), false)
     const dataPoints = (sortedChartData.map((element) => element.count));
+
+    centerSingleMonthDatasetIfNecessary(dataPoints, labels);
     setChartLabels(labels);
     setChartDataPoints(dataPoints);
   };

--- a/src/utils/charts/toggles.js
+++ b/src/utils/charts/toggles.js
@@ -109,7 +109,7 @@ function getPeriodLabelFromMetricPeriodMonthsToggle(toggledValue) {
 
 function getTrailingLabelFromMetricPeriodMonthsToggle(toggledValue) {
   if (toggledValue === '1') {
-    return 'Last 30 days';
+    return 'Current month';
   }
   if (toggledValue === '3' || toggledValue === '6' || toggledValue === '12') {
     return `Last ${toggledValue} months`;


### PR DESCRIPTION
## Description of the change

More fixes following initial integration with live data, including:
* Fixes enum value for Native Americans in race distribution chart
* Adds special styling for cells with null values in the case load table
* Slight updates to metric period labels across the view
* Centers the data point for the Revocations by Month chart when only a single month is in view

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Towards #133 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
