### PR TITLE
Fixes chart exports which were not working on first page load

### DIFF
--- a/src/components/charts/common/AdmissionCountsByType.js
+++ b/src/components/charts/common/AdmissionCountsByType.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Bar, Pie } from "react-chartjs-2";
 
@@ -233,15 +233,24 @@ const AdmissionCountsByType = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "ADMISSIONS BY TYPE",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "ADMISSIONS BY TYPE",
+      activeChart.props.data.datasets,
+      activeChart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { metricPeriodMonths, metricType, district, supervisionType }
+    );
+  }, [
+    metricPeriodMonths,
+    metricType,
+    district,
+    supervisionType,
     activeChart.props.data.datasets,
     activeChart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { metricPeriodMonths, metricType, district, supervisionType }
-  );
+  ]);
 
   return activeChart;
 };

--- a/src/components/charts/community/LsirScoreChangeSnapshot.js
+++ b/src/components/charts/community/LsirScoreChangeSnapshot.js
@@ -219,17 +219,26 @@ const LsirScoreChangeSnapshot = ({
       series: [],
     };
   };
-  configureDownloadButtons(
-    chartId,
-    "LSI-R SCORE CHANGES (AVERAGE)",
+
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "LSI-R SCORE CHANGES (AVERAGE)",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { supervisionType, district, metricPeriodMonths },
+      true,
+      true
+    );
+  }, [
+    metricPeriodMonths,
+    district,
+    supervisionType,
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { supervisionType, district, metricPeriodMonths },
-    true,
-    true
-  );
+  ]);
 
   useEffect(() => {
     const headerElement = document.getElementById(header);

--- a/src/components/charts/community/RevocationAdmissionsSnapshot.js
+++ b/src/components/charts/community/RevocationAdmissionsSnapshot.js
@@ -283,17 +283,28 @@ const RevocationAdmissionsSnapshot = ({
       series: [],
     };
   };
-  configureDownloadButtons(
-    chartId,
-    "PRISON ADMISSIONS DUE TO REVOCATION",
+
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "PRISON ADMISSIONS DUE TO REVOCATION",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      toggles,
+      true,
+      true
+    );
+  }, [
+    metricType,
+    metricPeriodMonths,
+    district,
+    supervisionType,
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
     toggles,
-    true,
-    true
-  );
+  ]);
 
   useEffect(() => {
     const headerElement = document.getElementById(header);

--- a/src/components/charts/community/RevocationCountOverTime.js
+++ b/src/components/charts/community/RevocationCountOverTime.js
@@ -192,17 +192,25 @@ const RevocationCountOverTime = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "REVOCATION ADMISSIONS BY MONTH",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "REVOCATION ADMISSIONS BY MONTH",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { metricType, supervisionType, district },
+      true,
+      true
+    );
+  }, [
+    metricType,
+    district,
+    supervisionType,
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { metricType, supervisionType, district },
-    true,
-    true
-  );
+  ]);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/community/RevocationProportionByRace.js
+++ b/src/components/charts/community/RevocationProportionByRace.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Bar, HorizontalBar } from "react-chartjs-2";
 
@@ -253,15 +253,24 @@ const RevocationProportionByRace = ({
     activeChart = ratesChart;
   }
 
-  configureDownloadButtons(
-    chartId,
-    "REVOCATIONS BY RACE",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "REVOCATIONS BY RACE",
+      activeChart.props.data.datasets,
+      activeChart.props.data.labels,
+      document.getElementById("revocationsByRace"),
+      exportedStructureCallback,
+      { metricPeriodMonths, district, supervisionType }
+    );
+  }, [
+    metricType,
+    metricPeriodMonths,
+    district,
+    supervisionType,
     activeChart.props.data.datasets,
     activeChart.props.data.labels,
-    document.getElementById("revocationsByRace"),
-    exportedStructureCallback,
-    { metricPeriodMonths, district, supervisionType }
-  );
+  ]);
 
   return activeChart;
 };

