### PR TITLE
remove SUPERVISON_LEVEL from skippedFilters for PA

### DIFF
--- a/src/views/tenants/us_pa/community/Revocations.js
+++ b/src/views/tenants/us_pa/community/Revocations.js
@@ -154,7 +154,7 @@ const Revocations = () => {
         <ErrorBoundary>
           <RevocationCountOverTime
             dataFilter={allDataFilter}
-            skippedFilters={[METRIC_PERIOD_MONTHS, SUPERVISION_TYPE]}
+            skippedFilters={[METRIC_PERIOD_MONTHS]}
             filterStates={filters}
             metricPeriodMonths={filters[METRIC_PERIOD_MONTHS]}
             stateCode={stateCode}


### PR DESCRIPTION
## Description of the change

We had a bug in the `AdmissionsOverTime` chart for PA. The total revocations each month were double what they should have been. This is because both `supervision_type=ALL` and `supervision_type=PAROLE` were being counted. This metric file must not have had the `supervision_type=ALL` rows at the time this chart was added.

Removed `SUPERVISION_TYPE` from the skippedFilters for PA to allow the filters to do their job!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
