### PR TITLE
Lantern UI launch blockers

### DIFF
--- a/src/assets/scripts/constants/colors.js
+++ b/src/assets/scripts/constants/colors.js
@@ -277,6 +277,11 @@ const COLORS = {
   'blue-standard': '#809AE5',
   'blue-standard-2': '#3F4D62',
   'blue-standard-light': 'rgba(63, 77, 98, .7)',
+  'lantern-orange': '#F07132',
+  'lantern-light-blue': '#03A9F4',
+  'lantern-eggplant': '#5C384D',
+  'lantern-burnt-orange': '#8B2D21',
+  'lantern-blue': '#182B5E',
 };
 
 const GREYS = {
@@ -337,6 +342,15 @@ const COLORS_FIVE_VALUES_LIGHT = [
   '#fdb0a8',
 ];
 
+const COLORS_LANTERN_SET = [
+  '#F07132',
+  '#03A9F4',
+  '#5C384D',
+  '#8B2D21',
+  '#182B5E',
+  '#0E2C16',
+];
+
 export {
   COLORS,
   GREYS,
@@ -347,4 +361,5 @@ export {
   COLORS_THREE_VALUES,
   COLORS_FIVE_VALUES,
   COLORS_FIVE_VALUES_LIGHT,
+  COLORS_LANTERN_SET,
 };

--- a/src/assets/styles/spec/components/dashboard.scss
+++ b/src/assets/styles/spec/components/dashboard.scss
@@ -70,8 +70,8 @@
           background: white;
           border-radius: 25px;
           padding: 0 12px;
-          border: 1px solid rgb(240, 113, 50);
-          color: rgb(240, 113, 50);
+          border: 1px solid rgb(92, 56, 77);
+          color: rgb(92, 56, 77);
           line-height: 24px;
           font-size: 12px;
           font-weight: 600;
@@ -79,7 +79,7 @@
       }
 
       &.is-selected .violation-type-label button {
-        background: rgb(240, 113, 50);
+        background: rgb(92, 56, 77);
         color: white;
       }
 
@@ -125,7 +125,7 @@
     }
 
     .violation-sum {
-      color: rgb(247, 176, 50);
+      color: #8B2D21;
       font-size: 16px;
       font-weight: 600;
     }
@@ -150,7 +150,7 @@
     line-height: 50px;
     text-align: center;
     border-radius: 25px;
-    background: rgb(240, 113, 50);
+    background: rgb(92, 56, 77);
     color: white;
     font-weight: 600;
     margin-left: 20px;
@@ -162,8 +162,8 @@
     border-radius: 25px;
     width: 100%;
     text-align: center;
-    border: 1px solid rgb(240, 113, 50);
-    color: rgb(240, 113, 50);
+    border: 1px solid rgb(92, 56, 77);
+    color: rgb(92, 56, 77);
     line-height: 24px;
     font-size: 12px;
     font-weight: 600;

--- a/src/assets/styles/spec/components/dashboard.scss
+++ b/src/assets/styles/spec/components/dashboard.scss
@@ -205,6 +205,13 @@
   }
 }
 
