### PR TITLE
Add a visual cue for rate charts that are not statistically significant

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,13 +10,17 @@ public/
 !server/core/objectStorage.js
 !server/routes/*.js
 !server/utils/*.js
+!src/components/charts/DataSignificanceWarningIcon.js
+!src/components/charts/WarningIcon.js
 !src/components/toggles/__tests__/MetricPeriodToggle.test.js
 !src/components/toggles/__tests__/MetricTypeToggle.test.js
 !src/components/toggles/__tests__/SupervisionTypeToggle.test.js
 !src/components/toggles/__tests__/ToggleBar.test.js
 !src/utils/charts/info.js
+!src/utils/charts/significantStatistics.js
 !src/utils/charts/__tests__/choropleth.test.js
 !src/utils/charts/__tests__/currentSpan.test.js
 !src/utils/charts/__tests__/metricGoal.test.js
+!src/utils/charts/__tests__/significantStatistics.test.js
 !src/utils/transforms/years.js
 !src/utils/transforms/__tests__/years.test.js

--- a/package.json
+++ b/package.json
@@ -64,8 +64,10 @@
     "morgan": "^1.9.1",
     "node-cache": "^5.1.0",
     "npm-run-all": "^4.1.5",
+    "patternomaly": "^1.3.2",
     "perfect-scrollbar": "^1.1.0",
     "popper.js": "^1.12.6",
+    "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-app-polyfill": "^1.0.1",
     "react-chartjs-2": "^2.7.6",
@@ -124,4 +126,3 @@
     ]
   }
 }
-

--- a/src/components/charts/DataSignificanceWarningIcon.js
+++ b/src/components/charts/DataSignificanceWarningIcon.js
@@ -16,20 +16,20 @@
 // =============================================================================
 
 import React from "react";
-import PropTypes from "prop-types";
-import ReactTooltip from "react-tooltip";
+import WarningIcon from "./WarningIcon";
 
-const WarningIcon = ({ tooltipText }) => (
-  <>
-    &nbsp;
-    <span data-tip data-for="warningTooltip" className="ti-alert" />
-    <ReactTooltip id="warningTooltip">{tooltipText}</ReactTooltip>
-  </>
-);
+const DataSignificanceWarningIcon = () => {
+  const text = (
+    <>
+      Some categories in this chart may not be statistically significant
+      <br />
+      due to having a sample size smaller than 100.
+      <br />
+      Those categories are represented with line shading.
+    </>
+  );
 
-WarningIcon.propTypes = {
-  tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
-    .isRequired,
+  return <WarningIcon tooltipText={text} />;
 };
 
-export default WarningIcon;
+export default DataSignificanceWarningIcon;

--- a/src/components/charts/WarningIcon.js
+++ b/src/components/charts/WarningIcon.js
@@ -1,0 +1,33 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from 'react';
+import ReactTooltip from 'react-tooltip'
+
+const WarningIcon = () => (
+  <>
+    {' '}
+    <span data-tip data-for="warningTooltip" className="ti-alert" />
+    <ReactTooltip id="warningTooltip">
+      Some categories in this chart may not be statistically significant <br />
+      due to having a sample size smaller than 100. <br />
+      Those categories are represented with line shading.
+    </ReactTooltip>
+  </>
+)
+
+export default WarningIcon;

--- a/src/components/charts/new_revocations/RevocationsByDistrict.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict.js
@@ -144,7 +144,7 @@ const RevocationsByDistrict = (props) => {
     countModeEnabled,
   ]);
 
-  const backgroundColor = ({ dataIndex, dataset, datasetIndex }) => {
+  const barBackgroundColor = ({ dataIndex, dataset, datasetIndex }) => {
     let color = (props.currentDistrict && props.currentDistrict.toLowerCase() === chartLabels[dataIndex].toLowerCase())
       ? COLORS['lantern-light-blue']
       : COLORS['lantern-orange']
@@ -165,7 +165,7 @@ const RevocationsByDistrict = (props) => {
           label: toggleLabel({
             counts: 'Revocations', rates: 'Revocation rate',
           }, countModeEnabled ? 'counts' : 'rates'),
-          backgroundColor: backgroundColor,
+          backgroundColor: barBackgroundColor,
           data: chartDataPoints,
         }],
       }}

--- a/src/components/charts/new_revocations/RevocationsByDistrict.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict.js
@@ -18,8 +18,10 @@
 import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import * as $ from 'jquery';
+import pattern from 'patternomaly';
 
 import ExportMenu from '../ExportMenu';
+import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -28,8 +30,15 @@ import { fetchChartData, awaitingResults } from '../../../utils/metricsClient';
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { axisCallbackForMetricType } from '../../../utils/charts/axis';
 import {
-  getTrailingLabelFromMetricPeriodMonthsToggle, getPeriodLabelFromMetricPeriodMonthsToggle,
-  toggleLabel, updateTooltipForMetricTypeWithCounts,
+  isDenominatorStatisticallySignificant,
+  isDenominatorsMatrixStatisticallySignificant,
+  tooltipForFooterWithCounts,
+} from '../../../utils/charts/significantStatistics';
+import {
+  getTrailingLabelFromMetricPeriodMonthsToggle,
+  getPeriodLabelFromMetricPeriodMonthsToggle,
+  toggleLabel,
+  updateTooltipForMetricTypeWithCounts,
 } from '../../../utils/charts/toggles';
 import { toInt } from '../../../utils/transforms/labels';
 
@@ -47,6 +56,8 @@ const RevocationsByDistrict = (props) => {
   const [awaitingRevocationApi, setAwaitingRevocationApi] = useState(true);
   const [supervisionApiData, setSupervisionApiData] = useState({});
   const [awaitingSupervisionApi, setAwaitingSupervisionApi] = useState(true);
+
+  const showWarning = !isDenominatorsMatrixStatisticallySignificant(denominatorCounts);
 
   const processResponse = () => {
     if (awaitingRevocationApi || awaitingSupervisionApi
@@ -133,19 +144,17 @@ const RevocationsByDistrict = (props) => {
     countModeEnabled,
   ]);
 
-  // This sets bar color to light-blue-500 when it's the current district, or orange-500 otherwise
-  const highlightCurrentDistrict = () => {
-    const colors = [];
-    for (let i = 0; i < chartLabels.length; i += 1) {
-      if (props.currentDistrict
-        && props.currentDistrict.toLowerCase() === chartLabels[i].toLowerCase()) {
-        colors.push(COLORS['lantern-light-blue']);
-      } else {
-        colors.push(COLORS['lantern-orange']);
-      }
+  const backgroundColor = ({ dataIndex, dataset, datasetIndex }) => {
+    let color = (props.currentDistrict && props.currentDistrict.toLowerCase() === chartLabels[dataIndex].toLowerCase())
+      ? COLORS['lantern-light-blue']
+      : COLORS['lantern-orange']
+
+    if (!countModeEnabled && !isDenominatorStatisticallySignificant(denominatorCounts[dataIndex])) {
+      color = pattern.draw('diagonal-right-left', color, '#ffffff', 5);
     }
-    return colors;
-  };
+
+    return color
+  }
 
   const chart = (
     <Bar
@@ -156,9 +165,7 @@ const RevocationsByDistrict = (props) => {
           label: toggleLabel({
             counts: 'Revocations', rates: 'Revocation rate',
           }, countModeEnabled ? 'counts' : 'rates'),
-          backgroundColor: highlightCurrentDistrict(),
-          hoverBackgroundColor: highlightCurrentDistrict(),
-          hoverBorderColor: highlightCurrentDistrict(),
+          backgroundColor: backgroundColor,
           data: chartDataPoints,
         }],
       }}
@@ -191,12 +198,14 @@ const RevocationsByDistrict = (props) => {
         },
         tooltips: {
           backgroundColor: COLORS['grey-800-light'],
+          footerFontSize: 9,
           mode: 'index',
           intersect: false,
           callbacks: {
             label: (tooltipItem, data) => updateTooltipForMetricTypeWithCounts(
               countModeEnabled ? 'counts' : 'rates', tooltipItem, data, numeratorCounts, denominatorCounts
             ),
+            footer: (tooltipItem) => !countModeEnabled && tooltipForFooterWithCounts(tooltipItem, denominatorCounts),
           },
         },
       }}
@@ -212,6 +221,7 @@ const RevocationsByDistrict = (props) => {
     <div>
       <h4>
         Revocations by district
+        {countModeEnabled === false && showWarning === true && <WarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/components/charts/new_revocations/RevocationsByDistrict.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict.js
@@ -20,8 +20,8 @@ import { Bar } from 'react-chartjs-2';
 import * as $ from 'jquery';
 import pattern from 'patternomaly';
 
+import DataSignificanceWarningIcon from '../DataSignificanceWarningIcon';
 import ExportMenu from '../ExportMenu';
-import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -221,7 +221,7 @@ const RevocationsByDistrict = (props) => {
     <div>
       <h4>
         Revocations by district
-        {countModeEnabled === false && showWarning === true && <WarningIcon />}
+        {countModeEnabled === false && showWarning === true && <DataSignificanceWarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/components/charts/new_revocations/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender.js
@@ -18,6 +18,7 @@
 import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import ExportMenu from '../ExportMenu';
+import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -26,7 +27,14 @@ import { fetchChartData, awaitingResults } from '../../../utils/metricsClient';
 import { COLORS } from '../../../assets/scripts/constants/colors';
 import { axisCallbackForPercentage } from '../../../utils/charts/axis';
 import {
-  getTrailingLabelFromMetricPeriodMonthsToggle, getPeriodLabelFromMetricPeriodMonthsToggle,
+  generateLabelsWithCustomColors,
+  getBackgroundColor,
+  isDenominatorsMatrixStatisticallySignificant,
+  tooltipForFooterWithNestedCounts,
+} from '../../../utils/charts/significantStatistics';
+import {
+  getTrailingLabelFromMetricPeriodMonthsToggle,
+  getPeriodLabelFromMetricPeriodMonthsToggle,
   tooltipForRateMetricWithNestedCounts,
 } from '../../../utils/charts/toggles';
 import { toInt } from '../../../utils/transforms/labels';
@@ -45,6 +53,8 @@ const RevocationsByGender = (props) => {
   const { loading, user, getTokenSilently } = useAuth0();
   const [apiData, setApiData] = useState({});
   const [awaitingApi, setAwaitingApi] = useState(true);
+
+  const showWarning = !isDenominatorsMatrixStatisticallySignificant(denominatorCounts);
 
   const getRevocationsForRiskLevel = (forGender, filteredData) => RISK_LEVELS.map((riskLevel) => (
     filteredData
@@ -119,28 +129,33 @@ const RevocationsByGender = (props) => {
     props.metricPeriodMonths,
   ]);
 
+  const colors = [
+    COLORS['lantern-light-blue'],
+    COLORS['lantern-orange'],
+  ]
+
+  const generateDataset = (label, index) => ({
+    label: label,
+    backgroundColor: getBackgroundColor(colors[index], denominatorCounts),
+    data: chartDataPoints[index],
+  });
+
   const chart = (
     <Bar
       id={chartId}
       data={{
         labels: CHART_LABELS,
-        datasets: [{
-          label: 'Women',
-          backgroundColor: COLORS['lantern-light-blue'],
-          hoverBackgroundColor: COLORS['lantern-light-blue'],
-          hoverBorderColor: COLORS['lantern-light-blue'],
-          data: chartDataPoints[0],
-        }, {
-          label: 'Men',
-          backgroundColor: COLORS['lantern-orange'],
-          hoverBackgroundColor: COLORS['lantern-orange'],
-          hoverBorderColor: COLORS['lantern-orange'],
-          data: chartDataPoints[1],
-        }],
+        datasets: [
+          generateDataset('Women', 0),
+          generateDataset('Men', 1),
+        ],
       }}
       options={{
         legend: {
           position: 'bottom',
+          labels: {
+            generateLabels: (chart) => generateLabelsWithCustomColors(chart, colors)
+          }
         },
         responsive: true,
         maintainAspectRatio: false,
@@ -164,10 +179,12 @@ const RevocationsByGender = (props) => {
         },
         tooltips: {
           backgroundColor: COLORS['grey-800-light'],
+          footerFontSize: 9,
           mode: 'index',
           intersect: false,
           callbacks: {
             label: (tooltipItem, data) => tooltipForRateMetricWithNestedCounts(tooltipItem, data, numeratorCounts, denominatorCounts),
+            footer: (tooltipItem) => tooltipForFooterWithNestedCounts(tooltipItem, denominatorCounts),
           },
         },
       }}
@@ -182,6 +199,7 @@ const RevocationsByGender = (props) => {
     <div>
       <h4>
         Percent revoked by gender and risk level
+        {showWarning === true && <WarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/components/charts/new_revocations/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender.js
@@ -28,7 +28,7 @@ import { COLORS } from '../../../assets/scripts/constants/colors';
 import { axisCallbackForPercentage } from '../../../utils/charts/axis';
 import {
   generateLabelsWithCustomColors,
-  getBackgroundColor,
+  getBarBackgroundColor,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithNestedCounts,
 } from '../../../utils/charts/significantStatistics';
@@ -136,7 +136,7 @@ const RevocationsByGender = (props) => {
 
   const generateDataset = (label, index) => ({
     label: label,
-    backgroundColor: getBackgroundColor(colors[index], denominatorCounts),
+    backgroundColor: getBarBackgroundColor(colors[index], denominatorCounts),
     data: chartDataPoints[index],
   });
 

--- a/src/components/charts/new_revocations/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender.js
@@ -17,8 +17,9 @@
 
 import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
+
+import DataSignificanceWarningIcon from '../DataSignificanceWarningIcon';
 import ExportMenu from '../ExportMenu';
-import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -199,7 +200,7 @@ const RevocationsByGender = (props) => {
     <div>
       <h4>
         Percent revoked by gender and risk level
-        {showWarning === true && <WarningIcon />}
+        {showWarning === true && <DataSignificanceWarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -17,8 +17,9 @@
 
 import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
+
+import DataSignificanceWarningIcon from '../DataSignificanceWarningIcon';
 import ExportMenu from '../ExportMenu';
-import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -197,7 +198,7 @@ const RevocationsByRace = (props) => {
     <div>
       <h4>
         Percent revoked by race/ethnicity and risk level
-        {showWarning === true && <WarningIcon />}
+        {showWarning === true && <DataSignificanceWarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -28,7 +28,7 @@ import { COLORS, COLORS_LANTERN_SET } from '../../../assets/scripts/constants/co
 import { axisCallbackForPercentage } from '../../../utils/charts/axis';
 import {
   generateLabelsWithCustomColors,
-  getBackgroundColor,
+  getBarBackgroundColor,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithNestedCounts,
 } from '../../../utils/charts/significantStatistics';
@@ -130,7 +130,7 @@ const RevocationsByRace = (props) => {
 
   const generateDataset = (label, index) => ({
     label: label,
-    backgroundColor: getBackgroundColor(COLORS_LANTERN_SET[index], denominatorCounts),
+    backgroundColor: getBarBackgroundColor(COLORS_LANTERN_SET[index], denominatorCounts),
     data: chartDataPoints[index],
   });
 

--- a/src/components/charts/new_revocations/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace.js
@@ -18,6 +18,7 @@
 import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import ExportMenu from '../ExportMenu';
+import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -26,7 +27,14 @@ import { fetchChartData, awaitingResults } from '../../../utils/metricsClient';
 import { COLORS, COLORS_LANTERN_SET } from '../../../assets/scripts/constants/colors';
 import { axisCallbackForPercentage } from '../../../utils/charts/axis';
 import {
-  getTrailingLabelFromMetricPeriodMonthsToggle, getPeriodLabelFromMetricPeriodMonthsToggle,
+  generateLabelsWithCustomColors,
+  getBackgroundColor,
+  isDenominatorsMatrixStatisticallySignificant,
+  tooltipForFooterWithNestedCounts,
+} from '../../../utils/charts/significantStatistics';
+import {
+  getTrailingLabelFromMetricPeriodMonthsToggle,
+  getPeriodLabelFromMetricPeriodMonthsToggle,
   tooltipForRateMetricWithNestedCounts,
 } from '../../../utils/charts/toggles';
 import { toInt } from '../../../utils/transforms/labels';
@@ -57,6 +65,8 @@ const RevocationsByRace = (props) => {
       .filter(({ race, risk_level: dataRiskLevel }) => race === forRace && dataRiskLevel === riskLevel)
       .reduce((result, { total_supervision_count: totalSupervisionCount }) => result += toInt(totalSupervisionCount), 0)
   ));
+
+  const showWarning = !isDenominatorsMatrixStatisticallySignificant(denominatorCounts);
 
   const processResponse = () => {
     if (awaitingApi || !apiData) {
@@ -118,52 +128,32 @@ const RevocationsByRace = (props) => {
     props.metricPeriodMonths,
   ]);
 
+  const generateDataset = (label, index) => ({
+    label: label,
+    backgroundColor: getBackgroundColor(COLORS_LANTERN_SET[index], denominatorCounts),
+    data: chartDataPoints[index],
+  });
+
   const chart = (
     <Bar
       id={chartId}
       data={{
         labels: CHART_LABELS,
-        datasets: [{
-          label: 'Caucasian',
-          backgroundColor: COLORS_LANTERN_SET[0],
-          hoverBackgroundColor: COLORS_LANTERN_SET[0],
-          hoverBorderColor: COLORS_LANTERN_SET[0],
-          data: chartDataPoints[0],
-        }, {
-          label: 'African American',
-          backgroundColor: COLORS_LANTERN_SET[1],
-          hoverBackgroundColor: COLORS_LANTERN_SET[1],
-          hoverBorderColor: COLORS_LANTERN_SET[1],
-          data: chartDataPoints[1],
-        }, {
-          label: 'Hispanic',
-          backgroundColor: COLORS_LANTERN_SET[2],
-          hoverBackgroundColor: COLORS_LANTERN_SET[2],
-          hoverBorderColor: COLORS_LANTERN_SET[2],
-          data: chartDataPoints[2],
-        }, {
-          label: 'Asian',
-          backgroundColor: COLORS_LANTERN_SET[3],
-          hoverBackgroundColor: COLORS_LANTERN_SET[3],
-          hoverBorderColor: COLORS_LANTERN_SET[3],
-          data: chartDataPoints[3],
-        }, {
-          label: 'Native American',
-          backgroundColor: COLORS_LANTERN_SET[4],
-          hoverBackgroundColor: COLORS_LANTERN_SET[4],
-          hoverBorderColor: COLORS_LANTERN_SET[4],
-          data: chartDataPoints[4],
-        }, {
-          label: 'Pacific Islander',
-          backgroundColor: COLORS_LANTERN_SET[5],
-          hoverBackgroundColor: COLORS_LANTERN_SET[5],
-          hoverBorderColor: COLORS_LANTERN_SET[5],
-          data: chartDataPoints[5],
-        }],
+        datasets: [
+          generateDataset('Caucasian', 0),
+          generateDataset('African American', 1),
+          generateDataset('Hispanic', 2),
+          generateDataset('Asian', 3),
+          generateDataset('Native American', 4),
+          generateDataset('Pacific Islander', 5),
+        ],
       }}
       options={{
         legend: {
           position: 'bottom',
+          labels: {
+            generateLabels: (chart) => generateLabelsWithCustomColors(chart, COLORS_LANTERN_SET)
+          }
         },
         responsive: true,
         maintainAspectRatio: false,
@@ -187,10 +177,12 @@ const RevocationsByRace = (props) => {
         },
         tooltips: {
           backgroundColor: COLORS['grey-800-light'],
+          footerFontSize: 9,
           mode: 'index',
           intersect: false,
           callbacks: {
             label: (tooltipItem, data) => tooltipForRateMetricWithNestedCounts(tooltipItem, data, numeratorCounts, denominatorCounts),
+            footer: (tooltipItem) => tooltipForFooterWithNestedCounts(tooltipItem, denominatorCounts),
           },
         },
       }}
@@ -205,6 +197,7 @@ const RevocationsByRace = (props) => {
     <div>
       <h4>
         Percent revoked by race/ethnicity and risk level
+        {showWarning === true && <WarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/components/charts/new_revocations/RevocationsByRiskLevel.js
+++ b/src/components/charts/new_revocations/RevocationsByRiskLevel.js
@@ -118,7 +118,7 @@ const RevocationsByRiskLevel = (props) => {
     props.metricPeriodMonths,
   ]);
 
-  const backgroundColor = ({ dataIndex, dataset, datasetIndex }) => {
+  const barBackgroundColor = ({ dataIndex, datasetIndex }) => {
     const color = COLORS['lantern-orange'];
     if (isDenominatorStatisticallySignificant(denominatorCounts[dataIndex])) {
       return color;
@@ -134,7 +134,7 @@ const RevocationsByRiskLevel = (props) => {
         labels: chartLabels,
         datasets: [{
           label: 'Revocation rate',
-          backgroundColor: backgroundColor,
+          backgroundColor: barBackgroundColor,
           data: chartDataPoints,
         }],
       }}

--- a/src/components/charts/new_revocations/RevocationsByRiskLevel.js
+++ b/src/components/charts/new_revocations/RevocationsByRiskLevel.js
@@ -18,8 +18,8 @@
 import React, { useState, useEffect } from 'react';
 import { Bar } from 'react-chartjs-2';
 import pattern from 'patternomaly';
+import DataSignificanceWarningIcon from '../DataSignificanceWarningIcon';
 import ExportMenu from '../ExportMenu';
-import WarningIcon from '../WarningIcon';
 import Loading from '../../Loading';
 
 import { useAuth0 } from '../../../react-auth0-spa';
@@ -186,7 +186,7 @@ const RevocationsByRiskLevel = (props) => {
     <div>
       <h4>
         Percent revoked by risk level
-        {showWarning === true && <WarningIcon />}
+        {showWarning === true && <DataSignificanceWarningIcon />}
         <ExportMenu
           chartId={chartId}
           chart={chart}

--- a/src/utils/charts/__tests__/significantStatistics.test.js
+++ b/src/utils/charts/__tests__/significantStatistics.test.js
@@ -1,0 +1,108 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import {
+  isDenominatorStatisticallySignificant,
+  isDenominatorsMatrixStatisticallySignificant,
+  tooltipForFooterWithCounts,
+  tooltipForFooterWithNestedCounts,
+} from "../significantStatistics";
+
+const statisticallySignificantDenominators = [0, 100, 1019];
+const statisticallyNotSignificantDenominators = [1, 10, 99];
+
+const statisticallySignificantDenominatorMatrix = [
+  [100, 234, 235, 123],
+  [930, 823, 348, 729],
+  [0, 829, 520, 327],
+  [981, 0, 124, 987],
+];
+
+const statisticallyNotSignificantDenominatorMatrix = [
+  [100, 234, 235, 123],
+  [930, 823, 348, 729],
+  [0, 829, 20, 327],
+  [981, 0, 124, 987],
+];
+
+describe("isDenominatorStatisticallySignificant function", () => {
+  it("should not be statistically significant", () => {
+    const given = statisticallyNotSignificantDenominators;
+
+    given.forEach((denominator) => {
+      expect(isDenominatorStatisticallySignificant(denominator)).toBe(false);
+    });
+  });
+
+  it("should be statistically significant", () => {
+    const given = statisticallySignificantDenominators;
+
+    given.forEach((denominator) => {
+      expect(isDenominatorStatisticallySignificant(denominator)).toBe(true);
+    });
+  });
+});
+
+describe("isDenominatorsMatrixStatisticallySignificant function", () => {
+  it("should not be statistically significant", () => {
+    const given = statisticallyNotSignificantDenominatorMatrix;
+
+    expect(isDenominatorsMatrixStatisticallySignificant(given)).toBe(false);
+  });
+
+  it("should be statistically significant", () => {
+    const given = statisticallySignificantDenominatorMatrix;
+
+    expect(isDenominatorsMatrixStatisticallySignificant(given)).toBeTrue(true);
+  });
+});
+
+describe("tooltipForFooterWithCounts function", () => {
+  it("returns warning footnote", () => {
+    const given = statisticallyNotSignificantDenominators;
+    const index = 2;
+
+    expect(tooltipForFooterWithCounts([{ index }], given)).toBe(
+      "* indicates low confidence due to small sample size"
+    );
+  });
+
+  it("returns empty footnote", () => {
+    const given = statisticallySignificantDenominators;
+    const index = 1;
+
+    expect(tooltipForFooterWithCounts([{ index }], given)).toBe("");
+  });
+});
+
+describe("tooltipForFooterWithNestedCounts function", () => {
+  it("returns warning footnote", () => {
+    const given = statisticallyNotSignificantDenominatorMatrix;
+    const index = 2;
+
+    expect(tooltipForFooterWithNestedCounts([{ index }], given)).toBe(
+      "* indicates low confidence due to small sample size"
+    );
+  });
+
+  it("returns empty footnote", () => {
+    const given = statisticallyNotSignificantDenominatorMatrix;
+    const index = 3;
+
+    expect(tooltipForFooterWithNestedCounts([{ index }], given)).toBe("");
+  });
+});

--- a/src/utils/charts/significantStatistics.js
+++ b/src/utils/charts/significantStatistics.js
@@ -1,0 +1,74 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2019 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { Chart } from 'react-chartjs-2';
+import pattern from 'patternomaly';
+
+function isDenominatorStatisticallySignificant(denomintor = 0) {
+  return denomintor === 0 || denomintor >= 100;
+}
+
+function isDenominatorsMatrixStatisticallySignificant(denominatorsMatrix) {
+  return !denominatorsMatrix.flat().some(d => !isDenominatorStatisticallySignificant(d));
+}
+
+function getBackgroundColor(color, denominators) {
+  return ({ dataIndex, dataset, datasetIndex }) => {
+    if (isDenominatorStatisticallySignificant(denominators[datasetIndex][dataIndex])) {
+      return color;
+    } else {
+      return pattern.draw('diagonal-right-left', color, '#ffffff', 5);
+    }
+  }
+}
+
+function tooltipForFooterWithCounts([{ index }], denominators) {
+  if (isDenominatorStatisticallySignificant(denominators[index])) {
+    return '';
+  } else {
+    return '* indicates low confidence due to small sample size';
+  }
+}
+
+function tooltipForFooterWithNestedCounts([{ index }], denominatorCounts) {
+  if (denominatorCounts.some(denominators => !isDenominatorStatisticallySignificant(denominators[index]))) {
+    return '* indicates low confidence due to small sample size';
+  } else {
+    return '';
+  }
+}
+
+/**
+ * Hack function for regenerate legend labels with custom colors
+ * because if chart bar is not statistically significant we should
+ * change color (add line shading) and after that chart do not know
+ * which color is right (with line shading or not).
+ */
+function generateLabelsWithCustomColors(chart, colors) {
+  return Chart.defaults.global.legend.labels
+    .generateLabels(chart)
+    .map((label, i) => ({ ...label, fillStyle: colors[i] }))
+}
+
+export {
+  generateLabelsWithCustomColors,
+  getBackgroundColor,
+  isDenominatorStatisticallySignificant,
+  isDenominatorsMatrixStatisticallySignificant,
+  tooltipForFooterWithCounts,
+  tooltipForFooterWithNestedCounts,
+}

