### PR TITLE
Chart export fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "express-jwt": "^5.3.1",
     "helmet": "^3.21.2",
     "highlight.js": "^9.15.6",
-    "html2canvas": "^1.0.0-rc.5",
+    "html2canvas": "=1.0.0-rc.1",
     "http-errors": "~1.6.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jquery": "^3.2.1",

--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -23,6 +23,11 @@ import infoAboutChart from '../../../utils/charts/info';
 import JSZip from 'jszip';
 import { toTitleCase, toHumanReadable } from '../../../utils/transforms/labels';
 
+// Functions for flowing through browser-specific download functionality
+// https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+const isIE = /*@cc_on!@*/false || !!document.documentMode;
+const isEdge = !isIE && !!window.StyleMedia;
+
 function configureFilename(chartId, toggleStates, shouldZipDownload) {
   let filename = `${chartId}-${timeStamp()}`;
   if (shouldZipDownload) {
@@ -152,7 +157,7 @@ function downloadObjectAsCsv(exportObj, exportName, shouldZipDownload) {
     if (err) throw err;
     const filename = `${exportName}.csv`;
 
-    if (navigator.msSaveBlob && !shouldZipDownload) { // User is on Windows
+    if ((isIE || isEdge) && !shouldZipDownload) { // User is on Windows
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
       navigator.msSaveBlob(blob, filename);
     } else { // User is not on Windows
@@ -291,9 +296,8 @@ function downloadHtmlElementAsImage(
   convertValuesToNumbers, handleTimeStringLabels, timeWindowDescription, shouldZipDownload
 ) {
   const element = document.getElementById(chartId);
-  // Setting the Y-scroll position fixes a bug that causes the image to be cut off when scrolled
-  // partially down the page, without changing the user's actual scroll position
-  html2canvas(element, { scrollY: -window.scrollY }).then((canvas) => {
+
+  html2canvas(element, {}).then((canvas) => {
     configureImageDownload(
       canvas, `${chartId}-${timeStamp()}.png`, chartTitle, toggleStates, chartId,
       timeWindowDescription, shouldZipDownload

--- a/src/components/charts/ExportMenu.js
+++ b/src/components/charts/ExportMenu.js
@@ -42,28 +42,28 @@ const ExportMenu = (props) => {
         <div className="dropdown-menu dropdown-menu-right" aria-labelledby={`exportDropdownMenuButton-${props.chartId}`}>
           <a className="dropdown-item" href="javascript:void(0);" data-toggle="modal" data-target={`#${modalId}`}>Additional info</a>
           {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement === undefined && (
-            <a className="dropdown-item" onClick={() => downloadChartAsImage(
+            <a className="dropdown-item" href="javascript:void(0);" onClick={() => downloadChartAsImage(
               props.chartId, props.metricTitle, props.chart.props.data.datasets,
               props.chart.props.data.labels, exportedStructureCallback, props.filters,
               undefined, undefined, props.timeWindowDescription, true
             )}>Export image</a>
           )}
           {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement === undefined && (
-            <a className="dropdown-item" onClick={() => downloadChartAsData(
+            <a className="dropdown-item" href="javascript:void(0);" onClick={() => downloadChartAsData(
               props.chartId, props.metricTitle, props.chart.props.data.datasets,
               props.chart.props.data.labels, exportedStructureCallback, props.filters,
               undefined, undefined, props.timeWindowDescription, true
             )}>Export data</a>
           )}
           {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement && (
-            <a className="dropdown-item" onClick={() => downloadHtmlElementAsImage(
+            <a className="dropdown-item" href="javascript:void(0);" onClick={() => downloadHtmlElementAsImage(
               props.chartId, props.metricTitle,props.elementDatasets, props.elementLabels,
               exportedStructureCallback, props.filters, undefined, undefined,
               props.timeWindowDescription, true
             )}>Export image</a>
           )}
           {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement && (
-            <a className="dropdown-item" onClick={() => downloadHtmlElementAsData(
+            <a className="dropdown-item" href="javascript:void(0);" onClick={() => downloadHtmlElementAsData(
               props.chartId, props.metricTitle,props.elementDatasets, props.elementLabels,
               exportedStructureCallback, props.filters, undefined, undefined,
               props.timeWindowDescription, true

--- a/src/components/charts/ExportMenu.js
+++ b/src/components/charts/ExportMenu.js
@@ -18,7 +18,7 @@
 import React from 'react';
 
 import {
-  configureDownloadButtons, configureDownloadButtonsRegularElement,
+  downloadChartAsImage, downloadChartAsData, downloadHtmlElementAsImage, downloadHtmlElementAsData,
 } from '../../assets/scripts/utils/downloads';
 import chartIdToInfo from '../../utils/charts/info';
 
@@ -27,7 +27,13 @@ const ExportMenu = (props) => {
 
   const modalId = `additionalInfoModal-${props.chartId}`;
 
-  const menuSpan = (
+  const exportedStructureCallback = () => (
+    {
+      metric: props.metricTitle,
+      series: [],
+    });
+
+  return (
     <span className="fa-pull-right">
       <div className="dropdown show">
         <a href="#" role="button" id={`exportDropdownMenuButton-${props.chartId}`} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -35,11 +41,33 @@ const ExportMenu = (props) => {
         </a>
         <div className="dropdown-menu dropdown-menu-right" aria-labelledby={`exportDropdownMenuButton-${props.chartId}`}>
           <a className="dropdown-item" href="javascript:void(0);" data-toggle="modal" data-target={`#${modalId}`}>Additional info</a>
-          {(props.shouldExport === undefined || props.shouldExport === true) && (
-            <a className="dropdown-item" id={`downloadChartAsImage-${props.chartId}`} href="javascript:void(0);">Export image</a>
+          {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement === undefined && (
+            <a className="dropdown-item" onClick={() => downloadChartAsImage(
+              props.chartId, props.metricTitle, props.chart.props.data.datasets,
+              props.chart.props.data.labels, exportedStructureCallback, props.filters,
+              undefined, undefined, props.timeWindowDescription, true
+            )}>Export image</a>
           )}
-          {(props.shouldExport === undefined || props.shouldExport === true) && (
-            <a className="dropdown-item" id={`downloadChartData-${props.chartId}`} href="javascript:void(0);">Export data</a>
+          {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement === undefined && (
+            <a className="dropdown-item" onClick={() => downloadChartAsData(
+              props.chartId, props.metricTitle, props.chart.props.data.datasets,
+              props.chart.props.data.labels, exportedStructureCallback, props.filters,
+              undefined, undefined, props.timeWindowDescription, true
+            )}>Export data</a>
+          )}
+          {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement && (
+            <a className="dropdown-item" onClick={() => downloadHtmlElementAsImage(
+              props.chartId, props.metricTitle,props.elementDatasets, props.elementLabels,
+              exportedStructureCallback, props.filters, undefined, undefined,
+              props.timeWindowDescription, true
+            )}>Export image</a>
+          )}
+          {(props.shouldExport === undefined || props.shouldExport === true) && props.regularElement && (
+            <a className="dropdown-item" onClick={() => downloadHtmlElementAsData(
+              props.chartId, props.metricTitle,props.elementDatasets, props.elementLabels,
+              exportedStructureCallback, props.filters, undefined, undefined,
+              props.timeWindowDescription, true
+            )}>Export data</a>
           )}
         </div>
       </div>
@@ -79,31 +107,6 @@ const ExportMenu = (props) => {
       </div>
     </span>
   );
-
-  if ((props.shouldExport === undefined || props.shouldExport === true)) {
-    const exportedStructureCallback = () => (
-      {
-        metric: props.metricTitle,
-        series: [],
-      });
-
-    if (props.regularElement) {
-      configureDownloadButtonsRegularElement(props.chartId, props.metricTitle,
-        props.elementDatasets, props.elementLabels,
-        document.getElementById(props.chartId), exportedStructureCallback,
-        props.filters, undefined, undefined, props.timeWindowDescription, true);
-    } else {
-      configureDownloadButtons(props.chartId,
-        props.metricTitle,
-        props.chart.props.data.datasets,
-        props.chart.props.data.labels,
-        document.getElementById(props.chartId),
-        exportedStructureCallback,
-        props.filters, undefined, undefined, props.timeWindowDescription, true);
-    }
-  }
-
-  return menuSpan;
 };
 
 export default ExportMenu;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,9 +2704,9 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base64-arraybuffer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz#4b944fac0191aa5907afe2d8c999ccc57ce80f45"
+base64-arraybuffer@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
 base64-js@^1.0.2, base64-js@^1.3.0:
   version "1.3.0"
@@ -3849,11 +3849,11 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-css-line-break@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-1.1.1.tgz#d5e9bdd297840099eb0503c7310fd34927a026ef"
+css-line-break@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-1.0.1.tgz#19f2063a33e95fb2831b86446c0b80c188af450a"
   dependencies:
-    base64-arraybuffer "^0.2.0"
+    base64-arraybuffer "^0.1.5"
 
 css-loader@3.4.2:
   version "3.4.2"
@@ -6155,11 +6155,11 @@ html-webpack-plugin@4.0.0-beta.11:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-html2canvas@^1.0.0-rc.5:
-  version "1.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.0.0-rc.5.tgz#4ee3cac9f6e20a0fa0c2f35a6f99c960ae7ec4c1"
+html2canvas@=1.0.0-rc.1:
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.0.0-rc.1.tgz#422222d21332d05ca55d86954e5f413e17fae6fb"
   dependencies:
-    css-line-break "1.1.1"
+    css-line-break "1.0.1"
 
 htmlparser2@^3.3.0, htmlparser2@^3.9.1:
   version "3.10.1"
@@ -6319,7 +6319,6 @@ ignore@^4.0.6:
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
 immer@1.10.0:
   version "1.10.0"
@@ -7631,7 +7630,6 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
 jszip@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.3.0.tgz#29d72c21a54990fa885b11fc843db320640d5271"
-  integrity sha512-EJ9k766htB1ZWnsV5ZMDkKLgA+201r/ouFF8R2OigVjVdcm2rurcBrrdXaeqBJbqnUVMko512PYmlncBKE1Huw==
   dependencies:
     lie "~3.3.0"
     pako "~1.0.2"
@@ -7756,7 +7754,6 @@ levn@^0.3.0, levn@~0.3.0:
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
 
@@ -9156,7 +9153,6 @@ package-json@^4.0.0:
 pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 pako@~1.0.5:
   version "1.0.10"
@@ -11314,7 +11310,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-immediate-shim@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Description of the change

This fixes a few related issues in the download functionality:
1. Ensures zipped files for both image and data can be successfully downloaded in MS browsers
1. Ensures the revocation matrix export works in IE11
1. Ensures that no special or magical configuration is needed for the revocation matrix download to be centered in the png (by reverting to a specific version of the `html2canvas` dependency [known to not exhibit this issue](https://github.com/niklasvh/html2canvas/issues/1878))
1. Switches the export menu options from a Jquery-esque "assign this function to the onclick of this element ahead of time" to a simpler, synchronous execution of a download function to avoid a race condition where the chart element _might_ not exist by the time the onclick is registered -- I did not backport this to the non-Lantern downloads yet because it would be a more significant change and there's no issue there as-is

It's easiest to work through this PR commit-by-commit.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #296 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
