### PR TITLE
Matrix bug fixes

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,6 +81,12 @@ app.get('/api/:stateCode/revocations', checkJwt, api.revocations);
 app.get('/api/:stateCode/snapshots', checkJwt, api.snapshots);
 app.get('/api/:stateCode/newRevocations', checkJwt, api.newRevocations);
 
+// An App Engine-specific API for handling warmup requests on new instance initialization
+app.get('/_ah/warmup', (req, res) => {
+  // The server automatically launches initialization of the metric cache, so nothing is needed here
+  console.log('Responding to warmup request...');
+});
+
 // Starts the background task for refresh metrics regularly
 require('./server/core/metricsRefresh');
 

--- a/server/core/metricsApi.js
+++ b/server/core/metricsApi.js
@@ -159,6 +159,8 @@ function fetchMetricsFromLocal(stateCode, metricType) {
  * Otherwise, fetches from Google Cloud Storage.
  */
 function fetchMetrics(stateCode, metricType, isDemo, callback) {
+  console.log(`Handling call to fetch ${metricType} metrics for state ${stateCode}...`);
+
   const cacheKey = `${stateCode}-${metricType}`;
   return memoryCache.wrap(cacheKey, (cacheCb) => {
     let fetcher = null;
@@ -175,7 +177,6 @@ function fetchMetrics(stateCode, metricType, isDemo, callback) {
     const metricPromises = fetcher(stateCode.toUpperCase(), metricType);
 
     Promise.all(metricPromises).then((allFileContents) => {
-      console.log(`Fetched all ${metricType} metrics for state ${stateCode} from ${source}`);
       const results = {};
       allFileContents.forEach((contents) => {
         console.log(`Fetched contents for fileKey: ${contents.fileKey}`);
@@ -183,6 +184,7 @@ function fetchMetrics(stateCode, metricType, isDemo, callback) {
         results[contents.fileKey] = deserializedFile;
       });
 
+      console.log(`Fetched all ${metricType} metrics for state ${stateCode} from ${source}`);
       cacheCb(null, results);
     });
   }, callback);

--- a/server/core/metricsRefresh.js
+++ b/server/core/metricsRefresh.js
@@ -30,17 +30,20 @@ const demoMode = require('../utils/demoMode');
 
 const isDemoMode = demoMode.isDemoMode();
 
-const METRIC_REFRESH_INTERVAL_MS = 1000 * 60 * 30; // Refresh metrics every 30 minutes
-const CACHED_STATE_CODES = [
-  'US_MO',
-  'US_ND',
-];
+const METRIC_REFRESH_INTERVAL_MS = 1000 * 60 * 5; // Refresh metrics every 5 minutes
+const CACHED_STATE_CODES = {
+  freeThroughRecovery: ['US_ND'],
+  reincarcerations: ['US_ND'],
+  revocations: ['US_ND'],
+  snapshots: ['US_ND'],
+  newRevocations: ['US_MO'],
+};
 
 /**
  * Performs a refresh of the free through recovery metrics cache, logging success or failure.
  */
 function refreshFreeThroughRecoveryMetrics() {
-  CACHED_STATE_CODES.forEach((stateCode) => {
+  CACHED_STATE_CODES.freeThroughRecovery.forEach((stateCode) => {
     metricsApi.fetchFreeThroughRecoveryMetrics(isDemoMode, stateCode, (err, data) => {
       if (err) {
         console.log(`Encountered error during scheduled fetch-and-cache
@@ -56,7 +59,7 @@ function refreshFreeThroughRecoveryMetrics() {
  * Performs a refresh of the reincarceration metrics cache, logging success or failure.
  */
 function refreshReincarcerationMetrics() {
-  CACHED_STATE_CODES.forEach((stateCode) => {
+  CACHED_STATE_CODES.reincarcerations.forEach((stateCode) => {
     metricsApi.fetchReincarcerationMetrics(isDemoMode, stateCode, (err, data) => {
       if (err) {
         console.log(`Encountered error during scheduled fetch-and-cache
@@ -72,7 +75,7 @@ function refreshReincarcerationMetrics() {
  * Performs a refresh of the revocation metrics cache, logging success or failure.
  */
 function refreshRevocationMetrics() {
-  CACHED_STATE_CODES.forEach((stateCode) => {
+  CACHED_STATE_CODES.revocations.forEach((stateCode) => {
     metricsApi.fetchRevocationMetrics(isDemoMode, stateCode, (err, data) => {
       if (err) {
         console.log(`Encountered error during scheduled fetch-and-cache
@@ -88,13 +91,29 @@ function refreshRevocationMetrics() {
  * Performs a refresh of the snapshot metrics cache, logging success or failure.
  */
 function refreshSnapshotMetrics() {
-  CACHED_STATE_CODES.forEach((stateCode) => {
+  CACHED_STATE_CODES.snapshots.forEach((stateCode) => {
     metricsApi.fetchSnapshotMetrics(isDemoMode, stateCode, (err, data) => {
       if (err) {
         console.log(`Encountered error during scheduled fetch-and-cache
           of snapshot metrics for ${stateCode}: ${err}`);
       } else {
         console.log(`Executed scheduled fetch-and-cache of snapshot metrics for ${stateCode}`);
+      }
+    });
+  });
+}
+
+/**
+ * Performs a refresh of the new revocations metrics cache, logging success or failure.
+ */
+function refreshNewRevocationsMetrics() {
+  CACHED_STATE_CODES.newRevocations.forEach((stateCode) => {
+    metricsApi.fetchNewRevocationMetrics(isDemoMode, stateCode, (err, data) => {
+      if (err) {
+        console.log(`Encountered error during scheduled fetch-and-cache
+          of new revocation metrics for ${stateCode}: ${err}`);
+      } else {
+        console.log(`Executed scheduled fetch-and-cache of new revocation metrics for ${stateCode}`);
       }
     });
   });
@@ -114,4 +133,5 @@ if (!isDemoMode) {
   executeAndSetInterval(refreshReincarcerationMetrics, METRIC_REFRESH_INTERVAL_MS);
   executeAndSetInterval(refreshRevocationMetrics, METRIC_REFRESH_INTERVAL_MS);
   executeAndSetInterval(refreshSnapshotMetrics, METRIC_REFRESH_INTERVAL_MS);
+  executeAndSetInterval(refreshNewRevocationsMetrics, METRIC_REFRESH_INTERVAL_MS);
 }

--- a/src/utils/transforms/months.js
+++ b/src/utils/transforms/months.js
@@ -48,8 +48,9 @@ const monthNamesWithYearsFromNumbers = function monthNamesShortWithYearsFromNumb
   monthNumbers, abbreviated,
 ) {
   const monthNames = monthNamesFromNumbers(monthNumbers, abbreviated);
-  const multipleYears = (monthNumbers.length > 12
-    || monthNumbers[monthNumbers.length - 1] < monthNumbers[0]);
+  const monthNumbersNormalized = monthNumbers.map((month) => Number(month));
+  const multipleYears = (monthNumbersNormalized.length > 12
+    || monthNumbersNormalized[monthNumbersNormalized.length - 1] < monthNumbersNormalized[0]);
   const january = abbreviated ? 'Jan' : 'January';
 
   const today = new Date();

--- a/src/views/tenants/us_mo/Revocations.js
+++ b/src/views/tenants/us_mo/Revocations.js
@@ -61,7 +61,7 @@ const CHARGE_CATEGORIES = [
 
 // TODO: Determine if we want to continue to explicitly provide charge_category=ALL or treat it
 // like supervision type where ALL is a summation of other rows
-const DEFAULT_CHARGE_CATEGORY = 'ALL';
+const DEFAULT_CHARGE_CATEGORY = 'All';
 
 const SUPERVISION_TYPES = [
   { value: '', label: 'All' },
@@ -70,6 +70,8 @@ const SUPERVISION_TYPES = [
   // TODO: Enable dual supervision filtering when supported in calculation methodology
   // { value: 'DUAL_SUPERVISION', label: 'Dual supervision' },
 ];
+
+const DEFAULT_DISTRICT = 'All';
 
 const TOGGLE_STYLE = {
   zIndex: 700,
@@ -86,7 +88,11 @@ const Revocations = () => {
 
   const [districts, setDistricts] = useState([]);
   const [filters, setFilters] = useState(
-    { metricPeriodMonths: DEFAULT_METRIC_PERIOD, chargeCategory: DEFAULT_CHARGE_CATEGORY },
+    {
+      metricPeriodMonths: DEFAULT_METRIC_PERIOD,
+      chargeCategory: DEFAULT_CHARGE_CATEGORY,
+      district: DEFAULT_DISTRICT,
+    },
   );
   const [selectedChart, setSelectedChart] = useState('District');
 
@@ -103,7 +109,7 @@ const Revocations = () => {
           .filter((district) => district.toLowerCase() !== 'all')),
       ];
       const districtsFromResponse = [
-        { value: '', label: 'All districts' },
+        { value: 'All', label: 'All districts' },
         ...districtValues.map((district) => ({ value: district, label: district })),
       ];
       districtsFromResponse.sort((a, b) => a.label - b.label);
@@ -143,7 +149,8 @@ const Revocations = () => {
           return false;
         }
       }
-      if (filters.district && !toSkip.includes('district')) {
+      if (filters.district && !toSkip.includes('district')
+        && !(treatCategoryAllAsAbsent && filters.district.toLowerCase() === 'all')) {
         if (!nullSafeComparison(item.district, filters.district)) {
           return false;
         }


### PR DESCRIPTION
## Description of the change

Fixes a few fresh bugs in the Dashboard for the new matrix view:
- Rationalizes log messages on the server side that were misleading
- Ensures the Node server only brings down API responses that make sense for a given state, not all for all states
- Ensures the backend cache refresh is covering the new revocation API
- Ensures we are not double-counting district=ALL data points in the revocation matrix and the matrix month-by-month companion chart
- Fixes a bug causing month labels to be inaccurate when viewing data for a metric period shorter than 12 months when the span crosses a year boundary and the month numbers are being parsed in such a way as to make them strings, i.e. when at least one data point in that span is empty and needed to be filled

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Towards #133 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
