### PR TITLE
Specific chart state fixes/additions

### DIFF
--- a/src/components/charts/GeoViewTimeChart.js
+++ b/src/components/charts/GeoViewTimeChart.js
@@ -423,6 +423,10 @@ class GeoViewTimeChart extends Component {
       keyedByOffice, centerLong, centerLat, chartId, stateCode,
     } = this.props;
 
+    const sortedDataPoints = sortChartDataPoints(
+      this.chartDataPoints, metricType, metricPeriodMonths, supervisionType,
+    );
+
     if (keyedByOffice) {
       // Show a choropleth map with colored, sized circles for P&P offices
       return (
@@ -469,7 +473,7 @@ class GeoViewTimeChart extends Component {
                 }
               </Geographies>
               <Markers>
-                {this.chartDataPoints.map((office) => (
+                {sortedDataPoints.map((office) => (
                   <Marker
                     key={office.officeName}
                     marker={office}

--- a/src/views/tenants/us_nd/Revocations.js
+++ b/src/views/tenants/us_nd/Revocations.js
@@ -481,6 +481,12 @@ const Revocations = () => {
                           prison for a supervision revocation where the violation that caused the
                           revocation cannot yet be determined.
                         </li>
+                        <li>
+                          Because new admissions are counted irrespective of any relationship to
+                          community supervision but the revocation admission types are directly
+                          related to supervision, filtering this chart by supervision type or by
+                          office impacts only the revocation admission counts.
+                        </li>
                       </ul>
                     </div>
                   </div>

--- a/src/views/tenants/us_nd/Snapshots.js
+++ b/src/views/tenants/us_nd/Snapshots.js
@@ -91,6 +91,9 @@ const Snapshots = () => {
                 <div className="layer w-100 pX-20 pT-20">
                   <h6 className="lh-1">
                     SUCCESSFUL COMPLETION OF SUPERVISION
+                    {chartDistrict !== 'all' && (
+                      <span className="pL-10 c-orange-500 ti-alert" data-toggle="tooltip" data-placement="bottom" title="Filtering this graph by a specific office requires knowing the officer that was assigned to historical periods of supervision. Because the Docstars data system does not currently keep a full historical record of officer assignments, we cannot track this measurement by office prior to when we first began ingesting data from DOCR." />
+                    )}
                     <span className="fa-pull-right">
                       <div className="geo-view-button pR-10">
                         <GeoViewToggle setGeoViewEnabled={setGeoViewEnabledSCOS} />
@@ -350,6 +353,9 @@ const Snapshots = () => {
                     LSI-R SCORE CHANGES (AVERAGE)
                     {chartMetricType !== 'counts' && (
                       <span className="pL-10 c-orange-500 ti-alert" data-toggle="tooltip" data-placement="bottom" title="This graph is showing average LSI-R score change. It does not support showing this metric as a rate." />
+                    )}
+                    {chartDistrict !== 'all' && (
+                      <span className="pL-10 c-orange-500 ti-alert" data-toggle="tooltip" data-placement="bottom" title="Filtering this graph by a specific office requires knowing the officer that was assigned to historical periods of supervision. Because the Docstars data system does not currently keep a full historical record of officer assignments, we cannot track this measurement by office prior to when we first began ingesting data from DOCR." />
                     )}
                     <span className="fa-pull-right">
                       <div className="geo-view-button pR-10">


### PR DESCRIPTION
## Description of the change

This applies a few final additions/fixes for specific chart states:
* Fixes a bug in geo view that meant that larger bubbles might overlap on top of smaller bubbles, which is the opposite of our intention
* Adds an alert icon for two charts for North Dakota specifically, to highlight a limit on historical availability in those charts
* Adds a methodology point for admissions by type to highlight why the new admissions count stays the same in some states while the other counts change

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Towards #140 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
