### PR TITLE
Consolidate demo mode logic to the Auth0 context provider + fix a few bugs in the process

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -20,15 +20,13 @@ import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 
 import { useAuth0 } from '../react-auth0-spa';
-import isDemoMode from '../utils/authentication/demoMode';
-import { canShowAuthenticatedView } from '../utils/authentication/viewAuthentication';
 
 const PrivateRoute = ({ component: Component, path, ...rest }) => {
   const { isAuthenticated, loginWithRedirect } = useAuth0();
 
   useEffect(() => {
     const fn = async () => {
-      if (!canShowAuthenticatedView(isAuthenticated)) {
+      if (!isAuthenticated) {
         await loginWithRedirect({
           appState: { targetUrl: path },
         });
@@ -37,10 +35,9 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     fn();
   }, [isAuthenticated, loginWithRedirect, path]);
 
-  if (!canShowAuthenticatedView(isAuthenticated)) return null;
+  if (!isAuthenticated) return null;
 
-  const render = (props) => (isAuthenticated === true || isDemoMode() === true
-    ? <Component {...props} /> : null);
+  const render = (props) => isAuthenticated === true ? <Component {...props} /> : null;
   return <Route path={path} render={render} {...rest} />;
 };
 

--- a/src/components/PrivateTenantRoute.js
+++ b/src/components/PrivateTenantRoute.js
@@ -20,11 +20,8 @@ import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 
 import { useAuth0 } from '../react-auth0-spa';
-import isDemoMode from '../utils/authentication/demoMode';
 import { getUserStateCode } from '../utils/authentication/user';
-import {
-  canShowAuthenticatedView, isViewAvailableForUserState
-} from '../utils/authentication/viewAuthentication';
+import { isViewAvailableForUserState } from '../utils/authentication/viewAuthentication';
 import { getComponentForStateView } from '../views/stateViews';
 import NotFound from '../views/NotFound';
 
@@ -33,7 +30,7 @@ const PrivateTenantRoute = ({ path, ...rest }) => {
 
   useEffect(() => {
     const fn = async () => {
-      if (!canShowAuthenticatedView(isAuthenticated)) {
+      if (!isAuthenticated) {
         await loginWithRedirect({
           appState: { targetUrl: path },
         });
@@ -42,9 +39,7 @@ const PrivateTenantRoute = ({ path, ...rest }) => {
     fn();
   }, [isAuthenticated, loginWithRedirect, path]);
 
-  if (!canShowAuthenticatedView(isAuthenticated)) {
-    return null;
-  }
+  if (!isAuthenticated) return null;
 
   let render = null;
   if (!isViewAvailableForUserState(user, path)) {
@@ -54,8 +49,7 @@ const PrivateTenantRoute = ({ path, ...rest }) => {
     // Else, grab the correct component for that view for their state and send them to it
     const stateCode = getUserStateCode(user);
     const Component = getComponentForStateView(stateCode, path);
-    render = (props) => (isAuthenticated === true || isDemoMode() === true
-      ? <Component {...props} /> : null);
+    render = (props) => isAuthenticated === true ? <Component {...props} /> : null;
   }
 
   return <Route path={path} render={render} {...rest} />;

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -20,11 +20,7 @@ import React from 'react';
 import { useAuth0 } from '../react-auth0-spa';
 import { normalizeAppPathToTitle } from '../assets/scripts/utils/strings';
 import lanternLogo from '../assets/static/images/lantern_logo.png';
-import isDemoMode from '../utils/authentication/demoMode';
 import { getUserStateCode, getUserStateName } from '../utils/authentication/user';
-import {
-  canShowAuthenticatedView, getDemoUser,
-} from '../utils/authentication/viewAuthentication';
 import { hasSideBar } from '../utils/layout/filters';
 import { isLanternState } from '../views/stateViews';
 
@@ -67,11 +63,6 @@ const TopBar = (props) => {
     navBarClass = 'header navbar';
   }
 
-  let displayUser = user;
-  if (isDemoMode()) {
-    displayUser = getDemoUser();
-  }
-
   return (
     <div className={navBarClass}>
       <div className="header-container">
@@ -81,7 +72,7 @@ const TopBar = (props) => {
           </a>
         ) : (
           <ul className="nav-left">
-            {canShowAuthenticatedView(isAuthenticated) && (
+            {isAuthenticated && (
             <li>
               <a id="sidebar-toggle" className="sidebar-toggle" href="javascript:void(0);">
                 <i className="ti-menu" />
@@ -94,7 +85,7 @@ const TopBar = (props) => {
           </ul>
         )}
         <ul className="nav-right">
-          {!canShowAuthenticatedView(isAuthenticated) && (
+          {!isAuthenticated && (
             <li className="dropdown">
               <a href="#" onClick={() => loginWithRedirect({ appState: { targetUrl: '/snapshots' } })} className="dropdown-toggle no-after peers fxw-nw ai-c lh-1" data-toggle="dropdown">
                 <div className="peer mR-10">
@@ -106,15 +97,15 @@ const TopBar = (props) => {
               </a>
             </li>
           )}
-          {canShowAuthenticatedView(isAuthenticated) && (
+          {isAuthenticated && (
             <li className="dropdown">
               <a href="#" className="dropdown-toggle no-after peers fxw-nw ai-c lh-1" data-toggle="dropdown">
                 <div className="peer mR-10">
-                  <img className="w-2r bdrs-50p" src={displayUser.picture} alt="" />
+                  <img className="w-2r bdrs-50p" src={user.picture} alt="" />
                 </div>
                 <div className="peer">
-                  <ul className="fsz-sm c-grey-900">{displayUser.name}</ul>
-                  <ul className="fsz-sm pT-3 c-grey-600">{getUserStateName(displayUser)}</ul>
+                  <ul className="fsz-sm c-grey-900">{user.name}</ul>
+                  <ul className="fsz-sm pT-3 c-grey-600">{getUserStateName(user)}</ul>
                 </div>
               </a>
               <ul className="dropdown-menu fsz-sm">

--- a/src/utils/authentication/user.js
+++ b/src/utils/authentication/user.js
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import isDemoMode from './demoMode';
 
 const STATE_NAME_BY_CODE = {
   us_mo: 'Missouri',
@@ -43,14 +42,9 @@ function getStateNameForCode(stateCode) {
 
 /**
  * Returns the state code of the authorized state for the given user.
- * For Recidiviz users, this will be 'recidiviz'. In demo mode, all users can be considered
- * Recidiviz users since no data is exposed.
+ * For Recidiviz users or users in demo mode, this will be 'recidiviz'.
  */
 function getUserStateCode(user) {
-  if (isDemoMode()) {
-    return 'recidiviz';
-  }
-
   const appMetadata = getUserAppMetadata(user);
   if (!appMetadata) {
     throw Error('No app_metadata available for user');

--- a/src/utils/authentication/viewAuthentication.js
+++ b/src/utils/authentication/viewAuthentication.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import isDemoMode from './demoMode';
 import { getUserStateCode } from './user';
 import {
   getAvailableViewsForState, getCurrentStateForAdminUsersFromStateCode, isAdminStateCode,
@@ -33,14 +32,6 @@ function getDemoUser() {
       state_code: 'RECIDIVIZ',
     },
   };
-}
-
-/**
- * A view that requires authentication can be shown if the user is authenticated
- * or if we are in demo mode.
- */
-function canShowAuthenticatedView(isAuthenticated) {
-  return isAuthenticated || isDemoMode();
 }
 
 /**
@@ -63,6 +54,5 @@ function isViewAvailableForUserState(user, view) {
 
 export {
   getDemoUser,
-  canShowAuthenticatedView,
   isViewAvailableForUserState,
 };

--- a/src/utils/layout/filters.js
+++ b/src/utils/layout/filters.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { canShowAuthenticatedView } from '../authentication/viewAuthentication';
 import { isLanternState } from '../../views/stateViews';
 
 /**
@@ -23,7 +22,7 @@ import { isLanternState } from '../../views/stateViews';
  * if the view has a side bar.
  */
 function hasSideBar(stateCode, isAuthenticated) {
-  return canShowAuthenticatedView(isAuthenticated) && !isLanternState(stateCode);
+  return isAuthenticated && !isLanternState(stateCode);
 }
 
 export {

--- a/src/utils/metricsClient.js
+++ b/src/utils/metricsClient.js
@@ -15,20 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import isDemoMode from './authentication/demoMode';
-
 /**
  * An asynchronous function that returns a promise which will eventually return the results from
  * invoking the given API endpoint. Takes in the |endpoint| as a string and the |getTokenSilently|
- * function, which will be used to authenticate the client against the API, if we are not in demo
- * mode where authentication is not required.
+ * function, which will be used to authenticate the client against the API.
  */
 async function callMetricsApi(endpoint, getTokenSilently) {
   try {
-    let token = '';
-    if (!isDemoMode()) {
-      token = await getTokenSilently();
-    }
+    const token = await getTokenSilently();
+
     const response = await fetch(`${process.env.REACT_APP_API_URL}/api/${endpoint}`, {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -46,10 +41,10 @@ async function callMetricsApi(endpoint, getTokenSilently) {
 /**
  * A convenience function returning whether or not the client is still awaiting what it needs to
  * display results to the user. We are ready if we are no longer loading the view, if we are no
- * longer awaiting the API, and if we either have an authenticated user or we are in demo mode.
+ * longer awaiting the API, and if we have an authenticated user.
  */
 function awaitingResults(loading, user, awaitingApi) {
-  return loading || (!user && !isDemoMode()) || awaitingApi;
+  return loading || !user || awaitingApi;
 }
 
 export {

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -19,20 +19,13 @@ import React from 'react';
 import { Container, Row, Col } from 'reactstrap';
 import Loading from '../components/Loading';
 import { useAuth0 } from '../react-auth0-spa';
-import isDemoMode from '../utils/authentication/demoMode';
 import { getUserStateName, isAdminUser } from '../utils/authentication/user';
-import { getDemoUser } from '../utils/authentication/viewAuthentication';
 import StateSelector from '../components/StateSelector';
 
 const Profile = () => {
   const { loading, user } = useAuth0();
 
-  let displayUser = user;
-  if (isDemoMode()) {
-    displayUser = getDemoUser();
-  }
-
-  if (loading || (!user && !isDemoMode())) {
+  if (loading || !user) {
     return <Loading />;
   }
 
@@ -43,15 +36,15 @@ const Profile = () => {
           <Row className="align-items-center profile-header mb-5 text-center text-md-left">
             <Col md={2}>
               <img
-                src={displayUser.picture}
+                src={user.picture}
                 alt="Profile"
                 className="rounded-circle img-fluid profile-picture mb-3 mb-md-0"
               />
             </Col>
             <Col md>
-              <h2>{displayUser.name}</h2>
-              <p className="lead text-muted">{displayUser.email}</p>
-              <p className="lead text-muted">{getUserStateName(displayUser)}</p>
+              <h2>{user.name}</h2>
+              <p className="lead text-muted">{user.email}</p>
+              <p className="lead text-muted">{getUserStateName(user)}</p>
               {isAdminUser(user) && (
               <div style={{ maxWidth: '33%' }}>
                 <p className="lead text-muted">Current view state:</p>


### PR DESCRIPTION
## Description of the change

This change consolidates demo mode logic (override of authentication status, user, etc.) to the Auth0 context provider in `react-auth0-spa.js`, so that most frontend code no longer needs to check whether or not the app is running in demo mode. This simplification also fixes the bugs described in https://github.com/Recidiviz/pulse-dashboard/issues/201.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#201]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
