### PR TITLE
Removes sort of violation list in violation record

### DIFF
--- a/src/utils/charts/violationRecord.js
+++ b/src/utils/charts/violationRecord.js
@@ -77,11 +77,7 @@ export function formatViolationRecord(records) {
     return "";
   }
 
-  return records
-    .slice()
-    .sort(violationComparator)
-    .map(violationFormatter)
-    .join(", ");
+  return records.slice().map(violationFormatter).join(", ");
 }
 
 export const parseAndFormatViolationRecord = compose(


### PR DESCRIPTION
## Description of the change

This PR removes the FE sorting of violations listed in the `violation_record` column. The violations in the `violation_record` string are sent to the FE _ordered_, so we do not need to order this string on the frontend.

I filed #520 to handle the fact that the violation record column is not getting properly sorted when the user toggles the "Sort by Violation Record" functionality.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes https://github.com/Recidiviz/pulse-dashboard/issues/520

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
