### PR TITLE
Added right padding to modal-body

### DIFF
--- a/src/assets/styles/spec/components/dashboard.scss
+++ b/src/assets/styles/spec/components/dashboard.scss
@@ -174,6 +174,7 @@
   ul {
     font-size: 14px;
     font-weight: normal;
+    padding-right: 40px;
   }
 }
 


### PR DESCRIPTION
## Description of the change

Added right padding to modal window, set it as 40px, like from the other side.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #217

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Lint rules pass locally
- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
