### PR TITLE
Adds protection in the geo view against unexpected districts

### DIFF
--- a/src/components/charts/GeoViewTimeChart.js
+++ b/src/components/charts/GeoViewTimeChart.js
@@ -332,7 +332,7 @@ class GeoViewTimeChart extends Component {
           return;
         }
 
-        // The API responses included data points for a district not in the list of site offices
+        // The API response included data points for a district not in the list of site offices
         if (!this.offices[districtId]) {
           return;
         }

--- a/src/components/charts/GeoViewTimeChart.js
+++ b/src/components/charts/GeoViewTimeChart.js
@@ -332,6 +332,11 @@ class GeoViewTimeChart extends Component {
           return;
         }
 
+        // The API responses included data points for a district not in the list of site offices
+        if (!this.offices[districtId]) {
+          return;
+        }
+
         const { officeName } = this.offices[districtId];
         const officeNameKey = normalizedOfficeKey(officeName);
         const supervisionTypeKey = normalizedSupervisionTypeKey(supervisionType);


### PR DESCRIPTION
## Description of the change

I tested different views in the dashboard in the presence of district ids that we don't have metadata for in the site offices file, and this appears to be the one place where the dashboard breaks. This just filters any such data points out.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Towards #140 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
