### PR TITLE
add space before "Recidiviz Support" link

### DIFF
--- a/src/views/VerificationNeeded.js
+++ b/src/views/VerificationNeeded.js
@@ -38,7 +38,8 @@ const VerificationNeeded = () => (
         </p>
         <p className="mB-30 fsz-def c-grey-700">
           If you have reached this page by mistake, please try to log in again.
-          If you are still having trouble, please reach out to &nbsp;
+          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+          If you are still having trouble, please reach out to{" "}
           <a
             href="mailto:web-support@recidiviz.org?Subject=Trouble%20logging%20in"
             target="_top"

--- a/src/views/VerificationNeeded.js
+++ b/src/views/VerificationNeeded.js
@@ -38,7 +38,7 @@ const VerificationNeeded = () => (
         </p>
         <p className="mB-30 fsz-def c-grey-700">
           If you have reached this page by mistake, please try to log in again.
-          If you are still having trouble, please reach out to
+          If you are still having trouble, please reach out to &nbsp;
           <a
             href="mailto:web-support@recidiviz.org?Subject=Trouble%20logging%20in"
             target="_top"


### PR DESCRIPTION
## Description of the change

Adds a space before the link in the help text.

I was going to just file a bug for this but thought I might as well try to create a PR on my own to explore the code a bit.

![Screen Shot 2020-07-27 at 10 22 47 AM (2)](https://user-images.githubusercontent.com/3762913/88591388-1eeb9b00-d011-11ea-8792-e65e322a7c85.png)


## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Related issues

None

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
