### PR TITLE
Fixing date math bug causing the wrong months to appear in charts

### DIFF
--- a/src/utils/transforms/datasets.js
+++ b/src/utils/transforms/datasets.js
@@ -82,8 +82,6 @@ function sortAndFilterMostRecentMonths(unsortedDataPoints, monthCount) {
  */
 function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
   const now = new Date();
-  const nowYear = now.getYear();
-  const nowMonth = now.getMonth();
   const thisMonth = now.getMonth() + 1;
 
   const representedMonths = {};
@@ -101,12 +99,15 @@ function addEmptyMonthsToData(dataPoints, monthCount, valueKey, emptyValue) {
     const remainder = ((i % 12) + 12) % 12;
     const month = (remainder === 0) ? 12 : remainder;
 
-    const monthsAgo = new Date(now.getTime());
-    monthsAgo.setMonth(nowMonth + i - 2);
-    const year = monthsAgo.getFullYear();
+    const dateMonthsAgo = new Date(now.getTime());
+    dateMonthsAgo.setMonth(i - 1);
+    const year = dateMonthsAgo.getFullYear();
 
-    if ((!representedMonths[year] || !representedMonths[year][month])
-      && year <= nowYear && month <= nowMonth) {
+    if (dateMonthsAgo.getMonth() !== (month - 1)) {
+      console.error(`Month mismatch: month=${month}, dateMonthsAgo=${dateMonthsAgo}`);
+    }
+
+    if (!representedMonths[year] || !representedMonths[year][month]) {
       const monthData = {
         year: year.toString(),
         month: month.toString(),


### PR DESCRIPTION
## Description of the change

Fixes a bug in the math used to identify which months were being shown in a chart. Adds a new error statement that will catch this issue in the future.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Lint rules pass locally
- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
