### PR TITLE
Production data bug - MO matrix technical revocation counts

### DIFF
--- a/src/components/charts/new_revocations/helpers.js
+++ b/src/components/charts/new_revocations/helpers.js
@@ -46,7 +46,8 @@ const includesAllItemFirst = (items) => {
 export const applyTopLevelFilters = (filters) => (
   data,
   skippedFilters = [],
-  treatCategoryAllAsAbsent = false
+  treatCategoryAllAsAbsent = false,
+  applySupervisionLevel = false
 ) =>
   data.filter((item) => {
     if (
@@ -91,10 +92,15 @@ export const applyTopLevelFilters = (filters) => (
       return false;
     }
     if (
-      filters.supervisionLevel &&
-      !skippedFilters.includes("supervisionLevel") &&
-      !isAllItem(filters.supervisionLevel) &&
-      !nullSafeComparison(item.supervision_level, filters.supervisionLevel)
+      (filters.supervisionLevel &&
+        !skippedFilters.includes("supervisionLevel") &&
+        !isAllItem(filters.supervisionLevel) &&
+        !nullSafeComparison(
+          item.supervision_level,
+          filters.supervisionLevel
+        )) ||
+      (!applySupervisionLevel &&
+        (!item.supervision_level || isAllItem(item.supervision_level)))
     ) {
       return false;
     }
@@ -120,7 +126,7 @@ const applyMatrixFilters = (filters) => (data) =>
     return true;
   });
 
-export const applyAllFilters = (filters) => (
+export const applyAllFilters = (filters, applySupervisionLevel = false) => (
   data,
   skippedFilters = [],
   treatCategoryAllAsAbsent = false
@@ -128,7 +134,8 @@ export const applyAllFilters = (filters) => (
   const filteredData = applyTopLevelFilters(filters)(
     data,
     skippedFilters,
-    treatCategoryAllAsAbsent
+    treatCategoryAllAsAbsent,
+    applySupervisionLevel
   );
   return applyMatrixFilters(filters)(filteredData);
 };

--- a/src/components/charts/new_revocations/helpers.js
+++ b/src/components/charts/new_revocations/helpers.js
@@ -43,11 +43,10 @@ const includesAllItemFirst = (items) => {
   return items.length === 1 && isAllItem(items[0]);
 };
 
-export const applyTopLevelFilters = (filters) => (
+export const applyTopLevelFilters = (filters, applySupervisionLevel = true) => (
   data,
   skippedFilters = [],
-  treatCategoryAllAsAbsent = false,
-  applySupervisionLevel = false
+  treatCategoryAllAsAbsent = false
 ) =>
   data.filter((item) => {
     if (
@@ -122,20 +121,18 @@ const applyMatrixFilters = (filters) => (data) =>
     ) {
       return false;
     }
-
     return true;
   });
 
-export const applyAllFilters = (filters, applySupervisionLevel = false) => (
+export const applyAllFilters = (filters, applySupervisionLevel = true) => (
   data,
   skippedFilters = [],
   treatCategoryAllAsAbsent = false
 ) => {
-  const filteredData = applyTopLevelFilters(filters)(
+  const filteredData = applyTopLevelFilters(filters, applySupervisionLevel)(
     data,
     skippedFilters,
-    treatCategoryAllAsAbsent,
-    applySupervisionLevel
+    treatCategoryAllAsAbsent
   );
   return applyMatrixFilters(filters)(filteredData);
 };

--- a/src/components/charts/new_revocations/helpers.js
+++ b/src/components/charts/new_revocations/helpers.js
@@ -99,7 +99,8 @@ export const applyTopLevelFilters = (filters, applySupervisionLevel = true) => (
           filters.supervisionLevel
         )) ||
       (!applySupervisionLevel &&
-        (!item.supervision_level || isAllItem(item.supervision_level)))
+        item.supervision_level &&
+        isAllItem(item.supervision_level))
     ) {
       return false;
     }

--- a/src/views/tenants/us_mo/community/Revocations.js
+++ b/src/views/tenants/us_mo/community/Revocations.js
@@ -120,7 +120,7 @@ const Revocations = () => {
     filters,
     userDistricts
   );
-  const allDataFilter = applyAllFilters(transformedFilters);
+  const allDataFilter = applyAllFilters(transformedFilters, false);
 
   const timeDescription = getTimeDescription(
     filters.metricPeriodMonths,

--- a/src/views/tenants/us_mo/community/Revocations.js
+++ b/src/views/tenants/us_mo/community/Revocations.js
@@ -120,7 +120,7 @@ const Revocations = () => {
     filters,
     userDistricts
   );
-  const allDataFilter = applyAllFilters(transformedFilters, true);
+  const allDataFilter = applyAllFilters(transformedFilters);
 
   const timeDescription = getTimeDescription(
     filters.metricPeriodMonths,
@@ -176,7 +176,7 @@ const Revocations = () => {
       <div className="d-f m-20 container-all-charts">
         <div className="matrix-container bgc-white p-20 mR-20">
           <RevocationMatrix
-            dataFilter={applyTopLevelFilters(transformedFilters)}
+            dataFilter={applyTopLevelFilters(transformedFilters, false)}
             filterStates={filters}
             updateFilters={updateFilters}
             timeDescription={timeDescription}

--- a/src/views/tenants/us_mo/community/Revocations.js
+++ b/src/views/tenants/us_mo/community/Revocations.js
@@ -120,7 +120,7 @@ const Revocations = () => {
     filters,
     userDistricts
   );
-  const allDataFilter = applyAllFilters(transformedFilters);
+  const allDataFilter = applyAllFilters(transformedFilters, true);
 
   const timeDescription = getTimeDescription(
     filters.metricPeriodMonths,

--- a/src/views/tenants/us_pa/community/Revocations.js
+++ b/src/views/tenants/us_pa/community/Revocations.js
@@ -121,7 +121,7 @@ const Revocations = () => {
     filters,
     userDistricts
   );
-  const allDataFilter = applyAllFilters(transformedFilters);
+  const allDataFilter = applyAllFilters(transformedFilters, true);
 
   const timeDescription = getTimeDescription(
     filters.metricPeriodMonths,

--- a/src/views/tenants/us_pa/community/Revocations.js
+++ b/src/views/tenants/us_pa/community/Revocations.js
@@ -121,7 +121,7 @@ const Revocations = () => {
     filters,
     userDistricts
   );
-  const allDataFilter = applyAllFilters(transformedFilters, true);
+  const allDataFilter = applyAllFilters(transformedFilters);
 
   const timeDescription = getTimeDescription(
     filters.metricPeriodMonths,


### PR DESCRIPTION
## Description of the change

Fixes a bug in production where revocations were being counted twice due to filtering logic not taking into account the new `supervisionLevel` rows in the MO data.

I agree with @jessex that this is not the most elegant solution, but the more elegant solution will take more time so lets get it in and I'll look at it more soon.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #498

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
