### PR TITLE
[IE11] multi-select onBlur bug

### DIFF
--- a/src/components/controls/MultiSelect/GroupHeading.js
+++ b/src/components/controls/MultiSelect/GroupHeading.js
@@ -49,12 +49,14 @@ const GroupHeading = ({
 
   return (
     <div className="MultiSelect__group-heading">
-      <label className="MultiSelect__checkbox-container" onClick={onClick}>
+      <label className="MultiSelect__checkbox-container">
         {label}
         <input
           className="MultiSelect__checkbox-input"
           type="checkbox"
           checked={isAllOptionsSelected}
+          onClick={onClick}
+          onKeyDown={onClick}
           disabled
         />
         <span className="MultiSelect__checkbox" />

--- a/src/components/controls/MultiSelect/MultiSelect.js
+++ b/src/components/controls/MultiSelect/MultiSelect.js
@@ -82,9 +82,10 @@ const MultiSelect = ({
       hideSelectedOptions={false}
       onChange={handleChange}
       options={options}
+      onFocus={() => ref.current.setState({ menuIsOpen: true })}
       value={value}
-      {...props}
       isMulti
+      {...props}
     />
   );
 };

--- a/src/components/controls/MultiSelect/ValueContainer.js
+++ b/src/components/controls/MultiSelect/ValueContainer.js
@@ -24,9 +24,9 @@ import { optionPropType } from "../../propTypes";
 const ValueContainer = ({ allOptions, summingOption, children, ...props }) => {
   const { selectProps, getValue } = props;
   const values = getValue();
-  const selectInput = React.Children.toArray(children).find((child) =>
-    child.type === components.Input ? child : null
-  );
+  const selectInput = React.Children.map(children, (child) => {
+    return child.type === components.Input ? child : null;
+  });
 
   const isAll =
     !selectProps.inputValue &&

--- a/src/components/controls/MultiSelect/ValueContainer.js
+++ b/src/components/controls/MultiSelect/ValueContainer.js
@@ -24,9 +24,8 @@ import { optionPropType } from "../../propTypes";
 const ValueContainer = ({ allOptions, summingOption, children, ...props }) => {
   const { selectProps, getValue } = props;
   const values = getValue();
-
-  const selectInput = React.Children.toArray(children).find((input) =>
-    ["DummyInput", "Input"].includes(input.type.name)
+  const selectInput = React.Children.toArray(children).find((child) =>
+    child.type === components.Input ? child : null
   );
 
   const isAll =


### PR DESCRIPTION
## Description of the change

We had a bug in IE11 where clicking outside of the multi-select menu did not close the menu. This bug only existed react-scripts builds and not in webpack builds which was strange.

The bug was fixed by cleaning up how we are searching for the select input to pass to the ValueContainer. We were not finding the input correctly with the react-scripts build (timing maybe) so the ref was lost, and therefore the focus/blur was broken.

This fix ended up breaking the `closeMenuOnSelect={false}` for IE11, so I manually changed the `onFocus` event handler to help IE11 out.

This has been deployed to staging for QA vs what you see in production.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #596

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
