### PR TITLE
Adds feature flag to suppress the revocation rate by exit feature

### DIFF
--- a/src/components/charts/new_revocations/RevocationsByDistrict/helpers.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict/helpers.js
@@ -21,6 +21,7 @@ import sumBy from "lodash/fp/sumBy";
 import toInteger from "lodash/fp/toInteger";
 
 import { calculateRate } from "../helpers/rate";
+import flags from "../../../../flags";
 
 /**
  * Creator function for grouping data by district.
@@ -74,8 +75,13 @@ export const sumCounts = (key, data) =>
     sumBy((item) => toInteger(item[key]))
   )(data);
 
-export const modeButtons = [
-  { label: "Revocation count", value: "counts" },
-  { label: "Percent revoked of standing population", value: "rates" },
-  { label: "Percent revoked of exits", value: "exits" },
-];
+export const modeButtons = flags.enableRevocationRateByExit
+  ? [
+      { label: "Revocation count", value: "counts" },
+      { label: "Percent revoked of standing population", value: "rates" },
+      { label: "Percent revoked of exits", value: "exits" },
+    ]
+  : [
+      { label: "Revocation count", value: "counts" },
+      { label: "Percent revoked of standing population", value: "rates" },
+    ];

--- a/src/components/charts/new_revocations/RevocationsByGender/RevocationsByGender.js
+++ b/src/components/charts/new_revocations/RevocationsByGender/RevocationsByGender.js
@@ -33,6 +33,7 @@ import DataSignificanceWarningIcon from "../../DataSignificanceWarningIcon";
 import ExportMenu from "../../ExportMenu";
 import Loading from "../../../Loading";
 
+import flags from "../../../../flags";
 import { COLORS } from "../../../../assets/scripts/constants/colors";
 import { axisCallbackForPercentage } from "../../../../utils/charts/axis";
 import {
@@ -173,7 +174,9 @@ const RevocationsByGender = ({
         />
       </h4>
       <h6 className="pB-20">{timeDescription}</h6>
-      <ModeSwitcher mode={mode} setMode={setMode} buttons={modeButtons} />
+      {flags.enableRevocationRateByExit && (
+        <ModeSwitcher mode={mode} setMode={setMode} buttons={modeButtons} />
+      )}
       <div className="static-chart-container fs-block">{chart}</div>
     </div>
   );

--- a/src/components/charts/new_revocations/RevocationsByRace/RevocationsByRace.js
+++ b/src/components/charts/new_revocations/RevocationsByRace/RevocationsByRace.js
@@ -33,6 +33,7 @@ import DataSignificanceWarningIcon from "../../DataSignificanceWarningIcon";
 import ExportMenu from "../../ExportMenu";
 import Loading from "../../../Loading";
 
+import flags from "../../../../flags";
 import {
   COLORS,
   COLORS_LANTERN_SET,
@@ -187,7 +188,9 @@ const RevocationsByRace = ({
         />
       </h4>
       <h6 className="pB-20">{timeDescription}</h6>
-      <ModeSwitcher mode={mode} setMode={setMode} buttons={modeButtons} />
+      {flags.enableRevocationRateByExit && (
+        <ModeSwitcher mode={mode} setMode={setMode} buttons={modeButtons} />
+      )}
       <div className="static-chart-container fs-block">{chart}</div>
     </div>
   );

--- a/src/components/charts/new_revocations/RevocationsByRiskLevel/RevocationsByRiskLevel.js
+++ b/src/components/charts/new_revocations/RevocationsByRiskLevel/RevocationsByRiskLevel.js
@@ -35,6 +35,7 @@ import DataSignificanceWarningIcon from "../../DataSignificanceWarningIcon";
 import ExportMenu from "../../ExportMenu";
 import Loading from "../../../Loading";
 
+import flags from "../../../../flags";
 import { COLORS } from "../../../../assets/scripts/constants/colors";
 import useChartData from "../../../../hooks/useChartData";
 import { axisCallbackForPercentage } from "../../../../utils/charts/axis";
@@ -200,7 +201,9 @@ const RevocationsByRiskLevel = ({
         />
       </h4>
       <h6 className="pB-20">{timeDescription}</h6>
-      <ModeSwitcher mode={mode} setMode={setMode} buttons={modeButtons} />
+      {flags.enableRevocationRateByExit && (
+        <ModeSwitcher mode={mode} setMode={setMode} buttons={modeButtons} />
+      )}
       <div className="static-chart-container fs-block">{chart}</div>
     </div>
   );

--- a/src/flags.js
+++ b/src/flags.js
@@ -1,4 +1,6 @@
 export default {
-  // TODO(425): Set true when we are ready to launch admission type filters for MO
-  "enableAdmissionTypeFilterForMO": false
+  // TODO(425): Set to true when we are ready to launch admission type filters for MO
+  "enableAdmissionTypeFilterForMO": false,
+  // TODO(395): Set to true when we have debugged the issues with the exit rate calculations
+  "enableRevocationRateByExit": false,
 }


### PR DESCRIPTION
## Description of the change

There are calculation issues on the backend that need to be debugged before we can enable this feature in production, hence the feature flag. This makes it so that the rate by exit charts cannot be reached until the flag has been switched _on_.

This should be the only thing currently on master that needs to be suppressed before we can ship our next release to production.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Related to #395 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
