### PR TITLE
Ensures there is a line of whitespace between the export data line an…

### DIFF
--- a/src/assets/scripts/utils/downloads.js
+++ b/src/assets/scripts/utils/downloads.js
@@ -185,7 +185,7 @@ function downloadMethodologyFile(chartId, chartTitle, timeWindowDescription, tog
   }
 
   text += "\r\n";
-  text += `Export Date: ${exportDate}\r\n`;
+  text += `Export Date: ${exportDate}\r\n\n`;
 
   infoChart.map((chart) => {
     text += chart.header + "\r\n";


### PR DESCRIPTION
## Description of the change
Ensures there is a line of whitespace between the export data line and the main body of the file in the Lantern methodology.txt file in exports.

@jovergaag if you haven't seen this feature yet, click the ellipsis menu in one of the Lantern cards, select either export option, and see that the downloaded zip contains a `methodology.txt` file. This tiny fix ensure there is more readable whitespace near the top of the file.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