--- a/src/utils/charts/significantStatistics.js
+++ b/src/utils/charts/significantStatistics.js
@@ -15,60 +15,65 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { Chart } from 'react-chartjs-2';
-import pattern from 'patternomaly';
+import pattern from "patternomaly";
+import { Chart } from "react-chartjs-2";
 
-function isDenominatorStatisticallySignificant(denomintor = 0) {
-  return denomintor === 0 || denomintor >= 100;
+function isDenominatorStatisticallySignificant(denominator = 0) {
+  return denominator === 0 || denominator >= 100;
 }
 
 function isDenominatorsMatrixStatisticallySignificant(denominatorsMatrix) {
-  return !denominatorsMatrix.flat().some(d => !isDenominatorStatisticallySignificant(d));
+  return ![]
+    .concat(...denominatorsMatrix)
+    .some((d) => !isDenominatorStatisticallySignificant(d));
 }
 
-function getBackgroundColor(color, denominators) {
-  return ({ dataIndex, dataset, datasetIndex }) => {
-    if (isDenominatorStatisticallySignificant(denominators[datasetIndex][dataIndex])) {
+function getBarBackgroundColor(color, denominators) {
+  const shadingSize = 5;
+
+  return ({ datasetIndex: i, dataIndex: j }) => {
+    if (isDenominatorStatisticallySignificant(denominators[i][j])) {
       return color;
-    } else {
-      return pattern.draw('diagonal-right-left', color, '#ffffff', 5);
     }
-  }
+    return pattern.draw("diagonal-right-left", color, "#ffffff", shadingSize);
+  };
 }
 
 function tooltipForFooterWithCounts([{ index }], denominators) {
   if (isDenominatorStatisticallySignificant(denominators[index])) {
-    return '';
-  } else {
-    return '* indicates low confidence due to small sample size';
+    return "";
   }
+  return "* indicates low confidence due to small sample size";
 }
 
 function tooltipForFooterWithNestedCounts([{ index }], denominatorCounts) {
-  if (denominatorCounts.some(denominators => !isDenominatorStatisticallySignificant(denominators[index]))) {
-    return '* indicates low confidence due to small sample size';
-  } else {
-    return '';
+  const isStatisticsImplicit = denominatorCounts.some(
+    (denominators) =>
+      !isDenominatorStatisticallySignificant(denominators[index])
+  );
+
+  if (isStatisticsImplicit) {
+    return "* indicates low confidence due to small sample size";
   }
+  return "";
 }
 
 /**
- * Hack function for regenerate legend labels with custom colors
- * because if chart bar is not statistically significant we should
- * change color (add line shading) and after that chart do not know
- * which color is right (with line shading or not).
+ * A hacky function to regenerate legend labels with custom colors.
+ * If a chart bar is not statistically significant we should change its color/pattern (i.e. add line shading).
+ * But labels/legends were generated ahead of time so the chart needs to be told to re-render them.
  */
 function generateLabelsWithCustomColors(chart, colors) {
   return Chart.defaults.global.legend.labels
     .generateLabels(chart)
-    .map((label, i) => ({ ...label, fillStyle: colors[i] }))
+    .map((label, i) => ({ ...label, fillStyle: colors[i] }));
 }
 
 export {
   generateLabelsWithCustomColors,
-  getBackgroundColor,
+  getBarBackgroundColor,
   isDenominatorStatisticallySignificant,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithCounts,
   tooltipForFooterWithNestedCounts,
-}
+};

--- a/src/utils/charts/toggles.js
+++ b/src/utils/charts/toggles.js
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { getTooltipWithoutTrendline } from './trendline';
+import { isDenominatorStatisticallySignificant } from './significantStatistics';
 
 function toggleLabel(labelsByToggle, toggledValue) {
   if (labelsByToggle[toggledValue]) {
@@ -149,8 +150,9 @@ function tooltipForRateMetricWithCounts(tooltipItem, data, numerators, denominat
   if (numerator !== undefined && denominator !== undefined) {
     appendedCounts = ` (${numerator}/${denominator})`;
   }
+  const cue = isDenominatorStatisticallySignificant(denominator) ? '' : ' *'
 
-  return `${label}: ${getTooltipWithoutTrendline(tooltipItem, data, '%')}${appendedCounts}`;
+  return `${label}: ${getTooltipWithoutTrendline(tooltipItem, data, '%')}${appendedCounts}${cue}`;
 }
 
 function tooltipForRateMetricWithNestedCounts(tooltipItem, data, numerators, denominators) {
@@ -163,8 +165,9 @@ function tooltipForRateMetricWithNestedCounts(tooltipItem, data, numerators, den
   if (numerator !== undefined && denominator !== undefined) {
     appendedCounts = ` (${numerator}/${denominator})`;
   }
+  const cue = isDenominatorStatisticallySignificant(denominator) ? '' : ' *'
 
-  return `${label}: ${getTooltipWithoutTrendline(tooltipItem, data, '%')}${appendedCounts}`;
+  return `${label}: ${getTooltipWithoutTrendline(tooltipItem, data, '%')}${appendedCounts}${cue}`;
 }
 
 function updateTooltipForMetricType(metricType, tooltipItem, data) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9311,6 +9311,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
 
+patternomaly@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/patternomaly/-/patternomaly-1.3.2.tgz#70b8db17d7318ab1471cc43f94011bb866c54d09"
+  integrity sha512-70UhA5+ZrnNgdfDBKXIGbMHpP+naTzfx9vPT4KwIdhtWWs0x6FWZRJQMXXhV2jcK0mxl28FA/2LPAKArNG058Q==
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"


### PR DESCRIPTION
## Description of the change

* Added `src/utils/charts/significantStatistics.js` which encapsulates all issue domain logic.
* Adapted revocations charts: by district (rate), by gender, by race and by risk.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #314

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
