### PR TITLE
Fixes the current month annotation box in the 3-year view 

### DIFF
--- a/src/components/charts/new_revocations/RevocationsOverTime.js
+++ b/src/components/charts/new_revocations/RevocationsOverTime.js
@@ -27,7 +27,7 @@ import {
 } from '../../../utils/charts/toggles';
 import { sortFilterAndSupplementMostRecentMonths } from '../../../utils/transforms/datasets';
 import { toInt } from '../../../utils/transforms/labels';
-import { monthNamesWithYearsFromNumbers } from '../../../utils/transforms/months';
+import { monthNamesAllWithYearsFromNumbers } from '../../../utils/transforms/months';
 
 const RevocationsOverTime = (props) => {
   const [chartLabels, setChartLabels] = useState([]);
@@ -54,7 +54,7 @@ const RevocationsOverTime = (props) => {
 
     const months = getMonthCountFromMetricPeriodMonthsToggle(props.metricPeriodMonths);
     const sortedChartData = sortFilterAndSupplementMostRecentMonths(chartData, months, 'count', 0);
-    const labels = monthNamesWithYearsFromNumbers(sortedChartData.map((element) => element.month), false)
+    const labels = monthNamesAllWithYearsFromNumbers(sortedChartData.map((element) => element.month), false)
     const dataPoints = (sortedChartData.map((element) => element.count));
 
     centerSingleMonthDatasetIfNecessary(dataPoints, labels);

--- a/src/utils/transforms/months.js
+++ b/src/utils/transforms/months.js
@@ -50,9 +50,7 @@ const monthNamesFromNumbers = function monthNamesFromNumbers(
   return monthList;
 };
 
-const monthNamesWithYearsFromNumbers = function monthNamesShortWithYearsFromNumbers(
-  monthNumbers, abbreviated,
-) {
+const monthNamesWithYears = function monthNamesWithyears(monthNumbers, abbreviated, allMonths) {
   const monthNames = monthNamesFromNumbers(monthNumbers, abbreviated);
   const monthNumbersNormalized = monthNumbers.map((month) => Number(month));
   const multipleYears = (monthNumbersNormalized.length > 12
@@ -68,9 +66,23 @@ const monthNamesWithYearsFromNumbers = function monthNamesShortWithYearsFromNumb
     } else if (multipleYears && monthNames[i] === january) {
       monthNames[i] = monthNames[i].concat(" '", year % 100);
       year -= 1;
+    } else if (allMonths) {
+      monthNames[i] = monthNames[i].concat(" '", year % 100);
     }
   }
   return monthNames;
+};
+
+const monthNamesWithYearsFromNumbers = function monthNamesShortWithYearsFromNumbers(
+  monthNumbers, abbreviated,
+) {
+  return monthNamesWithYears(monthNumbers, abbreviated, false);
+};
+
+const monthNamesAllWithYearsFromNumbers = function monthNamesShortWithYearsFromNumbers(
+  monthNumbers, abbreviated,
+) {
+  return monthNamesWithYears(monthNumbers, abbreviated, true);
 };
 
 const monthNamesFromShortName = function monthNamesFromShortName(shortName) {
@@ -94,5 +106,6 @@ export {
   monthNameFromNumberAbbreviated,
   monthNamesFromNumbers,
   monthNamesWithYearsFromNumbers,
+  monthNamesAllWithYearsFromNumbers,
   monthNamesFromShortName,
 };


### PR DESCRIPTION
## Description of the change

This works by requiring charts that use the current month annotation box to append years to each x-axis label, not just the left-most one and January months. This is required because the chartjs-annotations plugin chooses the left and right bounds of boxes it draws based on the x-axis labels themselves, not indices. So right now, in March 2020, if you select a 3-year view, it sees that the most recent month before the current one is "February" and then evaluates along the x-axis from left to right, selecting the first instance of "February" as the left-most boundary of the box, i.e. February 2018. Thus, adding the year abbreviations to the end of each x-axis label ensures that you always pick exactly the right left-most boundary.

This wasn't noticed initially because this was first put into place during February 2020, when the most recent month was "January '20", which will definitely only be written along the x-axis once.

I only changed the labels of the one chart that actually uses this functionality right now, to avoid too much disruption. See the screenshot with fake data for how it looks with this change.

<img width="1626" alt="Screen Shot 2020-03-12 at 18 00 24" src="https://user-images.githubusercontent.com/431895/76578008-ca45ea00-648c-11ea-8abc-84e50707db74.png">


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