--- a/src/components/charts/community/SupervisionSuccessSnapshot.js
+++ b/src/components/charts/community/SupervisionSuccessSnapshot.js
@@ -268,17 +268,26 @@ const SupervisionSuccessSnapshot = ({
     };
   };
 
-  configureDownloadButtons(
-    chartId,
-    "SUCCESSFUL COMPLETION OF SUPERVISION",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "SUCCESSFUL COMPLETION OF SUPERVISION",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { metricType, metricPeriodMonths, supervisionType, district },
+      true,
+      true
+    );
+  }, [
+    metricType,
+    metricPeriodMonths,
+    supervisionType,
+    district,
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { metricType, metricPeriodMonths, supervisionType, district },
-    true,
-    true
-  );
+  ]);
 
   useEffect(() => {
     const headerElement = document.getElementById(header);

--- a/src/components/charts/facilities/AdmissionsVsReleases.js
+++ b/src/components/charts/facilities/AdmissionsVsReleases.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Bar } from "react-chartjs-2";
 
@@ -170,17 +170,25 @@ const AdmissionsVsReleases = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "ADMISSIONS VERSUS RELEASES",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "ADMISSIONS VERSUS RELEASES",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { district, metricType, metricPeriodMonths },
+      true,
+      true
+    );
+  }, [
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { district, metricType, metricPeriodMonths },
-    true,
-    true
-  );
+    district,
+    metricPeriodMonths,
+    metricType,
+  ]);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/facilities/DaysAtLibertySnapshot.js
+++ b/src/components/charts/facilities/DaysAtLibertySnapshot.js
@@ -192,17 +192,19 @@ const DaysAtLibertySnapshot = ({
     };
   };
 
-  configureDownloadButtons(
-    chartId,
-    "DAYS AT LIBERTY (AVERAGE)",
-    chart.props.data.datasets,
-    chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    {},
-    true,
-    true
-  );
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "DAYS AT LIBERTY (AVERAGE)",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      {},
+      true,
+      true
+    );
+  }, [chart.props.data.datasets, chart.props.data.labels, metricPeriodMonths]);
 
   useEffect(() => {
     const headerElement = document.getElementById(header);

--- a/src/components/charts/facilities/ReincarcerationCountOverTime.js
+++ b/src/components/charts/facilities/ReincarcerationCountOverTime.js
@@ -218,17 +218,25 @@ const ReincarcerationCountOverTime = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "REINCARCERATIONS BY MONTH",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "REINCARCERATIONS BY MONTH",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { district, metricType, metricPeriodMonths },
+      true,
+      true
+    );
+  }, [
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { district, metricType, metricPeriodMonths },
-    true,
-    true
-  );
+    district,
+    metricPeriodMonths,
+    metricType,
+  ]);
 
   useEffect(() => {
     const chartData = chart.props.data.datasets[0].data;

--- a/src/components/charts/facilities/ReincarcerationRateByStayLength.js
+++ b/src/components/charts/facilities/ReincarcerationRateByStayLength.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Bar } from "react-chartjs-2";
 
@@ -162,15 +162,22 @@ const ReincarcerationRateByStayLength = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "REINCARCERATIONS BY PREVIOUS STAY LENGTH",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "REINCARCERATIONS BY PREVIOUS STAY LENGTH",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { district, metricType }
+    );
+  }, [
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { district, metricType }
-  );
+    district,
+    metricType,
+  ]);
 
   return chart;
 };

--- a/src/components/charts/programming/FtrReferralCountByMonth.js
+++ b/src/components/charts/programming/FtrReferralCountByMonth.js
@@ -166,17 +166,26 @@ const FtrReferralCountByMonth = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "FTR REFERRAL COUNT BY MONTH",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "FTR REFERRAL COUNT BY MONTH",
+      chart.props.data.datasets,
+      chart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { supervisionType, district, metricType, metricPeriodMonths },
+      true,
+      true
+    );
+  }, [
+    supervisionType,
+    district,
+    metricPeriodMonths,
+    metricType,
     chart.props.data.datasets,
     chart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { supervisionType, district, metricType, metricPeriodMonths },
-    true,
-    true
-  );
+  ]);
 
   const chartData = chart.props.data.datasets[0].data;
   const mostRecentValue = chartData[chartData.length - 1];

