### PR TITLE
Fixes bug in District Chart when applying more restrictive to less restrictive filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ That's it! We suggest installing a linting package for your preferred code edito
 
 Second and last, set up your environment variables.
 
-For Recidiviz staff, download and unzip the `pulse_dashboard_env_vars.zip` from the shared 1Password vault and copy the files into the project directory.
+For Recidiviz staff, download and unzip the `pulse_dashboard_env_vars.zip` from the shared 1Password vault and copy the files into the project directory. 
+
+IMPORTANT: Be sure to use `Shift+Command+.` in your Finder window to show the hidden files, and copy all of the files, including the hidden `.env` files. Follow the directory structure in the zip file, so if the file is nested in the `/src` directory in the zip, copy it into the `/src` directory in the repo. 
+
 For anyone trying to set this up independently, construct environment variables by hand based on the explanations below.
 
 Explanation of frontend env files:

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint-config-prettier": "^6.11.1",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.2.3",
+    "jest-canvas-mock": "^2.3.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-extended": "^0.11.5",
     "lint-staged": "^10.0.9",
@@ -136,7 +137,8 @@
   "jest": {
     "setupFilesAfterEnv": [
       "./src/setupTests.js",
-      "@testing-library/react-hooks/dont-cleanup-after-each.js"
+      "@testing-library/react-hooks/dont-cleanup-after-each.js",
+      "jest-canvas-mock"
     ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",

--- a/src/components/charts/new_revocations/RevocationsByDistrict/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict/createGenerateChartData.js
@@ -65,6 +65,7 @@ const generatePercentChartData = (apiData, currentDistricts, mode) => {
   const getBarBackgroundColor = ({ dataIndex }) => {
     let color =
       currentDistricts &&
+      labels[dataIndex] &&
       currentDistricts.find(
         (currentDistrict) =>
           currentDistrict.toLowerCase() === labels[dataIndex].toLowerCase()
@@ -115,6 +116,8 @@ const generateCountChartData = (apiData, currentDistricts) => {
   const labels = map("district", transformedData);
   const dataPoints = transformedData.map((item) => item.count);
   const getBarBackgroundColor = ({ dataIndex }) =>
+    currentDistricts &&
+    labels[dataIndex] &&
     currentDistricts.find(
       (currentDistrict) =>
         currentDistrict.toLowerCase() === labels[dataIndex].toLowerCase()

--- a/src/components/charts/new_revocations/RevocationsByDistrict/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict/createGenerateChartData.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import pattern from "patternomaly";
 import pipe from "lodash/fp/pipe";
 import filter from "lodash/fp/filter";
 import groupBy from "lodash/fp/groupBy";
@@ -27,7 +26,7 @@ import orderBy from "lodash/fp/orderBy";
 import { calculateRate } from "../helpers/rate";
 
 import { translate } from "../../../../views/tenants/utils/i18nSettings";
-import { isDenominatorStatisticallySignificant } from "../../../../utils/charts/significantStatistics";
+import { applyStatisticallySignificantShading } from "../../../../utils/charts/significantStatistics";
 import { filterOptimizedDataFormat } from "../../../../utils/charts/dataFilters";
 import { COLORS } from "../../../../assets/scripts/constants/colors";
 import { sumCounts } from "../utils/sumCounts";
@@ -63,7 +62,7 @@ const generatePercentChartData = (apiData, currentDistricts, mode) => {
   const numerators = map("count", filteredData);
 
   const getBarBackgroundColor = ({ dataIndex }) => {
-    let color =
+    const color =
       currentDistricts &&
       labels[dataIndex] &&
       currentDistricts.find(
@@ -72,12 +71,7 @@ const generatePercentChartData = (apiData, currentDistricts, mode) => {
       )
         ? COLORS["lantern-light-blue"]
         : COLORS["lantern-orange"];
-
-    if (!isDenominatorStatisticallySignificant(denominators[dataIndex])) {
-      color = pattern.draw("diagonal-right-left", color, "#ffffff", 5);
-    }
-
-    return color;
+    return applyStatisticallySignificantShading(color, denominators[dataIndex]);
   };
 
   const datasets = [
@@ -132,7 +126,6 @@ const generateCountChartData = (apiData, currentDistricts) => {
       data: dataPoints,
     },
   ];
-
   return { data: { datasets, labels }, denominators: [] };
 };
 

--- a/src/components/charts/new_revocations/RevocationsByGender/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByGender/createGenerateChartData.js
@@ -19,7 +19,7 @@ import pipe from "lodash/fp/pipe";
 import reduce from "lodash/fp/reduce";
 
 import { CHART_COLORS } from "./constants";
-import { getBarBackgroundColor } from "../../../../utils/charts/significantStatistics";
+import { applyStatisticallySignificantShadingToDataset } from "../../../../utils/charts/significantStatistics";
 import {
   getRiskLevels,
   getRiskLevelLabels,
@@ -59,7 +59,10 @@ const createGenerateChartData = (dataFilter, stateCode) => (
 
   const generateDataset = (label, index) => ({
     label,
-    backgroundColor: getBarBackgroundColor(CHART_COLORS[index], denominators),
+    backgroundColor: applyStatisticallySignificantShadingToDataset(
+      CHART_COLORS[index],
+      denominators
+    ),
     data: dataPoints[index],
   });
 

--- a/src/components/charts/new_revocations/RevocationsByOfficer/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByOfficer/createGenerateChartData.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import pattern from "patternomaly";
 import pipe from "lodash/fp/pipe";
 import groupBy from "lodash/fp/groupBy";
 import values from "lodash/fp/values";
@@ -26,7 +25,7 @@ import orderBy from "lodash/fp/orderBy";
 import { calculateRate } from "../helpers/rate";
 
 import { translate } from "../../../../views/tenants/utils/i18nSettings";
-import { isDenominatorStatisticallySignificant } from "../../../../utils/charts/significantStatistics";
+import { applyStatisticallySignificantShadingToDataset } from "../../../../utils/charts/significantStatistics";
 import { sumCounts } from "../utils/sumCounts";
 import getNameFromOfficerId from "../utils/getNameFromOfficerId";
 import { COLORS } from "../../../../assets/scripts/constants/colors";
@@ -63,20 +62,13 @@ const generatePercentChartData = (apiData, currentDistricts, mode) => {
   const denominators = map("supervision_count", filteredData);
   const numerators = map("count", filteredData);
 
-  const getBarBackgroundColor = ({ dataIndex }) => {
-    let color = COLORS["lantern-orange"];
-
-    if (!isDenominatorStatisticallySignificant(denominators[dataIndex])) {
-      color = pattern.draw("diagonal-right-left", color, "#ffffff", 5);
-    }
-
-    return color;
-  };
-
   const datasets = [
     {
       label: translate("percentOfPopulationRevoked"),
-      backgroundColor: getBarBackgroundColor,
+      backgroundColor: applyStatisticallySignificantShadingToDataset(
+        COLORS["lantern-orange"],
+        denominators
+      ),
       data: dataPoints,
     },
   ];

--- a/src/components/charts/new_revocations/RevocationsByRace/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByRace/createGenerateChartData.js
@@ -18,7 +18,6 @@
 import pipe from "lodash/fp/pipe";
 import reduce from "lodash/fp/reduce";
 
-import { getBarBackgroundColor } from "../../../../utils/charts/significantStatistics";
 import {
   getRiskLevelLabels,
   getRiskLevels,
@@ -29,6 +28,7 @@ import createRiskLevelsMap from "../utils/createRiskLevelsMap";
 import { filterOptimizedDataFormat } from "../../../../utils/charts/dataFilters";
 import { translate } from "../../../../views/tenants/utils/i18nSettings";
 import { COLORS_LANTERN_SET } from "../../../../assets/scripts/constants/colors";
+import { applyStatisticallySignificantShadingToDataset } from "../../../../utils/charts/significantStatistics";
 
 export const generateDatasets = (dataPoints, denominators) => {
   const raceLabelMap = translate("raceLabelMap");
@@ -36,7 +36,7 @@ export const generateDatasets = (dataPoints, denominators) => {
 
   return raceLabels.map((raceLabel, index) => ({
     label: raceLabel,
-    backgroundColor: getBarBackgroundColor(
+    backgroundColor: applyStatisticallySignificantShadingToDataset(
       COLORS_LANTERN_SET[index],
       denominators
     ),

--- a/src/components/charts/new_revocations/RevocationsByRiskLevel/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByRiskLevel/createGenerateChartData.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import pattern from "patternomaly";
 import pipe from "lodash/fp/pipe";
 import filter from "lodash/fp/filter";
 import groupBy from "lodash/fp/groupBy";
@@ -27,7 +26,7 @@ import { sumIntBy } from "../helpers/counts";
 import { calculateRate } from "../helpers/rate";
 import { translate } from "../../../../views/tenants/utils/i18nSettings";
 import { humanReadableTitleCase } from "../../../../utils/transforms/labels";
-import { isDenominatorStatisticallySignificant } from "../../../../utils/charts/significantStatistics";
+import { applyStatisticallySignificantShadingToDataset } from "../../../../utils/charts/significantStatistics";
 import getDenominatorKeyByMode from "../utils/getDenominatorKeyByMode";
 import getLabelByMode from "../utils/getLabelByMode";
 import { filterOptimizedDataFormat } from "../../../../utils/charts/dataFilters";
@@ -72,20 +71,15 @@ const createGenerateChartData = (dataFilter) => (
   const numerators = map("numerator", riskLevelCounts);
   const denominators = map("denominator", riskLevelCounts);
 
-  const barBackgroundColor = ({ dataIndex }) => {
-    const color = COLORS["lantern-orange"];
-    if (isDenominatorStatisticallySignificant(denominators[dataIndex])) {
-      return color;
-    }
-    return pattern.draw("diagonal-right-left", color, "#ffffff", 5);
-  };
-
   const data = {
     labels: map("label", riskLevelCounts),
     datasets: [
       {
         label: getLabelByMode(mode),
-        backgroundColor: barBackgroundColor,
+        backgroundColor: applyStatisticallySignificantShadingToDataset(
+          COLORS["lantern-orange"],
+          denominators
+        ),
         data: chartDataPoints,
       },
     ],

--- a/src/utils/charts/__tests__/significantStatistics.test.js
+++ b/src/utils/charts/__tests__/significantStatistics.test.js
@@ -15,10 +15,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import pattern from "patternomaly";
+
 import {
   isDenominatorStatisticallySignificant,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithCounts,
+  applyStatisticallySignificantShading,
+  applyStatisticallySignificantShadingToDataset,
 } from "../significantStatistics";
 
 const statisticallySignificantDenominators = [0, 100, 1019];
@@ -67,6 +71,93 @@ describe("isDenominatorsMatrixStatisticallySignificant function", () => {
     const given = statisticallySignificantDenominatorMatrix;
 
     expect(isDenominatorsMatrixStatisticallySignificant(given)).toBeTrue();
+  });
+});
+
+describe("applyStatisticallySignificantShading function", () => {
+  it("should not apply shading when statistically significant", () => {
+    const given = statisticallySignificantDenominators;
+    const color = "anyColor";
+
+    given.forEach((denominator) => {
+      expect(applyStatisticallySignificantShading(color, denominator)).toBe(
+        color
+      );
+    });
+  });
+
+  it("should apply shading when not statistically significant", () => {
+    const drawSpy = jest.spyOn(pattern, "draw");
+    drawSpy.mockReturnValue("#ffffff");
+
+    const given = statisticallyNotSignificantDenominators;
+    const color = "anyColor";
+
+    given.forEach((denominator) => {
+      expect(applyStatisticallySignificantShading(color, denominator)).toBe(
+        "#ffffff"
+      );
+    });
+  });
+});
+
+describe("applyStatisticallySignificantShadingToDataset function", () => {
+  let color;
+  let insignificantColor;
+
+  beforeEach(() => {
+    color = "anyColor";
+    insignificantColor = "#ffffff";
+
+    const drawSpy = jest.spyOn(pattern, "draw");
+    drawSpy.mockReturnValue(insignificantColor);
+  });
+
+  it("should not apply shading when statistically significant", () => {
+    const dataset = statisticallySignificantDenominators;
+
+    const backgroundColorFn = applyStatisticallySignificantShadingToDataset(
+      color,
+      dataset
+    );
+    dataset.forEach((_denominator, idx) => {
+      expect(backgroundColorFn({ dataIndex: idx })).toBe(color);
+    });
+  });
+
+  it("should apply shading when not statistically significant", () => {
+    const dataset = statisticallyNotSignificantDenominators;
+
+    const backgroundColorFn = applyStatisticallySignificantShadingToDataset(
+      color,
+      dataset
+    );
+    dataset.forEach((_denominator, idx) => {
+      expect(backgroundColorFn({ dataIndex: idx })).toBe(insignificantColor);
+    });
+  });
+
+  describe("when the dataset is a matrix with an insignificant datapoint", () => {
+    let backgroundColorFn;
+
+    beforeEach(() => {
+      const dataset = statisticallyNotSignificantDenominatorMatrix;
+
+      backgroundColorFn = applyStatisticallySignificantShadingToDataset(
+        color,
+        dataset
+      );
+    });
+
+    it("should not apply the shading to a statistically significant datapoint", () => {
+      expect(backgroundColorFn({ datasetIndex: 2, dataIndex: 1 })).toBe(color);
+    });
+
+    it("should not apply the shading to the statistically insignificant datapoint", () => {
+      expect(backgroundColorFn({ datasetIndex: 2, dataIndex: 2 })).toBe(
+        insignificantColor
+      );
+    });
   });
 });
 

--- a/src/utils/charts/__tests__/significantStatistics.test.js
+++ b/src/utils/charts/__tests__/significantStatistics.test.js
@@ -14,15 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-
-import pattern from "patternomaly";
-
 import {
   isDenominatorStatisticallySignificant,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithCounts,
   applyStatisticallySignificantShading,
   applyStatisticallySignificantShadingToDataset,
+  STATISTICALLY_INSIGNIFICANT_PATTERN,
 } from "../significantStatistics";
 
 const statisticallySignificantDenominators = [0, 100, 1019];
@@ -86,32 +84,20 @@ describe("applyStatisticallySignificantShading function", () => {
     });
   });
 
-  it("should apply shading when not statistically significant", () => {
-    const drawSpy = jest.spyOn(pattern, "draw");
-    drawSpy.mockReturnValue("#ffffff");
-
+  it("should apply shading when not statistically significant", async () => {
     const given = statisticallyNotSignificantDenominators;
     const color = "anyColor";
 
     given.forEach((denominator) => {
-      expect(applyStatisticallySignificantShading(color, denominator)).toBe(
-        "#ffffff"
-      );
+      expect(
+        applyStatisticallySignificantShading(color, denominator).shapeType
+      ).toEqual(STATISTICALLY_INSIGNIFICANT_PATTERN);
     });
   });
 });
 
 describe("applyStatisticallySignificantShadingToDataset function", () => {
-  let color;
-  let insignificantColor;
-
-  beforeEach(() => {
-    color = "anyColor";
-    insignificantColor = "#ffffff";
-
-    const drawSpy = jest.spyOn(pattern, "draw");
-    drawSpy.mockReturnValue(insignificantColor);
-  });
+  const color = "anyColor";
 
   it("should not apply shading when statistically significant", () => {
     const dataset = statisticallySignificantDenominators;
@@ -133,7 +119,9 @@ describe("applyStatisticallySignificantShadingToDataset function", () => {
       dataset
     );
     dataset.forEach((_denominator, idx) => {
-      expect(backgroundColorFn({ dataIndex: idx })).toBe(insignificantColor);
+      expect(backgroundColorFn({ dataIndex: idx }).shapeType).toEqual(
+        STATISTICALLY_INSIGNIFICANT_PATTERN
+      );
     });
   });
 
@@ -154,9 +142,9 @@ describe("applyStatisticallySignificantShadingToDataset function", () => {
     });
 
     it("should not apply the shading to the statistically insignificant datapoint", () => {
-      expect(backgroundColorFn({ datasetIndex: 2, dataIndex: 2 })).toBe(
-        insignificantColor
-      );
+      expect(
+        backgroundColorFn({ datasetIndex: 2, dataIndex: 2 }).shapeType
+      ).toEqual(STATISTICALLY_INSIGNIFICANT_PATTERN);
     });
   });
 });

--- a/src/utils/charts/significantStatistics.js
+++ b/src/utils/charts/significantStatistics.js
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-
 import pattern from "patternomaly";
+import { COLORS } from "../../assets/scripts/constants/colors";
+
+const STATISTICALLY_INSIGNIFICANT_PATTERN = "diagonal-right-left";
 
 function isDenominatorStatisticallySignificant(denominator = 0) {
   return denominator === 0 || denominator >= 100;
@@ -29,9 +31,15 @@ function isDenominatorsMatrixStatisticallySignificant(denominatorsMatrix) {
 
 function applyStatisticallySignificantShading(color, denominator) {
   const shadingSize = 5;
+
   return isDenominatorStatisticallySignificant(denominator)
     ? color
-    : pattern.draw("diagonal-right-left", color, "#ffffff", shadingSize);
+    : pattern.draw(
+        STATISTICALLY_INSIGNIFICANT_PATTERN,
+        color,
+        COLORS.white,
+        shadingSize
+      );
 }
 
 function applyStatisticallySignificantShadingToDataset(color, denominators) {
@@ -67,4 +75,5 @@ export {
   isDenominatorStatisticallySignificant,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithCounts,
+  STATISTICALLY_INSIGNIFICANT_PATTERN,
 };

--- a/src/utils/charts/significantStatistics.js
+++ b/src/utils/charts/significantStatistics.js
@@ -27,15 +27,21 @@ function isDenominatorsMatrixStatisticallySignificant(denominatorsMatrix) {
     .some((d) => !isDenominatorStatisticallySignificant(d));
 }
 
-function getBarBackgroundColor(color, denominators) {
+function applyStatisticallySignificantShading(color, denominator) {
   const shadingSize = 5;
+  return isDenominatorStatisticallySignificant(denominator)
+    ? color
+    : pattern.draw("diagonal-right-left", color, "#ffffff", shadingSize);
+}
 
-  return ({ datasetIndex: i, dataIndex: j }) => {
-    if (isDenominatorStatisticallySignificant(denominators[i][j])) {
-      return color;
-    }
-    return pattern.draw("diagonal-right-left", color, "#ffffff", shadingSize);
-  };
+function applyStatisticallySignificantShadingToDataset(color, denominators) {
+  return Array.isArray(denominators[0])
+    ? ({ datasetIndex: i, dataIndex: j }) => {
+        return applyStatisticallySignificantShading(color, denominators[i][j]);
+      }
+    : ({ dataIndex: j }) => {
+        return applyStatisticallySignificantShading(color, denominators[j]);
+      };
 }
 
 function tooltipForFooterWithCounts([{ index }], denominators) {
@@ -56,7 +62,8 @@ function tooltipForFooterWithCounts([{ index }], denominators) {
 }
 
 export {
-  getBarBackgroundColor,
+  applyStatisticallySignificantShadingToDataset,
+  applyStatisticallySignificantShading,
   isDenominatorStatisticallySignificant,
   isDenominatorsMatrixStatisticallySignificant,
   tooltipForFooterWithCounts,

--- a/src/utils/downloads/__tests__/transformChartDataToCsv.js
+++ b/src/utils/downloads/__tests__/transformChartDataToCsv.js
@@ -1,6 +1,23 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
 import transformChartDataToCsv from "../transformChartDataToCsv";
 
 describe("transformChartDataToCsv", () => {
+  const exportLabel = "Export Label";
   describe("when labels count more than datasets count should place labels in rows", () => {
     const datasets = [
       {
@@ -10,25 +27,28 @@ describe("transformChartDataToCsv", () => {
     ];
     const labels = ["Low", "Medium", "High", "Not assessed"];
 
-    it("standard case", () => {
-      expect(transformChartDataToCsv(datasets, labels)).resolves.toEqual(
-        `,Revocations\nLow,1\nMedium,2\nHigh,6\nNot assessed,8`
+    it("standard case", async () => {
+      expect(
+        await transformChartDataToCsv(datasets, labels, exportLabel)
+      ).toEqual(
+        `Export Label,Revocations\nLow,1\nMedium,2\nHigh,6\nNot assessed,8`
       );
     });
 
-    it("should not export trendline", () => {
+    it("should not export trendline", async () => {
       expect(
-        transformChartDataToCsv(
+        await transformChartDataToCsv(
           datasets.concat([
             {
               label: "trendline",
               data: [2, 3, 4, 6],
             },
           ]),
-          labels
+          labels,
+          exportLabel
         )
-      ).resolves.toEqual(
-        `,Revocations\nLow,1\nMedium,2\nHigh,6\nNot assessed,8`
+      ).toEqual(
+        `Export Label,Revocations\nLow,1\nMedium,2\nHigh,6\nNot assessed,8`
       );
     });
   });
@@ -54,15 +74,17 @@ describe("transformChartDataToCsv", () => {
     ];
     const labels = ["Low", "Medium", "High"];
 
-    it("datasets more than labels", () => {
-      expect(transformChartDataToCsv(datasets, labels)).resolves.toEqual(
-        `,Low,Medium,High\nWomen,1,2,6\nMen,2,4,6\nDog,3,3,4\nCat,1,6,8`
+    it("datasets more than labels", async () => {
+      expect(
+        await transformChartDataToCsv(datasets, labels, exportLabel)
+      ).toEqual(
+        `Export Label,Low,Medium,High\nWomen,1,2,6\nMen,2,4,6\nDog,3,3,4\nCat,1,6,8`
       );
     });
 
-    it("fixLabelsInColumns = true", () => {
+    it("fixLabelsInColumns = true", async () => {
       expect(
-        transformChartDataToCsv(
+        await transformChartDataToCsv(
           [
             { data: [1, 2, 6] },
             { data: [2, 4, 6] },
@@ -73,7 +95,7 @@ describe("transformChartDataToCsv", () => {
           false,
           true
         )
-      ).resolves.toEqual(`Low,Medium,High\n1,2,6\n2,4,6\n3,3,4\n1,6,8`);
+      ).toEqual(`Low,Medium,High\n1,2,6\n2,4,6\n3,3,4\n1,6,8`);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3751,7 +3751,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -4306,6 +4306,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -7605,6 +7610,14 @@ istanbul-reports@^2.2.6:
   dependencies:
     html-escaper "^2.0.0"
 
+jest-canvas-mock@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz#50f4cc178ae52c4c0e2ce4fd3a3ad2a41ad4eb36"
+  integrity sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
@@ -9254,6 +9267,13 @@ moment@^2.10.2, moment@^2.24.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moo-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.2.tgz#837c40758d2d58763825d1359a84e330531eca64"
+  integrity sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==
+  dependencies:
+    color-name "^1.1.4"
 
 moo@^0.5.0:
   version "0.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7074,9 +7074,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
+  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
 
 inquirer@7.0.4:
   version "7.0.4"


### PR DESCRIPTION
## Description of the change

We had a bug on the District Chart where we were seeing a `TypeError: Cannot read property 'toLowerCase' of undefined` error when switching from (for example) Case Type=SEX_OFFENSE to Case Type=ALL filters. The `labels` object occasionally had not updated to include the larger dataset before the chart tried to access it at the higher `dataIndex` . 

I traced this back, it started in the to the node/packages upgrade commit so there must be something slightly different with how chartJs is looping through the dataset given the new node env. I tested this thoroughly to ensure that the guard is not making us miss coloring one of the `currentDistrict` labels correctly. Even if a `currentDistrict` is the first or last of the labels, either before or after the filter change, chartJs eventually makes its way back through and applies the `currentDistrict` color treatment.

-This also includes a refactor to the statistically significant shading application on a few charts
-This also includes cleaned up of a test that was giving us a false positive (I saw the errors in the log but the test was not failing).
-This also includes a small update to the README after some feedback from Daniela as she was working on getting her environment set up today

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #649

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
