### PR TITLE
Adds Serious Mental Illness as a possible supervision level in the Lantern view

### DIFF
--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -20,7 +20,7 @@ import * as csvExport from 'jsonexport/dist';
 import { timeStamp } from './time';
 import infoAboutChart from '../../../utils/charts/info';
 import JSZip from 'jszip';
-import { toTitleCase, toHumanReadable } from '../../../utils/transforms/labels';
+import { humanReadableTitleCase } from '../../../utils/transforms/labels';
 
 // Functions for flowing through browser-specific download functionality
 // https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
@@ -83,7 +83,7 @@ function getFilterValue(filterValue, descriptionPlural, descriptionOne) {
   } else if (parseInt(filterValue) === 1 && (descriptionOne === "month")) {
     str = filterValue + " " + descriptionOne;
   } else {
-    str = descriptionOne + toHumanReadable(toTitleCase(filterValue.toLowerCase()));
+    str = descriptionOne + humanReadableTitleCase(filterValue.toLowerCase());
   }
   return str;
 }
@@ -96,7 +96,7 @@ function getViolation(toggleStates) {
       str += toggleStates.reportedViolations + " violations or notices of citation, ";
     }
     if (toggleStates.violationType !== undefined && toggleStates.violationType !== "") {
-      str += "Most severe: " + toHumanReadable(toTitleCase(toggleStates.violationType.toLowerCase()));
+      str += "Most severe: " + humanReadableTitleCase(toggleStates.violationType.toLowerCase());
     }
     return (str !== "- ") ? str + "\n" : "";
   }
@@ -146,6 +146,7 @@ function downloadZipFile(files, zipFilename) {
     downloadjs(content, zipFilename);
   });
 }
+
 function downloadObjectAsCsv(exportObj, exportName, shouldZipDownload) {
   const options = {
     mapHeaders: (header) => header.replace(/label|values./, ''),

--- a/src/utils/transforms/__tests__/labels.test.js
+++ b/src/utils/transforms/__tests__/labels.test.js
@@ -16,7 +16,7 @@
 // =============================================================================
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import * as labelsMethods from './labels';
+import * as labelsMethods from '../labels';
 
 describe('test label', () => {
 
@@ -38,6 +38,11 @@ describe('test label', () => {
  it('to Html friendly', () => {
    const dataAfterTest = labelsMethods.toHtmlFriendly('Los Angeles');
    expect(dataAfterTest.toString()).toEqual('Los-Angeles');
+ });
+
+ it('to Html friendly with multiple spaces', () => {
+   const dataAfterTest = labelsMethods.toHtmlFriendly('Los Angeles California');
+   expect(dataAfterTest.toString()).toEqual('Los-Angeles-California');
  });
 
  it('to human readable', () => {
@@ -63,8 +68,20 @@ describe('test label', () => {
    expect(dataErrorAfterTest).toEqual('');
  });
 
- it('human readable title case', () => {
-   const dataForTesting = 'SAN FRANCISCO CALIFORNIA';
+ it('human readable title case with underscores', () => {
+   const dataForTesting = 'SAN_FRANCISCO_CALIFORNIA';
+   const dataAfterTest = labelsMethods.humanReadableTitleCase(dataForTesting);
+   expect(dataAfterTest).toEqual('San Francisco California');
+ });
+
+ it('human readable title case with hyphens', () => {
+   const dataForTesting = 'SAN-FRANCISCO-CALIFORNIA';
+   const dataAfterTest = labelsMethods.humanReadableTitleCase(dataForTesting);
+   expect(dataAfterTest).toEqual('San Francisco California');
+ });
+
+ it('human readable title case with a mix of punctuation', () => {
+   const dataForTesting = 'SAN_FRANCISCO-CALIFORNIA';
    const dataAfterTest = labelsMethods.humanReadableTitleCase(dataForTesting);
    expect(dataAfterTest).toEqual('San Francisco California');
  });

--- a/src/utils/transforms/labels.js
+++ b/src/utils/transforms/labels.js
@@ -76,12 +76,12 @@ function raceValueToHumanReadable(raceValue) {
 }
 
 function toHtmlFriendly(string) {
-  return string.replace(' ', '-');
+  return string.replace(/ /g, '-');
 }
 
 function toHumanReadable(string) {
-  let newString = string.replace('-', ' ');
-  newString = newString.replace('_', ' ');
+  let newString = string.replace(/-/g, ' ');
+  newString = newString.replace(/_/g, ' ');
   return newString;
 }
 

--- a/src/views/tenants/us_mo/Revocations.js
+++ b/src/views/tenants/us_mo/Revocations.js
@@ -61,6 +61,7 @@ const CHARGE_CATEGORIES = [
   { value: 'GENERAL', label: 'General' },
   { value: 'SEX_OFFENDER', label: 'Sex Offense' },
   { value: 'DOMESTIC_VIOLENCE', label: 'Domestic Violence' },
+  { value: 'SERIOUS_MENTAL_ILLNESS', label: 'Serious Mental Illness' },
 ];
 
 // TODO: Determine if we want to continue to explicitly provide charge_category=ALL or treat it


### PR DESCRIPTION
## Description of the change

The calculation support already exists and, in fact, the fixture data (with the exception of the caseload table) already had the value latent, so it was a one line addition to add support.

The rest of the changes are around the fact that the dropdown value of "serious_mental_illness" revealed a bug in some of our `labels` utilities that we expected to replace all instances of underscores or hyphens with whitespace. In fact, they only replaced the first such instance. So I fixed that, add new unit tests, and move the `labels.test` to the right folder.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #318 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
