### PR TITLE
Final changes before the revocation matrix launch

### DIFF
--- a/src/assets/scripts/constants/colors.js
+++ b/src/assets/scripts/constants/colors.js
@@ -282,6 +282,7 @@ const COLORS = {
   'lantern-eggplant': '#5C384D',
   'lantern-burnt-orange': '#8B2D21',
   'lantern-blue': '#182B5E',
+  'lantern-dark-blue': '#002C42',
 };
 
 const GREYS = {

--- a/src/components/charts/new_revocations/CaseTable.js
+++ b/src/components/charts/new_revocations/CaseTable.js
@@ -138,12 +138,12 @@ const CaseTable = (props) => {
 
   const tableData = filteredData === undefined ? [] : filteredData.map((record) => {
       let obj = { data: [] };
-      obj.data.push(record.state_id);
-      obj.data.push(record.district);
-      obj.data.push(nameFromOfficerId(record.officer));
-      obj.data.push(humanReadableTitleCase(record.risk_level));
-      obj.data.push(toTitleCase(record.officer_recommendation));
-      obj.data.push(parseViolationRecord(record.violation_record));
+      obj.data.push(nullSafeLabel(record.state_id));
+      obj.data.push(nullSafeLabel(record.district));
+      obj.data.push(nullSafeLabel(nameFromOfficerId(record.officer)));
+      obj.data.push(nullSafeLabel(riskLevelValuetoLabel[record.risk_level]));
+      obj.data.push(nullSafeLabel(normalizeLabel(record.officer_recommendation)));
+      obj.data.push(nullSafeLabel(parseViolationRecord(record.violation_record)));
       return obj;
     });
 

--- a/src/components/charts/new_revocations/RevocationMatrix.js
+++ b/src/components/charts/new_revocations/RevocationMatrix.js
@@ -144,11 +144,11 @@ const RevocationMatrix = (props) => {
       lineHeight: `${radius}px`,
     };
     const cellStyle = {
-      background: `rgba(92, 56, 77, ${ratio})`,
+      background: `rgba(0, 44, 66, ${ratio})`,  // lantern-dark-blue with opacity
       width: '100%',
       height: '100%',
       borderRadius: Math.ceil(radius / 2),
-      color: ratio >= 0.5 ? COLORS.white : COLORS['lantern-eggplant'],
+      color: ratio >= 0.5 ? COLORS.white : COLORS['lantern-dark-blue'],
     };
 
     return (

--- a/src/components/charts/new_revocations/RevocationsOverTime.js
+++ b/src/components/charts/new_revocations/RevocationsOverTime.js
@@ -172,7 +172,9 @@ const RevocationsOverTime = (props) => {
   if (awaitingResults(loading, user, awaitingApi)) {
     return <Loading />;
   }
-  const chart = countZero > 2 ? barChart : lineChart;
+
+  // If at least a third of all points are 0, show bar chart. Otherwise, show line chart.
+  const chart = (countZero / props.metricPeriodMonths) >= 0.33 ? barChart : lineChart;
   return (
     <div>
       <h4>


### PR DESCRIPTION
## Description of the change

1. Fixes a bug breaking page load by choking on realistic data outside of demo mode in the case table component.
1. Changes the primary color of the revocation matrix to a dark blue that is approved by design and roughly equally accessible
1. Revises the logic for conversion between bar and line version of revocation over time chart to be proportional instead of absolute

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #300 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
