### PR TITLE
remove crypto fall back shims from index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,13 +20,6 @@
     </script>
 
     <!--
-      This promise polyfill enables the webcrypto shim polyfill which allows Auth0 to
-      fall back to msCrypto in the absence of the standard crypto in IE11.
-    -->
-    <script src="https://unpkg.com/bluebird"></script>
-    <script src="https://unpkg.com/webcrypto-shim"></script>
-
-    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->


### PR DESCRIPTION
## Description of the change

Starting Thursday afternoon I have noticed an issue authenticating the dashboard in IE11. The authentication requests were not being received by Auth0 when sourced from IE11. Other browsers were fine.

Removing these polyfills from`public/index.html` resolves the issue. 

[v1.2](https://github.com/auth0/auth0-spa-js/releases/tag/1.2.0) of auth-spa-js adds IE11 polyfills into the package itself rather than relying on fall back web polyfills. We upgraded our auth-spa-js package in #496 which upgraded us from v1.1 to v1.12. I have successfully authenticated several times in IE11 since this upgrade, so to be honest I'm not sure if those successful auths were the result of a stale cache or if the web based shims that were removed in this PR were updated recently.

Regardless, this fixes the issue. Yay.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #548 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