+.static-chart-container {
+  position: relative;
+  margin: auto;
+  height: 60vh;
+  width: 80vw;
+}
+
 .case-table {
   table {
     width: 100%;

--- a/src/components/charts/new_revocations/RevocationMatrix.js
+++ b/src/components/charts/new_revocations/RevocationMatrix.js
@@ -187,11 +187,11 @@ const RevocationMatrix = (props) => {
         {`${getTrailingLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)} (${getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)})`}
       </h6>
       <div className="x-label pY-30">
-        Number of violation reports and notices of citations (filed within 6 months before the revocation)
+        Number of violation reports and notices of citations (filed within 12 months before the revocation)
       </div>
       <div id="revocationMatrix" className="d-f">
         <div className="y-label" data-html2canvas-ignore>
-          Most severe violation reported (within 6 months before the revocation)
+          Most severe violation reported (within 12 months before the revocation)
         </div>
         <div className={`matrix ${isFiltered ? 'is-filtered' : ''} fs-block`}>
           <div className="violation-counts">

--- a/src/components/charts/new_revocations/RevocationMatrix.js
+++ b/src/components/charts/new_revocations/RevocationMatrix.js
@@ -18,6 +18,7 @@
 import React, { useState, useEffect } from 'react';
 import ExportMenu from '../ExportMenu';
 
+import { COLORS } from '../../../assets/scripts/constants/colors';
 import {
   getPeriodLabelFromMetricPeriodMonthsToggle, getTrailingLabelFromMetricPeriodMonthsToggle,
 } from '../../../utils/charts/toggles';
@@ -117,11 +118,11 @@ const RevocationMatrix = (props) => {
       lineHeight: `${radius}px`,
     };
     const cellStyle = {
-      background: `rgba(240, 113, 50, ${ratio})`,
+      background: `rgba(92, 56, 77, ${ratio})`,
       width: '100%',
       height: '100%',
       borderRadius: Math.ceil(radius / 2),
-      color: ratio >= 0.5 ? 'white' : 'rgba(240, 113, 50)',
+      color: ratio >= 0.5 ? COLORS.white : COLORS['lantern-eggplant'],
     };
 
     return (

--- a/src/components/charts/new_revocations/RevocationsByDistrict.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict.js
@@ -99,9 +99,9 @@ const RevocationsByDistrict = (props) => {
     for (let i = 0; i < chartLabels.length; i += 1) {
       if (props.currentDistrict
         && props.currentDistrict.toLowerCase() === chartLabels[i].toLowerCase()) {
-        colors.push(COLORS['light-blue-500']);
+        colors.push(COLORS['lantern-light-blue']);
       } else {
-        colors.push(COLORS['orange-500']);
+        colors.push(COLORS['lantern-orange']);
       }
     }
     return colors;

--- a/src/components/charts/new_revocations/RevocationsByDistrict.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict.js
@@ -127,6 +127,7 @@ const RevocationsByDistrict = (props) => {
           display: false,
         },
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           xAxes: [{
             scaleLabel: {
@@ -184,7 +185,7 @@ const RevocationsByDistrict = (props) => {
         </label>
       </div>
 
-      <div className="fs-block">
+      <div className="static-chart-container fs-block">
         {chart}
       </div>
     </div>

--- a/src/components/charts/new_revocations/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender.js
@@ -118,6 +118,7 @@ const RevocationsByGender = (props) => {
           position: 'bottom',
         },
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           xAxes: [{
             scaleLabel: {
@@ -161,7 +162,7 @@ const RevocationsByGender = (props) => {
         {`${getTrailingLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)} (${getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)})`}
       </h6>
 
-      <div className="fs-block">
+      <div className="static-chart-container fs-block">
         {chart}
       </div>
     </div>

--- a/src/components/charts/new_revocations/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender.js
@@ -101,15 +101,15 @@ const RevocationsByGender = (props) => {
         labels: CHART_LABELS,
         datasets: [{
           label: 'Women',
-          backgroundColor: COLORS['light-blue-500'],
-          hoverBackgroundColor: COLORS['light-blue-500'],
-          hoverBorderColor: COLORS['light-blue-500'],
+          backgroundColor: COLORS['lantern-light-blue'],
+          hoverBackgroundColor: COLORS['lantern-light-blue'],
+          hoverBorderColor: COLORS['lantern-light-blue'],
           data: chartDataPoints[0],
         }, {
           label: 'Men',
-          backgroundColor: COLORS['orange-500'],
-          hoverBackgroundColor: COLORS['orange-500'],
-          hoverBorderColor: COLORS['orange-500'],
+          backgroundColor: COLORS['lantern-orange'],
+          hoverBackgroundColor: COLORS['lantern-orange'],
+          hoverBorderColor: COLORS['lantern-orange'],
           data: chartDataPoints[1],
         }],
       }}

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -141,6 +141,7 @@ const RevocationsByRace = (props) => {
           position: 'bottom',
         },
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           xAxes: [{
             scaleLabel: {
@@ -184,7 +185,7 @@ const RevocationsByRace = (props) => {
         {`${getTrailingLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)} (${getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)})`}
       </h6>
 
-      <div className="fs-block">
+      <div className="static-chart-container fs-block">
         {chart}
       </div>
     </div>

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -19,7 +19,7 @@ import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import ExportMenu from '../ExportMenu';
 
-import { COLORS } from '../../../assets/scripts/constants/colors';
+import { COLORS, COLORS_LANTERN_SET } from '../../../assets/scripts/constants/colors';
 import {
   getTrailingLabelFromMetricPeriodMonthsToggle, getPeriodLabelFromMetricPeriodMonthsToggle,
   tooltipForRateMetricWithNestedCounts,
@@ -100,39 +100,39 @@ const RevocationsByRace = (props) => {
         labels: CHART_LABELS,
         datasets: [{
           label: 'Caucasian',
-          backgroundColor: COLORS['light-blue-600'],
-          hoverBackgroundColor: COLORS['light-blue-600'],
-          hoverBorderColor: COLORS['light-blue-600'],
+          backgroundColor: COLORS_LANTERN_SET[0],
+          hoverBackgroundColor: COLORS_LANTERN_SET[0],
+          hoverBorderColor: COLORS_LANTERN_SET[0],
           data: chartDataPoints[0],
         }, {
           label: 'African American',
-          backgroundColor: COLORS['light-blue-500'],
-          hoverBackgroundColor: COLORS['light-blue-500'],
-          hoverBorderColor: COLORS['light-blue-500'],
+          backgroundColor: COLORS_LANTERN_SET[1],
+          hoverBackgroundColor: COLORS_LANTERN_SET[1],
+          hoverBorderColor: COLORS_LANTERN_SET[1],
           data: chartDataPoints[1],
         }, {
           label: 'Hispanic',
-          backgroundColor: COLORS['light-blue-400'],
-          hoverBackgroundColor: COLORS['light-blue-400'],
-          hoverBorderColor: COLORS['light-blue-400'],
+          backgroundColor: COLORS_LANTERN_SET[2],
+          hoverBackgroundColor: COLORS_LANTERN_SET[2],
+          hoverBorderColor: COLORS_LANTERN_SET[2],
           data: chartDataPoints[2],
         }, {
           label: 'Asian',
-          backgroundColor: COLORS['light-blue-300'],
-          hoverBackgroundColor: COLORS['light-blue-300'],
-          hoverBorderColor: COLORS['light-blue-300'],
+          backgroundColor: COLORS_LANTERN_SET[3],
+          hoverBackgroundColor: COLORS_LANTERN_SET[3],
+          hoverBorderColor: COLORS_LANTERN_SET[3],
           data: chartDataPoints[3],
         }, {
           label: 'Native American',
-          backgroundColor: COLORS['light-blue-200'],
-          hoverBackgroundColor: COLORS['light-blue-200'],
-          hoverBorderColor: COLORS['light-blue-200'],
+          backgroundColor: COLORS_LANTERN_SET[4],
+          hoverBackgroundColor: COLORS_LANTERN_SET[4],
+          hoverBorderColor: COLORS_LANTERN_SET[4],
           data: chartDataPoints[4],
         }, {
           label: 'Pacific Islander',
-          backgroundColor: COLORS['light-blue-100'],
-          hoverBackgroundColor: COLORS['light-blue-100'],
-          hoverBorderColor: COLORS['light-blue-100'],
+          backgroundColor: COLORS_LANTERN_SET[5],
+          hoverBackgroundColor: COLORS_LANTERN_SET[5],
+          hoverBorderColor: COLORS_LANTERN_SET[5],
           data: chartDataPoints[5],
         }],
       }}

--- a/src/components/charts/new_revocations/RevocationsByRiskLevel.js
+++ b/src/components/charts/new_revocations/RevocationsByRiskLevel.js
@@ -101,6 +101,7 @@ const RevocationsByRiskLevel = (props) => {
           display: false,
         },
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           xAxes: [{
             scaleLabel: {
@@ -146,7 +147,7 @@ const RevocationsByRiskLevel = (props) => {
         {`${getTrailingLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)} (${getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)})`}
       </h6>
 
-      <div className="fs-block">
+      <div className="static-chart-container fs-block">
         {chart}
       </div>
     </div>

--- a/src/components/charts/new_revocations/RevocationsByRiskLevel.js
+++ b/src/components/charts/new_revocations/RevocationsByRiskLevel.js
@@ -90,9 +90,9 @@ const RevocationsByRiskLevel = (props) => {
         labels: chartLabels,
         datasets: [{
           label: 'Revocation rate',
-          backgroundColor: COLORS['orange-500'],
-          hoverBackgroundColor: COLORS['orange-500'],
-          hoverBorderColor: COLORS['orange-500'],
+          backgroundColor: COLORS['lantern-orange'],
+          hoverBackgroundColor: COLORS['lantern-orange'],
+          hoverBorderColor: COLORS['lantern-orange'],
           data: chartDataPoints,
         }],
       }}

--- a/src/components/charts/new_revocations/RevocationsByViolation.js
+++ b/src/components/charts/new_revocations/RevocationsByViolation.js
@@ -130,6 +130,7 @@ const RevocationsByViolation = (props) => {
           display: false,
         },
         responsive: true,
+        maintainAspectRatio: false,
         scales: {
           xAxes: [{
             scaleLabel: {
@@ -175,7 +176,7 @@ const RevocationsByViolation = (props) => {
         {`${getTrailingLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)} (${getPeriodLabelFromMetricPeriodMonthsToggle(props.metricPeriodMonths)})`}
       </h6>
 
-      <div className="fs-block">
+      <div className="static-chart-container fs-block">
         {chart}
       </div>
     </div>

--- a/src/components/charts/new_revocations/RevocationsByViolation.js
+++ b/src/components/charts/new_revocations/RevocationsByViolation.js
@@ -100,10 +100,10 @@ const RevocationsByViolation = (props) => {
   const colorTechnicalAndLaw = () => {
     const colors = [];
     for (let i = 0; i < technicalViolationTypes.length; i += 1) {
-      colors.push(COLORS['light-blue-500']);
+      colors.push(COLORS['lantern-light-blue']);
     }
     for (let i = 0; i < lawViolationTypes.length; i += 1) {
-      colors.push(COLORS['orange-500']);
+      colors.push(COLORS['lantern-orange']);
     }
     return colors;
   };

--- a/src/components/charts/new_revocations/RevocationsByViolation.js
+++ b/src/components/charts/new_revocations/RevocationsByViolation.js
@@ -118,7 +118,7 @@ const RevocationsByViolation = (props) => {
       data={{
         labels: chartLabels,
         datasets: [{
-          label: 'Revocations',
+          label: 'Proportion of violations',
           backgroundColor: colorTechnicalAndLaw(),
           hoverBackgroundColor: colorTechnicalAndLaw(),
           hoverBorderColor: colorTechnicalAndLaw(),

--- a/src/components/charts/new_revocations/RevocationsOverTime.js
+++ b/src/components/charts/new_revocations/RevocationsOverTime.js
@@ -25,7 +25,7 @@ import {
   centerSingleMonthDatasetIfNecessary,
 } from '../../../utils/charts/toggles';
 import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/transforms/datasets';
-import { toInt } from '../../../utils/transforms/labels';
+import { toInt, labelCurrentMonth } from '../../../utils/transforms/labels';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/transforms/months';
 
 const RevocationsOverTime = (props) => {
@@ -70,8 +70,8 @@ const RevocationsOverTime = (props) => {
 
   const datasets = [{
     label: 'Revocations',
-    borderColor: COLORS['light-blue-500'],
-    pointBackgroundColor: COLORS['light-blue-500'],
+    borderColor: COLORS['lantern-light-blue'],
+    pointBackgroundColor: COLORS['lantern-light-blue'],
     fill: false,
     lineTension: 0,
     borderWidth: 2,
@@ -95,6 +95,7 @@ const RevocationsOverTime = (props) => {
           xAxes: [{
             ticks: {
               autoSkip: false,
+              callback: labelCurrentMonth,
             },
           }],
           yAxes: [{

--- a/src/components/charts/new_revocations/RevocationsOverTime.js
+++ b/src/components/charts/new_revocations/RevocationsOverTime.js
@@ -20,12 +20,13 @@ import { Line } from 'react-chartjs-2';
 import ExportMenu from '../ExportMenu';
 
 import { COLORS } from '../../../assets/scripts/constants/colors';
+import { labelCurrentMonth, currentMonthBox } from '../../../utils/charts/currentSpan';
 import {
   getMonthCountFromMetricPeriodMonthsToggle, getTrailingLabelFromMetricPeriodMonthsToggle,
   centerSingleMonthDatasetIfNecessary,
 } from '../../../utils/charts/toggles';
 import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/transforms/datasets';
-import { toInt, labelCurrentMonth } from '../../../utils/transforms/labels';
+import { toInt } from '../../../utils/transforms/labels';
 import { monthNamesWithYearsFromNumbers } from '../../../utils/transforms/months';
 
 const RevocationsOverTime = (props) => {
@@ -95,7 +96,6 @@ const RevocationsOverTime = (props) => {
           xAxes: [{
             ticks: {
               autoSkip: false,
-              callback: labelCurrentMonth,
             },
           }],
           yAxes: [{
@@ -111,7 +111,11 @@ const RevocationsOverTime = (props) => {
         tooltips: {
           backgroundColor: COLORS['grey-800-light'],
           mode: 'x',
+          callbacks: {
+            title: (tooltipItem) => labelCurrentMonth(tooltipItem, chartLabels),
+          },
         },
+        annotation: currentMonthBox('currentMonthBoxRevocationsOverTime', chartLabels),
       }}
     />
   );

--- a/src/utils/charts/currentSpan.js
+++ b/src/utils/charts/currentSpan.js
@@ -1,0 +1,78 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { COLORS } from '../../assets/scripts/constants/colors';
+import { getCurrentMonthName } from '../transforms/months';
+
+function labelCurrentMonth(tooltipItems, labels) {
+  const tooltipItem = tooltipItems[0];
+  const { index, xLabel: label } = tooltipItem;
+
+  const onlyMonthInSet = !labels[0] && !labels[labels.length - 1] && index === 1;
+  const lastMonthInSet = index === labels.length - 1;
+  const currentMonth = getCurrentMonthName();
+
+  if ((lastMonthInSet || onlyMonthInSet) && label && label.startsWith(currentMonth)) {
+    return `${label} (in progress)`;
+  }
+
+  return label;
+}
+
+function currentMonthBox(annotationId, chartLabels) {
+  if (chartLabels.length < 2) {
+    return null;
+  }
+
+  const currentMonth = getCurrentMonthName();
+  const lastMonthInChart = chartLabels[chartLabels.length - 1];
+
+  if (!lastMonthInChart.startsWith(currentMonth)) {
+    return null;
+  }
+
+  const previousMonthTick = chartLabels[chartLabels.length - 2];
+  return {
+    drawTime: 'beforeDatasetsDraw',
+    events: ['click'],
+
+    // Array of annotation configuration objects
+    // See below for detailed descriptions of the annotation options
+    annotations: [{
+      type: 'box',
+
+      // optional annotation ID (must be unique)
+      id: annotationId,
+      xScaleID: 'x-axis-0',
+
+      drawTime: 'beforeDatasetsDraw',
+
+      borderColor: COLORS['grey-300'],
+      borderWidth: 1,
+      backgroundColor: 'rgba(224, 224, 224, 0.5)',
+
+      xMin: previousMonthTick,
+
+      onClick(e) { return e; },
+    }],
+  };
+}
+
+export {
+  labelCurrentMonth,
+  currentMonthBox,
+};

--- a/src/utils/charts/info.js
+++ b/src/utils/charts/info.js
@@ -40,7 +40,7 @@ const chartIdToInfo = {
       header: 'What this chart shows',
       body: `This chart plots all people who were revoked to prison during the time period
         selected by the user, according to their most serious violation and the number of
-        violation reports and notices of citation filed within 6 months before the revocation.
+        violation reports and notices of citation filed within 12 months before the revocation.
         The user can select the time period for revocations included in the chart by using the
         drop down menu in the upper left hand corner of the page.`,
     },
@@ -48,7 +48,7 @@ const chartIdToInfo = {
       header: 'Most serious violation',
       body: `Violations are listed in order of severity, starting with the least serious violation
         in the top row. A person's most serious violation is calculated by looking back at all
-        violation reports and notices of citation filed within 6 months before the revocation and
+        violation reports and notices of citation filed within 12 months before the revocation and
         identifying the most serious violation listed in those reports. The most serious violation
         determines what row a person is placed in, regardless of whether it was the most recent
         violation. For example, if a person had one misdemeanor violation, then two technical
@@ -58,8 +58,8 @@ const chartIdToInfo = {
     {
       header: 'Number of violation reports and notices of citation filed',
       body: `This is determined by counting the total number of violation reports and notices of
-        citation that were filed within 6 months before the revocation. For example, if a person
-        had one violation report and one notice of citation during the 6 months before the
+        citation that were filed within 12 months before the revocation. For example, if a person
+        had one violation report and one notice of citation during the 12 months before the
         revocation, they would be in the “2” column. This is so even if the violation report listed
         several types of violations or conditions violated.`,
     },
@@ -140,7 +140,7 @@ const chartIdToInfo = {
         violation was a technical, divided by the total number of people whose most serious
         violation was a technical, including those who were not revoked. In calculating the number
         of people who were not revoked whose most serious violation was a technical, we look back
-        for the same 6 month period as used to determine most serious violation in the revocations
+        for the same 12 month period as used to determine most serious violation in the revocations
         plot, from either the current date (if the person is still on supervision) or the date that
         the person was discharged from supervision.`,
     },
@@ -149,7 +149,7 @@ const chartIdToInfo = {
     {
       header: 'What this chart shows',
       body: `This chart shows the relative frequency of each type of violation for people who were
-        revoked to prison, looking back over a period 6 months before the revocation. This is
+        revoked to prison, looking back over a period 12 months before the revocation. This is
         calculated as the total number of times each type of violation was reported on all notices
         of citation and violation reports filed during that period, divided by the total number of
         notices of citation and violation reports filed during that period. For this chart, if
@@ -204,7 +204,7 @@ const chartIdToInfo = {
         violation was a technical, divided by the total number of people whose most serious
         violation was a technical, including those who were not revoked. In calculating the number
         of people who were not revoked whose most serious violation was a technical, we look back
-        for the same 6 month period as used to determine most serious violation in the revocations
+        for the same 12 month period as used to determine most serious violation in the revocations
         plot, from either the current date (if the person is still on supervision) or the date that
         the person was discharged from supervision.`,
     },
@@ -243,7 +243,7 @@ const chartIdToInfo = {
         violation was a technical, divided by the total number of people whose most serious
         violation was a technical, including those who were not revoked. In calculating the number
         of people who were not revoked whose most serious violation was a technical, we look back
-        for the same 6 month period as used to determine most serious violation in the revocations
+        for the same 12 month period as used to determine most serious violation in the revocations
         plot, from either the current date (if the person is still on supervision) or the date that
         the person was discharged from supervision.`,
     },

--- a/src/utils/transforms/labels.js
+++ b/src/utils/transforms/labels.js
@@ -15,8 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { getCurrentMonthName } from './months';
-
 const riskLevelValuetoLabel = {
   NOT_ASSESSED: 'Not Assessed',
   LOW: 'Low',
@@ -125,17 +123,6 @@ function nameFromOfficerId(officerId) {
   return parts[1].trim();
 }
 
-function labelCurrentMonth(value, index, values) {
-  const onlyMonthInSet = !values[0] && !values[values.length - 1] && index === 1;
-  const lastMonthInSet = index === values.length - 1;
-
-  const currentMonth = getCurrentMonthName();
-  if ((lastMonthInSet || onlyMonthInSet) && value.startsWith(currentMonth)) {
-    return `${value} (now)`;
-  }
-  return value;
-}
-
 export {
   riskLevelValuetoLabel,
   violationTypeToLabel,
@@ -150,5 +137,4 @@ export {
   humanReadableTitleCase,
   numberFromOfficerId,
   nameFromOfficerId,
-  labelCurrentMonth,
 };

--- a/src/utils/transforms/labels.js
+++ b/src/utils/transforms/labels.js
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { getCurrentMonthName } from './months';
+
 const riskLevelValuetoLabel = {
   NOT_ASSESSED: 'Not Assessed',
   LOW: 'Low',
@@ -123,6 +125,17 @@ function nameFromOfficerId(officerId) {
   return parts[1].trim();
 }
 
+function labelCurrentMonth(value, index, values) {
+  const onlyMonthInSet = !values[0] && !values[values.length - 1] && index === 1;
+  const lastMonthInSet = index === values.length - 1;
+
+  const currentMonth = getCurrentMonthName();
+  if ((lastMonthInSet || onlyMonthInSet) && value.startsWith(currentMonth)) {
+    return `${value} (now)`;
+  }
+  return value;
+}
+
 export {
   riskLevelValuetoLabel,
   violationTypeToLabel,
@@ -137,4 +150,5 @@ export {
   humanReadableTitleCase,
   numberFromOfficerId,
   nameFromOfficerId,
+  labelCurrentMonth,
 };

--- a/src/utils/transforms/months.js
+++ b/src/utils/transforms/months.js
@@ -23,6 +23,12 @@ const MONTH_NAMES_ABBREVIATED = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ];
 
+const getCurrentMonthName = function getCurrentMonthName() {
+  const now = new Date();
+  const thisMonth = now.getMonth();
+  return MONTH_NAMES[thisMonth];
+};
+
 const monthNameFromNumber = function monthNameFromNumber(number) {
   return MONTH_NAMES[number - 1];
 };
@@ -83,6 +89,7 @@ const monthNamesFromShortName = function monthNamesFromShortName(shortName) {
 };
 
 export {
+  getCurrentMonthName,
   monthNameFromNumber,
   monthNameFromNumberAbbreviated,
   monthNamesFromNumbers,

--- a/src/views/tenants/us_mo/Revocations.js
+++ b/src/views/tenants/us_mo/Revocations.js
@@ -295,7 +295,7 @@ const Revocations = () => {
           <p className="fw-300">
             This chart plots all people who were revoked to prison during the selected time period,
             according to their most serious violation and the total number of violation reports and
-            notices of citation filed within 6 months before revocation.
+            notices of citation filed within 12 months before revocation.
           </p>
           <p className="fw-300">
             The numbers inside the bubbles represent the number of people who were revoked, whose


### PR DESCRIPTION
## Description of the change

Addresses three launch blockers for the revocation analysis matrix tool:
- Makes the color scheme significantly more accessible
- Makes the static charts below the matrix more easily viewable by holding their size as a relative proportion of the viewport
- Adds a new visual treatment for the current month in progress for month-over-month charts

This is all still pending design review.

This replaces #202.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #190 
Closes #191 
Closes #192 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
