### PR TITLE
Fixes the sticky top elements in IE11 and Safari.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-scripts": "3.0.1",
     "react-select": "^3.0.8",
     "react-simple-maps": "^0.12.1",
+    "react-sticky-fill": "^0.8.4",
     "react-tooltip": "^3.11.1",
     "reactstrap": "^8.0.0",
     "skycons": "^1.0.0"

--- a/src/components/toggles/ToggleBar.js
+++ b/src/components/toggles/ToggleBar.js
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import React from 'react';
+import Sticky from 'react-sticky-fill';
 
 import DistrictToggle from './DistrictToggle';
 import MetricTypeToggle from './MetricTypeToggle';
@@ -24,49 +25,49 @@ import MetricPeriodToggle from './MetricPeriodToggle';
 
 const TOGGLE_STYLE = {
   zIndex: 700,
-  position: 'sticky',
   top: 55,
 };
 
 const ToggleBar = (props) => (
-  <div className="row gap-20 pB-10" style={TOGGLE_STYLE}>
-    {/* Figure out how to make sticky top work without hiding the dropdown */}
-    <div className="col-md-12">
-      <div className="bd bgc-white p-20">
-        <div className="row">
-          {props.setChartMetricType && (
-          <div className="col-md-2">
-            <MetricTypeToggle onMetricTypeUpdate={props.setChartMetricType} />
-          </div>
-          )}
+  <Sticky style={TOGGLE_STYLE}>
+    <div className="row gap-20 pB-10">
+      <div className="col-md-12">
+        <div className="bd bgc-white p-20">
+          <div className="row">
+            {props.setChartMetricType && (
+            <div className="col-md-2">
+              <MetricTypeToggle onMetricTypeUpdate={props.setChartMetricType} />
+            </div>
+            )}
 
-          {props.setChartMetricPeriodMonths && (
-          <div className="col-md-4">
-            <MetricPeriodToggle onMetricPeriodMonthsUpdate={props.setChartMetricPeriodMonths} />
-          </div>
-          )}
+            {props.setChartMetricPeriodMonths && (
+            <div className="col-md-4">
+              <MetricPeriodToggle onMetricPeriodMonthsUpdate={props.setChartMetricPeriodMonths} />
+            </div>
+            )}
 
-          {props.setChartSupervisionType && (
-          <div className="col-md-3">
-            <SupervisionTypeToggle onSupervisionTypeUpdate={props.setChartSupervisionType} />
-          </div>
-          )}
+            {props.setChartSupervisionType && (
+            <div className="col-md-3">
+              <SupervisionTypeToggle onSupervisionTypeUpdate={props.setChartSupervisionType} />
+            </div>
+            )}
 
-          {props.setChartDistrict && (
-          <div className="col-md-2">
-            <DistrictToggle
-              districtOffices={props.districtOffices}
-              districts={props.availableDistricts}
-              onDistrictUpdate={props.setChartDistrict}
-              stateCode={props.stateCode}
-              replaceLa={props.replaceLa}
-            />
+            {props.setChartDistrict && (
+            <div className="col-md-2">
+              <DistrictToggle
+                districtOffices={props.districtOffices}
+                districts={props.availableDistricts}
+                onDistrictUpdate={props.setChartDistrict}
+                stateCode={props.stateCode}
+                replaceLa={props.replaceLa}
+              />
+            </div>
+            )}
           </div>
-          )}
         </div>
       </div>
     </div>
-  </div>
+  </Sticky>
 );
 
 export default ToggleBar;

--- a/src/utils/charts/choropleth.js
+++ b/src/utils/charts/choropleth.js
@@ -18,18 +18,49 @@ import { scaleLinear } from 'd3-scale';
 import { toHumanReadable } from '../transforms/labels';
 import { COLORS } from '../../assets/scripts/constants/colors';
 