--- a/src/components/charts/programming/FtrReferralsByAge.js
+++ b/src/components/charts/programming/FtrReferralsByAge.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Bar } from "react-chartjs-2";
 
 import pipe from "lodash/fp/pipe";
@@ -303,15 +303,24 @@ const FtrReferralsByAge = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "FTR REFERRALS BY AGE",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "FTR REFERRALS BY AGE",
+      activeChart.props.data.datasets,
+      activeChart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { supervisionType, district, metricPeriodMonths, metricType }
+    );
+  }, [
+    supervisionType,
+    district,
+    metricPeriodMonths,
+    metricType,
     activeChart.props.data.datasets,
     activeChart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { supervisionType, district, metricPeriodMonths, metricType }
-  );
+  ]);
 
   return activeChart;
 };

--- a/src/components/charts/programming/FtrReferralsByGender.js
+++ b/src/components/charts/programming/FtrReferralsByGender.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Bar } from "react-chartjs-2";
 
 import groupBy from "lodash/fp/groupBy";
@@ -226,15 +226,24 @@ const FtrReferralsByGender = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "FTR REFERRALS BY GENDER",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "FTR REFERRALS BY GENDER",
+      activeChart.props.data.datasets,
+      activeChart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { supervisionType, district, metricPeriodMonths, metricType }
+    );
+  }, [
+    supervisionType,
+    district,
+    metricPeriodMonths,
+    metricType,
     activeChart.props.data.datasets,
     activeChart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { supervisionType, district, metricPeriodMonths, metricType }
-  );
+  ]);
 
   return activeChart;
 };

--- a/src/components/charts/programming/FtrReferralsByLsir.js
+++ b/src/components/charts/programming/FtrReferralsByLsir.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Bar } from "react-chartjs-2";
 
 import defaults from "lodash/fp/defaults";
@@ -296,15 +296,24 @@ const FtrReferralsByLsir = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "FTR REFERRALS BY LSI-R",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "FTR REFERRALS BY LSI-R",
+      activeChart.props.data.datasets,
+      activeChart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { supervisionType, district, metricPeriodMonths, metricType }
+    );
+  }, [
+    supervisionType,
+    district,
+    metricPeriodMonths,
+    metricType,
     activeChart.props.data.datasets,
     activeChart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { supervisionType, district, metricPeriodMonths, metricType }
-  );
+  ]);
 
   return activeChart;
 };

--- a/src/components/charts/programming/FtrReferralsByRace.js
+++ b/src/components/charts/programming/FtrReferralsByRace.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Bar, HorizontalBar } from "react-chartjs-2";
 
 import map from "lodash/fp/map";
@@ -280,15 +280,24 @@ const FtrReferralsByRace = ({
     series: [],
   });
 
-  configureDownloadButtons(
-    chartId,
-    "FTR REFERRALS BY RACE",
+  useEffect(() => {
+    configureDownloadButtons(
+      chartId,
+      "FTR REFERRALS BY RACE",
+      activeChart.props.data.datasets,
+      activeChart.props.data.labels,
+      document.getElementById(chartId),
+      exportedStructureCallback,
+      { supervisionType, district, metricPeriodMonths, metricType }
+    );
+  }, [
+    supervisionType,
+    district,
+    metricPeriodMonths,
+    metricType,
     activeChart.props.data.datasets,
     activeChart.props.data.labels,
-    document.getElementById(chartId),
-    exportedStructureCallback,
-    { supervisionType, district, metricPeriodMonths, metricType }
-  );
+  ]);
 
   return activeChart;
 };


### PR DESCRIPTION
## Description of the change

The charts that were working were using shared components that put the export configuration calls inside of `useEffect` hooks. The charts that were not working did not have these hooks in place, meaning that they would not work on first arrival to the page, only after changes were made to cause re-render.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #446 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
