### PR TITLE
Fix vertical alignment of filter chip - label and delete button

### DIFF
--- a/src/components/charts/new_revocations/Chip.js
+++ b/src/components/charts/new_revocations/Chip.js
@@ -19,17 +19,19 @@ import React from "react";
 import PropTypes from "prop-types";
 import cn from "classnames";
 
+import { usePageState } from "../../../contexts/PageContext";
 import "./Chip.scss";
 
-const Chip = ({
-  label,
-  onClick = () => {},
-  onDelete = null,
-  isSelected = false,
-  className,
-}) => {
+const Chip = ({ label, onClick, onDelete, isSelected, isShrinkable }) => {
+  const { isTopBarShrinking } = usePageState();
+
   return (
-    <div className={cn("Chip", { "Chip--selected": isSelected }, className)}>
+    <div
+      className={cn("Chip", {
+        "Chip--selected": isSelected,
+        "Chip--shrinking": isTopBarShrinking && isShrinkable,
+      })}
+    >
       <button type="button" className="Chip__label" onClick={onClick}>
         {label}
       </button>
@@ -50,7 +52,7 @@ Chip.defaultProps = {
   onClick: () => {},
   onDelete: null,
   isSelected: false,
-  className: "",
+  isShrinkable: false,
 };
 
 Chip.propTypes = {
@@ -58,7 +60,7 @@ Chip.propTypes = {
   onClick: PropTypes.func,
   onDelete: PropTypes.func,
   isSelected: PropTypes.bool,
-  className: PropTypes.string,
+  isShrinkable: PropTypes.bool,
 };
 
 export default Chip;

--- a/src/components/charts/new_revocations/Chip.js
+++ b/src/components/charts/new_revocations/Chip.js
@@ -17,9 +17,8 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
+import cn from "classnames";
 
-import { usePageState } from "../../../contexts/PageContext";
 import "./Chip.scss";
 
 const Chip = ({
@@ -27,15 +26,10 @@ const Chip = ({
   onClick = () => {},
   onDelete = null,
   isSelected = false,
+  className,
 }) => {
-  const { isTopBarShrinking } = usePageState();
   return (
-    <div
-      className={cx("Chip", {
-        "Chip--selected": isSelected,
-        "Chip--shrinking": isTopBarShrinking,
-      })}
-    >
+    <div className={cn("Chip", { "Chip--selected": isSelected }, className)}>
       <button type="button" className="Chip__label" onClick={onClick}>
         {label}
       </button>
@@ -56,6 +50,7 @@ Chip.defaultProps = {
   onClick: () => {},
   onDelete: null,
   isSelected: false,
+  className: "",
 };
 
 Chip.propTypes = {
@@ -63,6 +58,7 @@ Chip.propTypes = {
   onClick: PropTypes.func,
   onDelete: PropTypes.func,
   isSelected: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default Chip;

--- a/src/components/charts/new_revocations/Chip.scss
+++ b/src/components/charts/new_revocations/Chip.scss
@@ -10,6 +10,7 @@
   border-radius: 24px;
   margin-right: 10px;
   width: auto;
+  vertical-align: middle;
 
   &--selected {
     background-color: $color1;
@@ -18,7 +19,6 @@
   &--shrinking {
     height: 28px;
     border-radius: 24px;
-    line-height: 18px;
   }
 
   &__label {
@@ -28,7 +28,8 @@
     font-weight: 500;
     border: none;
     background-color: $color2;
-    padding: 0 6px;
+    vertical-align: middle;
+    line-height: 21px;
 
     &:focus {
       outline: none;
@@ -38,22 +39,28 @@
       color: $color2;
       background-color: $color1;
     }
+
+    .Chip--shrinking & {
+      line-height: 18px;
+    }
   }
 
   &__delete-button {
-    padding: 0;
     margin-left: 4px;
-    margin-top: 1px;
+    margin-top: 2px;
     border: none;
     background: transparent;
     color: $color1;
+    vertical-align: middle;
+    line-height: 21px;
 
     .Chip--selected & {
       color: $color2;
     }
 
     .Chip--shrinking & {
-      margin-top: 2px;
+      margin-top: 0;
+      line-height: 18px;
     }
   }
 }

--- a/src/components/charts/new_revocations/ToggleBar/FilterField.scss
+++ b/src/components/charts/new_revocations/ToggleBar/FilterField.scss
@@ -35,6 +35,8 @@
       font-size: 0.9rem;
     }
 
+    vertical-align: middle;
+
     &--shrink {
       margin-bottom: 0;
       margin-right: 1rem;

--- a/src/components/charts/new_revocations/ToggleBar/ViolationFilter.js
+++ b/src/components/charts/new_revocations/ToggleBar/ViolationFilter.js
@@ -17,6 +17,7 @@
 
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
+import cn from "classnames";
 
 import FilterField from "./FilterField";
 import Chip from "../Chip";
@@ -25,8 +26,10 @@ import {
   matrixViolationTypeToLabel,
   pluralize,
 } from "../../../../utils/transforms/labels";
+import { usePageState } from "../../../../contexts/PageContext";
 
 const ViolationFilter = ({ reportedViolations, violationType, onClick }) => {
+  const { isTopBarShrinking } = usePageState();
   const formattedMatrixFilters = useMemo(() => {
     const parts = [];
     if (violationType) {
@@ -39,7 +42,6 @@ const ViolationFilter = ({ reportedViolations, violationType, onClick }) => {
     }
     return parts.join(", ");
   }, [reportedViolations, violationType]);
-
   if (!formattedMatrixFilters) return null;
 
   return (
@@ -50,6 +52,7 @@ const ViolationFilter = ({ reportedViolations, violationType, onClick }) => {
       >
         <Chip
           label={formattedMatrixFilters}
+          className={cn({ "Chip--shrinking": isTopBarShrinking })}
           onDelete={() => {
             onClick({ violationType: "", reportedViolations: "" });
           }}

--- a/src/components/charts/new_revocations/ToggleBar/ViolationFilter.js
+++ b/src/components/charts/new_revocations/ToggleBar/ViolationFilter.js
@@ -17,7 +17,6 @@
 
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
-import cn from "classnames";
 
 import FilterField from "./FilterField";
 import Chip from "../Chip";
@@ -26,10 +25,8 @@ import {
   matrixViolationTypeToLabel,
   pluralize,
 } from "../../../../utils/transforms/labels";
-import { usePageState } from "../../../../contexts/PageContext";
 
 const ViolationFilter = ({ reportedViolations, violationType, onClick }) => {
-  const { isTopBarShrinking } = usePageState();
   const formattedMatrixFilters = useMemo(() => {
     const parts = [];
     if (violationType) {
@@ -52,10 +49,10 @@ const ViolationFilter = ({ reportedViolations, violationType, onClick }) => {
       >
         <Chip
           label={formattedMatrixFilters}
-          className={cn({ "Chip--shrinking": isTopBarShrinking })}
           onDelete={() => {
             onClick({ violationType: "", reportedViolations: "" });
           }}
+          isShrinkable
         />
       </FilterField>
     </div>


### PR DESCRIPTION
## Description of the change

The filter chips were vertically misaligned. This was the case in the 'Additional Filters' filter bar as well as the filter buttons in the revocations by district chart.

The chips after the fix:
![Screen Shot 2020-11-03 at 1 16 40 PM](https://user-images.githubusercontent.com/5872651/98042071-c548f880-1dd7-11eb-91be-507cb68711db.png)
![Screen Shot 2020-11-03 at 1 41 31 PM](https://user-images.githubusercontent.com/5872651/98043588-515c1f80-1dda-11eb-925f-8d5aef34c8e9.png)
![Screen Shot 2020-11-03 at 1 41 36 PM](https://user-images.githubusercontent.com/5872651/98043593-5325e300-1dda-11eb-860c-061f258714df.png)




## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #595

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
