### PR TITLE
Fixes the district appendage at the end of exported image titles.

### DIFF
--- a/src/components/charts/revocations/BarCharts.js
+++ b/src/components/charts/revocations/BarCharts.js
@@ -217,7 +217,7 @@ export const getPerOfficerChartDefinition = (props) => {
   }
 
   function configureDownloads(
-    officerLabels, officerViolationCountsByType, visibleOffice,
+    officerLabels, officerViolationCountsByType, offices, visibleOffice,
   ) {
     const exportedStructureCallback = () => (
       {
@@ -232,7 +232,13 @@ export const getPerOfficerChartDefinition = (props) => {
     }));
 
     const humanReadableOfficerLabels = officerLabels.map((element) => `Officer ${element}`);
-    const officeReadable = toHumanReadable(visibleOffice).toUpperCase();
+    let officeReadable = toHumanReadable(visibleOffice).toUpperCase();
+    if (officeReadable !== 'ALL') {
+      const officeName = offices[toInt(visibleOffice)];
+      if (officeName) {
+        officeReadable = toHumanReadable(officeName).toUpperCase();
+      }
+    }
     const chartTitle = `${exportLabel.toUpperCase()} - ${officeReadable}`;
 
     const convertValuesToNumbers = false;
@@ -310,7 +316,7 @@ export const getPerOfficerChartDefinition = (props) => {
       officerLabels, officerViolationCountsByType,
     } = getDataForVisibleOffice(dataPoints, String(visibleOffice));
     setDataForVisibleOffice(officerLabels, officerViolationCountsByType, visibleOffice);
-    configureDownloads(officerLabels, officerViolationCountsByType, visibleOffice);
+    configureDownloads(officerLabels, officerViolationCountsByType, offices, visibleOffice);
   };
 
   return {


### PR DESCRIPTION
## Description of the change

If you export an image for a by-officer chart, to help in legibility, exported images have the district added to the end. For example, export an image of the "Revocations By Officer" chart with a specific district selected and you'll see that the top of the image has a title of "Revocations By Officer - [District]". Prior to this fix, that district was the district's site id number, e.g. "1" instead of "Bismarck" in the case of North Dakota. This fixes that.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