-function colorForValue(value, maxValue, useDark) {
-  const scale = scaleLinear()
+const BLUES = ['#F5F6F7', '#9FB1E3', COLORS['blue-standard-2']];
+const DARK_BLUES = ['#CCD1DE', '#8897C4', '#1F2A3B'];
+const REDS = ['#F7F5F6', '#E39FB1', COLORS['red-standard']];
+const DARK_REDS = ['#DECCD1', '#C48897', '#3B1F2A'];
+
+function colorForValue(value, maxValue, useDark, possibleNegative) {
+  const scaleValue = possibleNegative ? Math.abs(value) : value;
+  const valueWasNegative = value < 0;
+
+  // For charts without negative values, default to using blues. If negative values can occur,
+  // use reds for positive and blues for negative, in line with convention elsewhere in the UI.
+  const positiveColors = possibleNegative ? REDS : BLUES;
+  const darkPositiveColors = possibleNegative ? DARK_REDS : DARK_BLUES;
+  const negativeColors = BLUES;
+  const darkNegativeColors = DARK_BLUES;
+
+  const positiveScale = scaleLinear()
     .domain([0, maxValue / 8, maxValue])
-    .range(['#F5F6F7', '#9FB1E3', COLORS['blue-standard-2']]);
+    .range(positiveColors);
 
-  const darkScale = scaleLinear()
+  const darkPositiveScale = scaleLinear()
     .domain([0, maxValue / 2, maxValue])
-    .range(['#CCD1DE', '#8897C4', '#1F2A3B']);
+    .range(darkPositiveColors);
 
-  const color = (useDark)
-    ? darkScale(value) : scale(value);
-  return color;
+  const negativeScale = scaleLinear()
+    .domain([0, maxValue / 8, maxValue])
+    .range(negativeColors);
+
+  const darkNegativeScale = scaleLinear()
+    .domain([0, maxValue / 2, maxValue])
+    .range(darkNegativeColors);
+
+  if (useDark) {
+    if (valueWasNegative) {
+      return darkNegativeScale(scaleValue);
+    }
+    return darkPositiveScale(scaleValue);
+  }
+
+  if (valueWasNegative) {
+    return negativeScale(scaleValue);
+  }
+  return positiveScale(scaleValue);
 }
 
 function countyNameFromCode(stateCode, countyCode) {

--- a/src/views/tenants/us_mo/Revocations.js
+++ b/src/views/tenants/us_mo/Revocations.js
@@ -17,6 +17,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Select from 'react-select';
+import Sticky from 'react-sticky-fill';
 
 import Loading from '../../../components/Loading';
 import '../../../assets/styles/index.scss';
@@ -75,7 +76,6 @@ const DEFAULT_DISTRICT = 'All';
 
 const TOGGLE_STYLE = {
   zIndex: 700,
-  position: 'sticky',
   top: 65,
 };
 
@@ -242,37 +242,39 @@ const Revocations = () => {
 
   return (
     <main className="dashboard bgc-grey-100">
-      <div className="top-level-filters d-f" style={TOGGLE_STYLE}>
-        <div className="top-level-filter">
-          <h4>Time Period</h4>
-          <Select
-            options={METRIC_PERIODS}
-            onChange={(option) => updateFilters({ metricPeriodMonths: option.value })}
-            value={METRIC_PERIODS.filter((option) => option.value === filters.metricPeriodMonths)}
-          />
+      <Sticky style={TOGGLE_STYLE}>
+        <div className="top-level-filters d-f">
+          <div className="top-level-filter">
+            <h4>Time Period</h4>
+            <Select
+              options={METRIC_PERIODS}
+              onChange={(option) => updateFilters({ metricPeriodMonths: option.value })}
+              value={METRIC_PERIODS.filter((option) => option.value === filters.metricPeriodMonths)}
+            />
+          </div>
+          <div className="top-level-filter">
+            <h4>District</h4>
+            <Select
+              options={districts}
+              onChange={(option) => updateFilters({ district: option.value })}
+            />
+          </div>
+          <div className="top-level-filter">
+            <h4>Supervision Level</h4>
+            <Select
+              options={CHARGE_CATEGORIES}
+              onChange={(option) => updateFilters({ chargeCategory: option.value })}
+            />
+          </div>
+          <div className="top-level-filter">
+            <h4>Supervision Type</h4>
+            <Select
+              options={SUPERVISION_TYPES}
+              onChange={(option) => updateFilters({ supervisionType: option.value })}
+            />
+          </div>
         </div>
-        <div className="top-level-filter">
-          <h4>District</h4>
-          <Select
-            options={districts}
-            onChange={(option) => updateFilters({ district: option.value })}
-          />
-        </div>
-        <div className="top-level-filter">
-          <h4>Supervision Level</h4>
-          <Select
-            options={CHARGE_CATEGORIES}
-            onChange={(option) => updateFilters({ chargeCategory: option.value })}
-          />
-        </div>
-        <div className="top-level-filter">
-          <h4>Supervision Type</h4>
-          <Select
-            options={SUPERVISION_TYPES}
-            onChange={(option) => updateFilters({ supervisionType: option.value })}
-          />
-        </div>
-      </div>
+      </Sticky>
       <div className="bgc-white p-20 m-20">
         <RevocationCountOverTime
           data={applyAllFilters(apiData.revocations_matrix_by_month, ['metricPeriodMonths'])}

--- a/src/views/tenants/us_nd/Reincarcerations.js
+++ b/src/views/tenants/us_nd/Reincarcerations.js
@@ -226,6 +226,7 @@ const Reincarcerations = () => {
                       metricType={chartMetricType}
                       metricPeriodMonths={chartMetricPeriodMonths}
                       keyedByOffice={false}
+                      possibleNegativeValues
                       stateCode="us_nd"
                       dataPointsByOffice={apiData.admissions_versus_releases_by_period}
                       numeratorKeys={['population_change']}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3083,6 +3083,10 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-supports@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/css-supports/-/css-supports-0.1.1.tgz#9ae201f952beb65f00c5e4b249ebce8ef58a013d"
+
 css-tree@1.0.0-alpha.29:
   version "1.0.0-alpha.29"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.29.tgz#3fa9d4ef3142cbd1c301e7664c1f352bd82f5a39"
@@ -8572,6 +8576,13 @@ react-simple-maps@^0.12.1:
     d3-geo-projection "1.2.2"
     topojson-client "2.1.0"
 
+react-sticky-fill@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/react-sticky-fill/-/react-sticky-fill-0.8.4.tgz#8870a71b1c356b5caf2c451ff0010fdfa0de6111"
+  dependencies:
+    css-supports "^0.1.1"
+    stickyfill "^1.1.1"
+
 react-tooltip@^3.11.1:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.11.1.tgz#7b4ce48ed26a46e996662b19a2afebbfd483513b"
@@ -9444,6 +9455,10 @@ stdout-stream@^1.4.0:
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
+stickyfill@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stickyfill/-/stickyfill-1.1.1.tgz#39413fee9d025c74a7e59ceecb23784cc0f17f02"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Description of the change

This ensures that the sticky top components, the toggle bars, work in IE11 and Safari, in addition to the existing support in Chrome, Firefox, Edge, etc.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #163 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
