### PR TITLE
Adds support for Lantern users to view all Lantern states.

### DIFF
--- a/src/components/StateSelector.js
+++ b/src/components/StateSelector.js
@@ -18,29 +18,33 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
 
-import { getStateNameForCode } from '../utils/authentication/user';
+import { getStateNameForCode, isRecidivizUser, isLanternUser } from '../utils/authentication/user';
 import {
-  getAvailableStates,
-  getCurrentStateForRecidivizUsers,
-  setCurrentStateForRecidivizUsers,
+  getAvailableStatesForAdminUser,
+  getCurrentStateForAdminUsers,
+  setCurrentStateForAdminUsers,
 } from '../views/stateViews';
 
-const StateSelector = () => {
-  const availableStateCodes = getAvailableStates();
+const StateSelector = (props) => {
+  const { user } = props;
+  const recidivizUser = isRecidivizUser(user);
+  const lanternUser = isLanternUser(user);
+
+  const availableStateCodes = getAvailableStatesForAdminUser(recidivizUser, lanternUser);
   const availableStates = availableStateCodes.map(
     (code) => ({ value: code, label: getStateNameForCode(code) }),
   );
 
   const [selectedState, setSelectedState] = useState(
     {
-      value: getCurrentStateForRecidivizUsers(),
-      label: getStateNameForCode(getCurrentStateForRecidivizUsers()),
+      value: getCurrentStateForAdminUsers(isRecidivizUser, isLanternUser),
+      label: getStateNameForCode(getCurrentStateForAdminUsers(isRecidivizUser, isLanternUser)),
     },
   );
 
   const selectState = (selectedOption) => {
     const stateCode = selectedOption.value.toLowerCase();
-    setCurrentStateForRecidivizUsers(stateCode);
+    setCurrentStateForAdminUsers(stateCode);
     setSelectedState({ value: stateCode, label: getStateNameForCode(stateCode) });
     // Refresh the entire page
     window.location.reload(false);

--- a/src/utils/authentication/user.js
+++ b/src/utils/authentication/user.js
@@ -19,6 +19,7 @@ import isDemoMode from './demoMode';
 const STATE_NAME_BY_CODE = {
   us_mo: 'Missouri',
   us_nd: 'North Dakota',
+  lantern: 'Lantern',
   recidiviz: 'Recidiviz',
 };
 
@@ -71,6 +72,14 @@ function getUserStateName(user) {
 }
 
 /**
+ * Returns whether or not the given user is a Lantern user, i.e. has access to all Lantern states.
+ */
+function isLanternUser(user) {
+  const stateCode = getUserStateCode(user);
+  return stateCode.toLowerCase() === 'lantern';
+}
+
+/**
  * Returns whether or not the given user is a Recidiviz user, i.e. has access to all states.
  */
 function isRecidivizUser(user) {
@@ -78,9 +87,18 @@ function isRecidivizUser(user) {
   return stateCode.toLowerCase() === 'recidiviz';
 }
 
+/**
+ * Returns whether or not the given user is an admin user, i.e. has access to multiple states.
+ */
+function isAdminUser(user) {
+  return isRecidivizUser(user) || isLanternUser(user);
+}
+
 export {
   getStateNameForCode,
   getUserStateCode,
   getUserStateName,
+  isLanternUser,
   isRecidivizUser,
+  isAdminUser,
 };

--- a/src/utils/authentication/viewAuthentication.js
+++ b/src/utils/authentication/viewAuthentication.js
@@ -18,7 +18,7 @@
 import isDemoMode from './demoMode';
 import { getUserStateCode } from './user';
 import {
-  getAvailableViewsForState, getCurrentStateForRecidivizUsers,
+  getAvailableViewsForState, getCurrentStateForAdminUsersFromStateCode, isAdminStateCode,
 } from '../../views/stateViews';
 
 /**
@@ -49,8 +49,8 @@ function canShowAuthenticatedView(isAuthenticated) {
  */
 function isViewAvailableForUserState(user, view) {
   const stateCode = getUserStateCode(user);
-  const normalizedCode = (stateCode.toLowerCase() === 'recidiviz')
-    ? getCurrentStateForRecidivizUsers() : stateCode.toLowerCase();
+  const normalizedCode = isAdminStateCode(stateCode)
+    ? getCurrentStateForAdminUsersFromStateCode(stateCode) : stateCode.toLowerCase();
 
   const permittedViews = getAvailableViewsForState(normalizedCode);
   if (!permittedViews) {

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -20,7 +20,7 @@ import { Container, Row, Col } from 'reactstrap';
 import Loading from '../components/Loading';
 import { useAuth0 } from '../react-auth0-spa';
 import isDemoMode from '../utils/authentication/demoMode';
-import { getUserStateName, isRecidivizUser } from '../utils/authentication/user';
+import { getUserStateName, isAdminUser } from '../utils/authentication/user';
 import { getDemoUser } from '../utils/authentication/viewAuthentication';
 import StateSelector from '../components/StateSelector';
 
@@ -52,10 +52,10 @@ const Profile = () => {
               <h2>{displayUser.name}</h2>
               <p className="lead text-muted">{displayUser.email}</p>
               <p className="lead text-muted">{getUserStateName(displayUser)}</p>
-              {isRecidivizUser(user) && (
+              {isAdminUser(user) && (
               <div style={{ maxWidth: '33%' }}>
                 <p className="lead text-muted">Current view state:</p>
-                <StateSelector />
+                <StateSelector user={user} />
               </div>
               )}
             </Col>


### PR DESCRIPTION
## Description of the change

This extends the admin-user authentication support used by Recidiviz staff to cover Lantern partners, who should have access to all Lantern states specifically.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
