### PR TITLE
Fixes erroneously configured numerator for geo view for successful termination rate

### DIFF
--- a/src/views/tenants/us_nd/Snapshots.js
+++ b/src/views/tenants/us_nd/Snapshots.js
@@ -139,7 +139,7 @@ const Snapshots = () => {
                           keyedByOffice={true}
                           officeData={apiData.site_offices}
                           dataPointsByOffice={apiData.supervision_termination_by_type_by_period}
-                          numeratorKeys={['revocation_termination']}
+                          numeratorKeys={['successful_termination']}
                           denominatorKeys={['revocation_termination', 'successful_termination']}
                           centerLat={47.3}
                           centerLong={-100.5}


### PR DESCRIPTION
## Description of the change

The rate should be `successful / (successful + revocation)`, but geo view was configured as `revocation / (successful + revocation)`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Towards #140 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
