### PR TITLE
Adds Not Assessed as a tracked category in risk-level-related charts …

### DIFF
--- a/src/components/charts/new_revocations/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender.js
@@ -26,8 +26,8 @@ import {
 } from '../../../utils/charts/toggles';
 import { toInt } from '../../../utils/transforms/labels';
 
-const CHART_LABELS = ['Overall', 'Low Risk', 'Moderate Risk', 'High Risk', 'Very High Risk'];
-const RISK_LEVELS = ['LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH'];
+const CHART_LABELS = ['Overall', 'Not Assessed', 'Low Risk', 'Moderate Risk', 'High Risk', 'Very High Risk'];
+const RISK_LEVELS = ['NOT_ASSESSED', 'LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH'];
 const GENDERS = ['FEMALE', 'MALE'];
 
 const chartId = 'revocationsByGender';

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -26,8 +26,8 @@ import {
 } from '../../../utils/charts/toggles';
 import { toInt } from '../../../utils/transforms/labels';
 
-const CHART_LABELS = ['Overall', 'Low Risk', 'Moderate Risk', 'High Risk', 'Very High Risk'];
-const RISK_LEVELS = ['LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH'];
+const CHART_LABELS = ['Overall', 'Not Assessed', 'Low Risk', 'Moderate Risk', 'High Risk', 'Very High Risk'];
+const RISK_LEVELS = ['NOT_ASSESSED', 'LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH'];
 const RACES = ['WHITE', 'BLACK', 'HISPANIC', 'ASIAN', 'AMERICAN_INDIAN_ALASKAN_NATIVE', 'PACIFIC_ISLANDER'];
 
 const chartId = 'revocationsByRace';

--- a/src/utils/transforms/labels.js
+++ b/src/utils/transforms/labels.js
@@ -16,6 +16,7 @@
 // =============================================================================
 
 const riskLevelValuetoLabel = {
+  NOT_ASSESSED: 'Not Assessed',
   LOW: 'Low',
   MEDIUM: 'Moderate',
   HIGH: 'High',


### PR DESCRIPTION
## Description of the change

Adds "Not Assessed" as a distinctly tracked category for risk-level-related charts in the revocation analysis matrix view.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #133 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
