### PR TITLE
Styling tweaks

### DIFF
--- a/src/components/charts/new_revocations/RevocationMatrix/RevocationMatrixCell.js
+++ b/src/components/charts/new_revocations/RevocationMatrix/RevocationMatrixCell.js
@@ -37,7 +37,9 @@ const RevocationMatrixCell = ({ count, maxCount, isSelected, onClick }) => {
   };
 
   const cellStyle = {
-    background: `rgba(0, 44, 66, ${ratio})`, // lantern-dark-blue with opacity
+    // lantern-dark-blue with opacity
+    background:
+      ratio === 0 ? COLORS.white : `rgba(0, 44, 66, ${Math.max(ratio, 0.05)})`,
     width: "100%",
     height: "100%",
     borderRadius: Math.ceil(radius / 2),

--- a/src/components/charts/new_revocations/RevocationMatrix/RevocationMatrixExplanation.js
+++ b/src/components/charts/new_revocations/RevocationMatrix/RevocationMatrixExplanation.js
@@ -17,13 +17,13 @@
 
 import React from "react";
 
-import { translate } from "../../../views/tenants/utils/i18nSettings";
+import { translate } from "../../../../views/tenants/utils/i18nSettings";
 
 const RevocationMatrixExplanation = () => (
   <div className="matrix-explanation bgc-white p-20">
     <h4>Using this chart</h4>
-    <p className="fw-300">{translate("matrixExplanationP1")}</p>
-    <p className="fw-300">{translate("matrixExplanationP2")}</p>
+    <p className="fw-400">{translate("matrixExplanationP1")}</p>
+    <p className="fw-400">{translate("matrixExplanationP2")}</p>
     <div className="d-f mT-20">
       <div className="example-icon-container">
         <div className="example-violation-total">35</div>

--- a/src/components/controls/Select.js
+++ b/src/components/controls/Select.js
@@ -27,6 +27,7 @@ import ReactSelect, { components } from "react-select";
 import has from "lodash/fp/has";
 import map from "lodash/fp/map";
 
+import { COLORS } from "../../assets/scripts/constants/colors";
 import "./Select.scss";
 
 export const getAllOptionsWithValue = (options, summingOption) => {
@@ -224,9 +225,7 @@ const defaultStyles = {
     ...base,
     ...fontStyles,
     backgroundColor: state.isMulti ? "transparent" : base.backgroundColor,
-    "&:active": {
-      backgroundColor: state.isMulti ? "transparent" : base.backgroundColor,
-    },
+    color: state.isSelected && !state.isMulti ? COLORS.white : fontStyles.color,
   }),
   singleValue: (base) => ({ ...base, ...fontStyles }),
   group: (base) => ({ ...base, ...fontStyles, marginLeft: 20 }),

--- a/src/views/tenants/us_mo/community/Revocations.js
+++ b/src/views/tenants/us_mo/community/Revocations.js
@@ -26,7 +26,7 @@ import RevocationsByRace from "../../../../components/charts/new_revocations/Rev
 import RevocationsByDistrict from "../../../../components/charts/new_revocations/RevocationsByDistrict/RevocationsByDistrict";
 import RevocationCountOverTime from "../../../../components/charts/new_revocations/RevocationsOverTime";
 import RevocationMatrix from "../../../../components/charts/new_revocations/RevocationMatrix/RevocationMatrix";
-import RevocationMatrixExplanation from "../../../../components/charts/new_revocations/RevocationMatrixExplanation";
+import RevocationMatrixExplanation from "../../../../components/charts/new_revocations/RevocationMatrix/RevocationMatrixExplanation";
 import ToggleBar from "../../../../components/charts/new_revocations/ToggleBar/ToggleBar";
 import MetricPeriodMonthsFilter from "../../../../components/charts/new_revocations/ToggleBar/MetricPeriodMonthsFilter";
 import DistrictFilter from "../../../../components/charts/new_revocations/ToggleBar/DistrictFilter";

--- a/src/views/tenants/us_pa/community/Revocations.js
+++ b/src/views/tenants/us_pa/community/Revocations.js
@@ -26,7 +26,7 @@ import RevocationsByRace from "../../../../components/charts/new_revocations/Rev
 import RevocationsByDistrict from "../../../../components/charts/new_revocations/RevocationsByDistrict/RevocationsByDistrict";
 import RevocationCountOverTime from "../../../../components/charts/new_revocations/RevocationsOverTime";
 import RevocationMatrix from "../../../../components/charts/new_revocations/RevocationMatrix/RevocationMatrix";
-import RevocationMatrixExplanation from "../../../../components/charts/new_revocations/RevocationMatrixExplanation";
+import RevocationMatrixExplanation from "../../../../components/charts/new_revocations/RevocationMatrix/RevocationMatrixExplanation";
 import ToggleBar from "../../../../components/charts/new_revocations/ToggleBar/ToggleBar";
 import MetricPeriodMonthsFilter from "../../../../components/charts/new_revocations/ToggleBar/MetricPeriodMonthsFilter";
 import DistrictFilter from "../../../../components/charts/new_revocations/ToggleBar/DistrictFilter";


### PR DESCRIPTION
## Description of the change

The final PA comb through surfaced a few styling tweaks that need to be addressed:
1. Change `font-weight: 400` for the 'Using this chart' section of the Revocation Matrix
2. Change the text color to white for the 'selected' option in the Select dropdown
3. Give the Revocation Matrix bubbles a color floor so that numbers close to zero can still be differentiated from zero by having a grey circle.

Changes were made based on requests [here](https://docs.google.com/document/d/1o1mJD0Cbb8B9M-Dt10uWkbPbhzbnSNN3XO9_gQ4bEmQ/edit#).
Note: two of the items in the document were not addressed here because they were fixed in another PR

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #511

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
