### PR TITLE
Applies a partial fix for ensuring the right landing view is used.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -94,8 +94,8 @@ const App = () => {
   };
 
   // This lets us retrieve the state code for the user only after we have authenticated
-  const getLandingView = () => {
-    if (!isAuthenticated) {
+  const getLandingView = (authenticated) => {
+    if (!authenticated) {
       return '/revocations';
     }
 
@@ -123,7 +123,7 @@ const App = () => {
               <TopBar pathname={window.location.pathname} />
               <Switch>
                 <Route exact path="/">
-                  <Redirect to={getLandingView()} />
+                  <Redirect to={getLandingView(isAuthenticated)} />
                 </Route>
                 <PrivateTenantRoute path="/snapshots" />
                 <PrivateTenantRoute path="/revocations" />

--- a/src/App.js
+++ b/src/App.js
@@ -93,6 +93,16 @@ const App = () => {
     return hasSideBar(stateCode, authenticated);
   };
 
+  // This lets us retrieve the state code for the user only after we have authenticated
+  const getLandingView = () => {
+    if (!isAuthenticated) {
+      return '/revocations';
+    }
+
+    const stateCode = getUserStateCode(user);
+    return getLandingViewForState(stateCode);
+  };
+
   let containerClass = 'wide-page-container';
   if (shouldLoadSidebar(isAuthenticated)) {
     containerClass = 'page-container';
@@ -113,7 +123,7 @@ const App = () => {
               <TopBar pathname={window.location.pathname} />
               <Switch>
                 <Route exact path="/">
-                  <Redirect to="/revocations" />
+                  <Redirect to={getLandingView()} />
                 </Route>
                 <PrivateTenantRoute path="/snapshots" />
                 <PrivateTenantRoute path="/revocations" />


### PR DESCRIPTION
## Description of the change

This is a _partial_ fix to ensure that the right landing view is loaded when a user navigates to the base path (`/`) in the app. One navigates there when they go directly to it in the browser, when they click on conspicuous links in the UI, after they have logged in, or after they have verified their email address after signing up.

Each state has their own configured landing view, and this loads the proper one in all cases except after they have logged in. The issue appears to be that the layout in `App.js` is fully evaluated for rendering _prior_ to authentication having been handled, which means that we can't check the state code of the current user and have to fall back to a default option. I picked as a default option, in the absence of having solved this issue, the only view that is currently available for all states. 

I am confident there is a canonical fix for this but I haven't been able to figure it out this evening. This gets us part of the way there, though, for now.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
