### PR TITLE
Fixes bug in time-gap-filling logic for month-over-month charts

### DIFF
--- a/src/utils/transforms/datasets.js
+++ b/src/utils/transforms/datasets.js
@@ -100,7 +100,7 @@ function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
     const month = (remainder === 0) ? 12 : remainder;
 
     const monthsAgo = new Date(now.getTime());
-    monthsAgo.setMonth(now.getMonth() + i - 1);
+    monthsAgo.setMonth(now.getMonth() + i - 2);
     const year = monthsAgo.getFullYear();
 
     if (!representedMonths[year] || !representedMonths[year][month]) {


### PR DESCRIPTION
## Description of the change

This off-by-one error caused the x-axis of month-over-month charts to be inconsistent with the stated period of by-period charts (one month earlier in some cases, one month later in others) and which also causes phantom December months to show up out of order in some cases.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Towards #140 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
