### PR TITLE
Adds a quick check to ensure we don't add future months or years to m…

### DIFF
--- a/src/utils/transforms/datasets.js
+++ b/src/utils/transforms/datasets.js
@@ -82,6 +82,8 @@ function sortAndFilterMostRecentMonths(unsortedDataPoints, monthCount) {
  */
 function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
   const now = new Date();
+  const nowYear = now.getYear();
+  const nowMonth = now.getMonth();
   const thisMonth = now.getMonth() + 1;
 
   const representedMonths = {};
@@ -100,10 +102,11 @@ function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
     const month = (remainder === 0) ? 12 : remainder;
 
     const monthsAgo = new Date(now.getTime());
-    monthsAgo.setMonth(now.getMonth() + i - 2);
+    monthsAgo.setMonth(nowMonth + i - 2);
     const year = monthsAgo.getFullYear();
 
-    if (!representedMonths[year] || !representedMonths[year][month]) {
+    if ((!representedMonths[year] || !representedMonths[year][month])
+      && year <= nowYear && month <= nowMonth) {
       const monthData = {
         year: year.toString(),
         month: month.toString(),


### PR DESCRIPTION
## Description of the change

This doesn't change any underlying arithmetic but ensures that the gap-filling logic doesn't try to fill fake gaps for months that haven't occurred yet. Tested locally pointing to production data.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
