### PR TITLE
Fix violation count display bug in caseload table

### DIFF
--- a/src/components/charts/new_revocations/CaseTable.js
+++ b/src/components/charts/new_revocations/CaseTable.js
@@ -20,6 +20,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import ExportMenu from '../ExportMenu';
 
 import { COLORS } from '../../../assets/scripts/constants/colors';
+import parseViolationRecord from '../../../utils/charts/parseViolationRecord';
 import {
   getTrailingLabelFromMetricPeriodMonthsToggle, getPeriodLabelFromMetricPeriodMonthsToggle,
 } from '../../../utils/charts/toggles';
@@ -28,9 +29,6 @@ import {
 } from '../../../utils/transforms/labels';
 
 const CASES_PER_PAGE = 15;
-const VIOLATION_SEVERITY = [
-  'fel', 'misd', 'absc', 'muni', 'subs', 'tech',
-];
 
 const unknownStyle = {
   fontStyle: 'italic',
@@ -105,32 +103,6 @@ const CaseTable = (props) => {
       return <td>{label}</td>;
     }
     return <td style={unknownStyle}>{nullSafeLabel(label)}</td>;
-  };
-
-  const indexOf = (element, array) => {
-    for (let i = 0; i < array.length; i += 1) {
-      if (element === array[i]) {
-        return i;
-      }
-    }
-    return -1;
-  };
-
-  const parseViolationRecord = (recordLabel) => {
-    if (!recordLabel) {
-      return '';
-    }
-
-    const recordParts = recordLabel.split(';');
-    const records = recordParts.map((recordPart) => {
-      const number = recordPart[0];
-      const abbreviation = recordPart.substring(1);
-      return { number, abbreviation };
-    });
-    records.sort((a, b) => indexOf(a.abbreviation, VIOLATION_SEVERITY)
-      - indexOf(b.abbreviation, VIOLATION_SEVERITY));
-
-    return records.map((record) => `${record.number} ${record.abbreviation}`).join(', ');
   };
 
   return (

--- a/src/utils/charts/parseViolationRecord.js
+++ b/src/utils/charts/parseViolationRecord.js
@@ -2,15 +2,6 @@ const VIOLATION_SEVERITY = [
   'fel', 'misd', 'absc', 'muni', 'subs', 'tech',
 ];
 
-const indexOf = (element, array) => {
-  for (let i = 0; i < array.length; i += 1) {
-    if (element === array[i]) {
-      return i;
-    }
-  }
-  return -1;
-};
-
 const parseViolationRecord = (recordLabel) => {
   if (!recordLabel) {
     return '';
@@ -19,8 +10,8 @@ const parseViolationRecord = (recordLabel) => {
   const recordParts = recordLabel.split(';');
   const recordPartRegex = /(?<number>\d+)(?<abbreviation>\w+)/;
   const records = recordParts.map((recordPart) => recordPart.match(recordPartRegex).groups);
-  records.sort((a, b) => indexOf(a.abbreviation, VIOLATION_SEVERITY)
-    - indexOf(b.abbreviation, VIOLATION_SEVERITY));
+  records.sort((a, b) => VIOLATION_SEVERITY.indexOf(a.abbreviation)
+    - VIOLATION_SEVERITY.indexOf(b.abbreviation));
 
   return records.map((record) => `${record.number} ${record.abbreviation}`).join(', ');
 };

--- a/src/utils/charts/parseViolationRecord.js
+++ b/src/utils/charts/parseViolationRecord.js
@@ -1,0 +1,31 @@
+const VIOLATION_SEVERITY = [
+  'fel', 'misd', 'absc', 'muni', 'subs', 'tech',
+];
+
+const indexOf = (element, array) => {
+  for (let i = 0; i < array.length; i += 1) {
+    if (element === array[i]) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const parseViolationRecord = (recordLabel) => {
+  if (!recordLabel) {
+    return '';
+  }
+
+  const recordParts = recordLabel.split(';');
+  const records = recordParts.map((recordPart) => {
+    const number = recordPart[0];
+    const abbreviation = recordPart.substring(1);
+    return { number, abbreviation };
+  });
+  records.sort((a, b) => indexOf(a.abbreviation, VIOLATION_SEVERITY)
+    - indexOf(b.abbreviation, VIOLATION_SEVERITY));
+
+  return records.map((record) => `${record.number} ${record.abbreviation}`).join(', ');
+};
+
+export default parseViolationRecord;

--- a/src/utils/charts/parseViolationRecord.js
+++ b/src/utils/charts/parseViolationRecord.js
@@ -17,11 +17,8 @@ const parseViolationRecord = (recordLabel) => {
   }
 
   const recordParts = recordLabel.split(';');
-  const records = recordParts.map((recordPart) => {
-    const number = recordPart[0];
-    const abbreviation = recordPart.substring(1);
-    return { number, abbreviation };
-  });
+  const recordPartRegex = /(?<number>\d+)(?<abbreviation>\w+)/;
+  const records = recordParts.map((recordPart) => recordPart.match(recordPartRegex).groups);
   records.sort((a, b) => indexOf(a.abbreviation, VIOLATION_SEVERITY)
     - indexOf(b.abbreviation, VIOLATION_SEVERITY));
 

--- a/src/utils/charts/parseViolationRecord.test.js
+++ b/src/utils/charts/parseViolationRecord.test.js
@@ -1,0 +1,15 @@
+import parseViolationRecord from './parseViolationRecord';
+
+describe('parseViolationRecord function', () => {
+  test('reformats semicolon-separated strings', () => {
+    const rawInput = '1fel;1muni;4subs;3tech';
+    const expectedOutput = '1 fel, 1 muni, 4 subs, 3 tech';
+    expect(parseViolationRecord(rawInput)).toBe(expectedOutput);
+  });
+  test('returns a string even when there is no input', () => {
+    expect(parseViolationRecord()).toBe('');
+    expect(parseViolationRecord('')).toBe('');
+    expect(parseViolationRecord(null)).toBe('');
+  });
+  test.todo('handles multi-digit violation counts');
+});

--- a/src/utils/charts/parseViolationRecord.test.js
+++ b/src/utils/charts/parseViolationRecord.test.js
@@ -11,5 +11,9 @@ describe('parseViolationRecord function', () => {
     expect(parseViolationRecord('')).toBe('');
     expect(parseViolationRecord(null)).toBe('');
   });
-  test.todo('handles multi-digit violation counts');
+  test('handles multi-digit violation counts', () => {
+    const rawInput = '1fel;13muni;400subs';
+    const expectedOutput = '1 fel, 13 muni, 400 subs';
+    expect(parseViolationRecord(rawInput)).toBe(expectedOutput);
+  });
 });


### PR DESCRIPTION
## Description of the change

Fixes bug in MO revocation caseload table where double-digit violation counts in the `Violation Record` column would be displayed incorrectly. 

<img width="218" alt="Screen Shot 2020-03-24 at 5 24 54 PM" src="https://user-images.githubusercontent.com/5385319/77489812-7a551480-6df6-11ea-8a4c-e0a2913e890e.png">

I factored out the offending function and added tests in the course of doing this. As part of that refactor I removed what appeared to be a reimplementation of the `Array.indexOf` method because I couldn't really see why it was needed ... but if there was a good reason that I missed please slap me

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #251

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Lint rules pass locally
- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
