### PR TITLE
Fixes map size in IE

### DIFF
--- a/src/components/charts/GeoViewTimeChart.js
+++ b/src/components/charts/GeoViewTimeChart.js
@@ -161,7 +161,7 @@ function toggleTooltipForCounty(
 }
 
 function colorForMarker(
-  office, maxValues, metricType, metricPeriodMonths, supervisionType, useDarkMode,
+  office, maxValues, metricType, metricPeriodMonths, supervisionType, useDarkMode, possibleNegative,
 ) {
   const supervisionTypeKey = normalizedSupervisionTypeKey(supervisionType);
 
@@ -171,7 +171,7 @@ function colorForMarker(
   }
   const maxValue = relatedMaxValue(maxValues, metricType, metricPeriodMonths, supervisionTypeKey);
 
-  return colorForValue(Math.abs(dataValue), maxValue, useDarkMode);
+  return colorForValue(dataValue, maxValue, useDarkMode, possibleNegative);
 }
 
 function sortChartDataPoints(dataPoints, metricType, metricPeriodMonths, supervisionType) {
@@ -435,6 +435,7 @@ class GeoViewTimeChart extends Component {
     const {
       metricType, metricPeriodMonths, supervisionType,
       keyedByOffice, centerLong, centerLat, chartId, stateCode,
+      possibleNegativeValues,
     } = this.props;
 
     const sortedDataPoints = sortChartDataPoints(
@@ -494,7 +495,7 @@ class GeoViewTimeChart extends Component {
                       marker={office}
                       style={{
                         default: {
-                          fill: colorForMarker(office, this.maxValues, metricType, metricPeriodMonths, supervisionType, true),
+                          fill: colorForMarker(office, this.maxValues, metricType, metricPeriodMonths, supervisionType, true, possibleNegativeValues),
                           stroke: '#F5F6F7',
                           strokeWidth: '3',
                         },
@@ -543,13 +544,13 @@ class GeoViewTimeChart extends Component {
                     projection={projection}
                     style={{
                       default: {
-                        fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, false),
+                        fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, false, possibleNegativeValues),
                         stroke: COLORS['grey-700'],
                         strokeWidth: 0.2,
                         outline: 'none',
                       },
                       hover: {
-                        fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, true),
+                        fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, true, possibleNegativeValues),
                         stroke: COLORS['grey-700'],
                         strokeWidth: 0.2,
                         outline: 'none',

--- a/src/components/charts/GeoViewTimeChart.js
+++ b/src/components/charts/GeoViewTimeChart.js
@@ -39,6 +39,20 @@ const maxMarkerRadius = 35;
 
 const METRIC_PERIODS = ['1', '3', '6', '12', '36'];
 
+const RATIO_CONTAINER_OUTER_STYLE = {
+  position: 'relative',
+  height: 0,
+  paddingBottom: '50%',
+};
+
+const RATIO_CONTAINER_INNER_STYLE = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+};
+
 function normalizedOfficeKey(officeName) {
   let normalized = toHtmlFriendly(officeName).toLowerCase();
   normalized = normalized.replace(/-/g, '_');
@@ -430,126 +444,130 @@ class GeoViewTimeChart extends Component {
     if (keyedByOffice) {
       // Show a choropleth map with colored, sized circles for P&P offices
       return (
-        <div className="map-container">
-          <ComposableMap
-            projection={geoAlbersUsa}
-            projectionConfig={{ scale: 1000 }}
-            width={980}
-            height={580}
-            style={{
-              width: '100%',
-              height: 'auto',
-            }}
-          >
-            <ZoomableGroup center={[centerLong, centerLat]} zoom={8.2}>
-              <Geographies geography={geographyObject}>
-                {(geographies, projection) => geographies.map((geography) => (
-                  <Geography
-                    key={geography.properties.NAME}
-                    geography={geography}
-                    projection={projection}
-                    style={{
-                      default: {
-                        fill: '#F5F6F7',
-                        stroke: COLORS['grey-300'],
-                        strokeWidth: 0.2,
-                        outline: 'none',
-                      },
-                      hover: {
-                        fill: '#F5F6F7',
-                        stroke: COLORS['grey-300'],
-                        strokeWidth: 0.2,
-                        outline: 'none',
-                      },
-                      pressed: {
-                        fill: '#F5F6F7',
-                        stroke: COLORS['grey-300'],
-                        strokeWidth: 0.2,
-                        outline: 'none',
-                      },
-                    }}
-                  />
-                ))
-                }
-              </Geographies>
-              <Markers>
-                {sortedDataPoints.map((office) => (
-                  <Marker
-                    key={office.officeName}
-                    marker={office}
-                    style={{
-                      default: {
-                        fill: colorForMarker(office, this.maxValues, metricType, metricPeriodMonths, supervisionType, true),
-                        stroke: '#F5F6F7',
-                        strokeWidth: '3',
-                      },
-                      hover: { fill: COLORS['blue-standard'] },
-                      pressed: { fill: COLORS['blue-standard'] },
-                    }}
-                  >
-                    <circle
-                      data-tip={toggleTooltip(office, metricType, metricPeriodMonths, supervisionType)}
-                      cx={0}
-                      cy={0}
-                      r={radiusOfMarker(office, this.maxValues, metricType, metricPeriodMonths, supervisionType)}
+        <div className="map-container" style={RATIO_CONTAINER_OUTER_STYLE}>
+          <div style={RATIO_CONTAINER_INNER_STYLE}>
+            <ComposableMap
+              projection={geoAlbersUsa}
+              projectionConfig={{ scale: 1000 }}
+              width={980}
+              height={580}
+              style={{
+                width: '100%',
+                height: 'auto',
+              }}
+            >
+              <ZoomableGroup center={[centerLong, centerLat]} zoom={8.2}>
+                <Geographies geography={geographyObject}>
+                  {(geographies, projection) => geographies.map((geography) => (
+                    <Geography
+                      key={geography.properties.NAME}
+                      geography={geography}
+                      projection={projection}
+                      style={{
+                        default: {
+                          fill: '#F5F6F7',
+                          stroke: COLORS['grey-300'],
+                          strokeWidth: 0.2,
+                          outline: 'none',
+                        },
+                        hover: {
+                          fill: '#F5F6F7',
+                          stroke: COLORS['grey-300'],
+                          strokeWidth: 0.2,
+                          outline: 'none',
+                        },
+                        pressed: {
+                          fill: '#F5F6F7',
+                          stroke: COLORS['grey-300'],
+                          strokeWidth: 0.2,
+                          outline: 'none',
+                        },
+                      }}
                     />
-                  </Marker>
-                ))}
-              </Markers>
-            </ZoomableGroup>
-          </ComposableMap>
-          <ReactTooltip />
+                  ))
+                  }
+                </Geographies>
+                <Markers>
+                  {sortedDataPoints.map((office) => (
+                    <Marker
+                      key={office.officeName}
+                      marker={office}
+                      style={{
+                        default: {
+                          fill: colorForMarker(office, this.maxValues, metricType, metricPeriodMonths, supervisionType, true),
+                          stroke: '#F5F6F7',
+                          strokeWidth: '3',
+                        },
+                        hover: { fill: COLORS['blue-standard'] },
+                        pressed: { fill: COLORS['blue-standard'] },
+                      }}
+                    >
+                      <circle
+                        data-tip={toggleTooltip(office, metricType, metricPeriodMonths, supervisionType)}
+                        cx={0}
+                        cy={0}
+                        r={radiusOfMarker(office, this.maxValues, metricType, metricPeriodMonths, supervisionType)}
+                      />
+                    </Marker>
+                  ))}
+                </Markers>
+              </ZoomableGroup>
+            </ComposableMap>
+            <ReactTooltip />
+          </div>
         </div>
       );
     }
 
     // Show just a regular choropleth, with no circles for offices
     return (
-      <div className="map-container" id={chartId}>
-        <ComposableMap
-          projection={geoAlbersUsa}
-          projectionConfig={{ scale: 1000 }}
-          width={980}
-          height={500}
-          style={{
-            width: '100%',
-            height: 'auto',
-          }}
-        >
-          <ZoomableGroup center={[centerLong, centerLat]} zoom={7} disablePanning>
-            <Geographies geography={geographyObject} disableOptimization>
-              {(geographies, projection) => geographies.map((geography) => (
-                <Geography
-                  key={geography.properties.NAME}
-                  data-tip={toggleTooltipForCounty(this.offices, geography.properties.NAME, metricType, metricPeriodMonths, supervisionType, stateCode)}
-                  geography={geography}
-                  projection={projection}
-                  style={{
-                    default: {
-                      fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, false),
-                      stroke: COLORS['grey-700'],
-                      strokeWidth: 0.2,
-                      outline: 'none',
-                    },
-                    hover: {
-                      fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, true),
-                      stroke: COLORS['grey-700'],
-                      strokeWidth: 0.2,
-                      outline: 'none',
-                    },
-                    pressed: {
-                      fill: '#CFD8DC',
-                      stroke: COLORS['grey-700'],
-                      strokeWidth: 0.2,
-                      outline: 'none',
-                    },
-                  }}
-                />
-              ))}
-            </Geographies>
-          </ZoomableGroup>
-        </ComposableMap>
-        <ReactTooltip />
+      <div id={chartId} className="map-container" style={RATIO_CONTAINER_OUTER_STYLE}>
+        <div style={RATIO_CONTAINER_INNER_STYLE}>
+          <ComposableMap
+            projection={geoAlbersUsa}
+            projectionConfig={{ scale: 1000 }}
+            width={980}
+            height={500}
+            style={{
+              width: '100%',
+              height: 'auto',
+            }}
+          >
+            <ZoomableGroup center={[centerLong, centerLat]} zoom={7} disablePanning>
+              <Geographies geography={geographyObject} disableOptimization>
+                {(geographies, projection) => geographies.map((geography) => (
+                  <Geography
+                    key={geography.properties.NAME}
+                    data-tip={toggleTooltipForCounty(this.offices, geography.properties.NAME, metricType, metricPeriodMonths, supervisionType, stateCode)}
+                    geography={geography}
+                    projection={projection}
+                    style={{
+                      default: {
+                        fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, false),
+                        stroke: COLORS['grey-700'],
+                        strokeWidth: 0.2,
+                        outline: 'none',
+                      },
+                      hover: {
+                        fill: colorForMarker(getOfficeForCounty(this.offices, geography.properties.NAME, stateCode), this.maxValues, metricType, metricPeriodMonths, supervisionType, true),
+                        stroke: COLORS['grey-700'],
+                        strokeWidth: 0.2,
+                        outline: 'none',
+                      },
+                      pressed: {
+                        fill: '#CFD8DC',
+                        stroke: COLORS['grey-700'],
+                        strokeWidth: 0.2,
+                        outline: 'none',
+                      },
+                    }}
+                  />
+                ))}
+              </Geographies>
+            </ZoomableGroup>
+          </ComposableMap>
+          <ReactTooltip />
+        </div>
       </div>
     );
   }

--- a/src/utils/charts/choropleth.js
+++ b/src/utils/charts/choropleth.js
@@ -18,18 +18,49 @@ import { scaleLinear } from 'd3-scale';
 import { toHumanReadable } from '../transforms/labels';
 import { COLORS } from '../../assets/scripts/constants/colors';
 
-function colorForValue(value, maxValue, useDark) {
-  const scale = scaleLinear()
+const BLUES = ['#F5F6F7', '#9FB1E3', COLORS['blue-standard-2']];
+const DARK_BLUES = ['#CCD1DE', '#8897C4', '#1F2A3B'];
+const REDS = ['#F7F5F6', '#E39FB1', COLORS['red-standard']];
+const DARK_REDS = ['#DECCD1', '#C48897', '#3B1F2A'];
+
+function colorForValue(value, maxValue, useDark, possibleNegative) {
+  const scaleValue = possibleNegative ? Math.abs(value) : value;
+  const valueWasNegative = value < 0;
+
+  // For charts without negative values, default to using blues. If negative values can occur,
+  // use reds for positive and blues for negative, in line with convention elsewhere in the UI.
+  const positiveColors = possibleNegative ? REDS : BLUES;
+  const darkPositiveColors = possibleNegative ? DARK_REDS : DARK_BLUES;
+  const negativeColors = BLUES;
+  const darkNegativeColors = DARK_BLUES;
+
+  const positiveScale = scaleLinear()
     .domain([0, maxValue / 8, maxValue])
-    .range(['#F5F6F7', '#9FB1E3', COLORS['blue-standard-2']]);
+    .range(positiveColors);
 
-  const darkScale = scaleLinear()
+  const darkPositiveScale = scaleLinear()
     .domain([0, maxValue / 2, maxValue])
-    .range(['#CCD1DE', '#8897C4', '#1F2A3B']);
+    .range(darkPositiveColors);
 
-  const color = (useDark)
-    ? darkScale(value) : scale(value);
-  return color;
+  const negativeScale = scaleLinear()
+    .domain([0, maxValue / 8, maxValue])
+    .range(negativeColors);
+
+  const darkNegativeScale = scaleLinear()
+    .domain([0, maxValue / 2, maxValue])
+    .range(darkNegativeColors);
+
+  if (useDark) {
+    if (valueWasNegative) {
+      return darkNegativeScale(scaleValue);
+    }
+    return darkPositiveScale(scaleValue);
+  }
+
+  if (valueWasNegative) {
+    return negativeScale(scaleValue);
+  }
+  return positiveScale(scaleValue);
 }
 
 function countyNameFromCode(stateCode, countyCode) {

--- a/src/views/tenants/us_nd/Reincarcerations.js
+++ b/src/views/tenants/us_nd/Reincarcerations.js
@@ -226,6 +226,7 @@ const Reincarcerations = () => {
                       metricType={chartMetricType}
                       metricPeriodMonths={chartMetricPeriodMonths}
                       keyedByOffice={false}
+                      possibleNegativeValues
                       stateCode="us_nd"
                       dataPointsByOffice={apiData.admissions_versus_releases_by_period}
                       numeratorKeys={['population_change']}


### PR DESCRIPTION
## Description of the change

The map-based charts have been small in IE11, relative to their expected size and their size in other browsers. This uses the [ratio container technique](https://github.com/zcreativelabs/react-simple-maps/issues/37#issuecomment-349435145) to fix the issue.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #77 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
