### PR TITLE
Fixes a fast-follow bug fixes after feedback sessions with program ma…

### DIFF
--- a/src/components/charts/GeoViewTimeChart.js
+++ b/src/components/charts/GeoViewTimeChart.js
@@ -369,12 +369,12 @@ class GeoViewTimeChart extends Component {
             denominator = totalDenominatorByMetricPeriod[metricPeriodMonths];
           }
 
-          if (numerator === 0 || (denominator === 0 && denominatorKeys.length > 0)) {
+          if (numerator === 0 && (denominator === 0 && denominatorKeys.length > 0)) {
             return;
           }
 
           let rate = 0.0;
-          if (denominatorKeys.length > 0) {
+          if (denominator !== 0 && denominatorKeys.length > 0) {
             rate = (100 * (numerator / denominator));
           }
           const rateFixed = rate.toFixed(2);

--- a/src/components/charts/reincarcerations/AdmissionsVsReleases.js
+++ b/src/components/charts/reincarcerations/AdmissionsVsReleases.js
@@ -165,7 +165,7 @@ const AdmissionsVsReleases = (props) => {
 
   const header = document.getElementById(props.header);
 
-  if (header && mostRecentValue !== null && props.district.toUpperCase() === 'ALL') {
+  if (header && mostRecentValue !== null && props.metricType === 'counts' && props.district.toUpperCase() === 'ALL') {
     let title = '';
     if (mostRecentValue === 0) {
       title = 'The ND facilities <b style=\'color:#809AE5\'> have not changed in size</b> this month.';

--- a/src/components/charts/revocations/RevocationCountByOfficer.js
+++ b/src/components/charts/revocations/RevocationCountByOfficer.js
@@ -293,6 +293,7 @@ const RevocationCountByOfficer = (props) => {
             stacked: true,
             ticks: {
               display: displayOfficerIds,
+              autoSkip: false,
             },
           }],
           yAxes: [{

--- a/src/views/tenants/us_nd/Revocations.js
+++ b/src/views/tenants/us_nd/Revocations.js
@@ -207,6 +207,9 @@ const Revocations = () => {
                 <div className="layer w-100 pX-20 pT-20">
                   <h6 className="lh-1">
                     REVOCATIONS BY OFFICER
+                    {chartDistrict === 'all' && (
+                      <span className="pL-10 c-orange-500 ti-alert" data-toggle="tooltip" data-placement="bottom" title="Exporting this chart as an image will not include officer IDs unless a specific P&P office is selected from the Explore bar." />
+                    )}
                     <span className="fa-pull-right">
                       <div className="dropdown show">
                         <a className="btn btn-secondary btn-sm dropdown-toggle" href="#" role="button" id="exportDropdownMenuButton-revocationsByOfficer" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Description of the change

This fixes all 3 bugs from the issues listed below. For #172, it was determined that there was no way to cleanly display all officer id labels along the x-axis when no office is selected, so we added an alert icon in that case to explain that exports will not have labels until an office is selected.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #169 
Closes #171 
Closes #172 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
