### PR TITLE
Remove statistical significance indicator from agent/officer chart 

### DIFF
--- a/src/components/charts/new_revocations/PercentRevokedChart.js
+++ b/src/components/charts/new_revocations/PercentRevokedChart.js
@@ -33,6 +33,7 @@ const PercentRevokedChart = ({
   denominators,
   xAxisLabel,
   yAxisLabel,
+  includeWarning,
 }) => (
   <Bar
     id={chartId}
@@ -79,9 +80,11 @@ const PercentRevokedChart = ({
               tooltipItem,
               tooltipData,
               numerators,
-              denominators
+              denominators,
+              includeWarning
             ),
           footer: (tooltipItem) =>
+            includeWarning &&
             tooltipForFooterWithCounts(tooltipItem, denominators),
         },
       },
@@ -106,6 +109,11 @@ PercentRevokedChart.propTypes = {
   xAxisLabel: PropTypes.string.isRequired,
   yAxisLabel: PropTypes.string.isRequired,
   averageRate: PropTypes.number.isRequired,
+  includeWarning: PropTypes.bool,
+};
+
+PercentRevokedChart.defaultProps = {
+  includeWarning: true,
 };
 
 export default PercentRevokedChart;

--- a/src/components/charts/new_revocations/RevocationsByDimension/RevocationsByDimension.js
+++ b/src/components/charts/new_revocations/RevocationsByDimension/RevocationsByDimension.js
@@ -41,6 +41,7 @@ const RevocationsByDimension = ({
   modes,
   defaultMode,
   dataExportLabel,
+  includeWarning,
 }) => {
   const [mode, setMode] = useState(defaultMode);
 
@@ -64,9 +65,9 @@ const RevocationsByDimension = ({
     unflattenedValues
   );
 
-  const showWarning = !isDenominatorsMatrixStatisticallySignificant(
-    denominators
-  );
+  const showWarning =
+    includeWarning &&
+    !isDenominatorsMatrixStatisticallySignificant(denominators);
 
   const modeButtons = modes.map((item) => ({
     label: getLabelByMode(item),
@@ -108,6 +109,7 @@ RevocationsByDimension.defaultProps = {
   modes: [],
   defaultMode: null,
   dataExportLabel: null,
+  includeWarning: true,
 };
 
 RevocationsByDimension.propTypes = {
@@ -124,6 +126,7 @@ RevocationsByDimension.propTypes = {
   modes: PropTypes.arrayOf(PropTypes.string),
   defaultMode: PropTypes.string,
   dataExportLabel: PropTypes.string,
+  includeWarning: PropTypes.bool,
 };
 
 export default RevocationsByDimension;

--- a/src/components/charts/new_revocations/RevocationsByOfficer/RevocationsByOfficer.js
+++ b/src/components/charts/new_revocations/RevocationsByOfficer/RevocationsByOfficer.js
@@ -35,12 +35,14 @@ const RevocationsByOfficer = ({
   timeDescription,
 }) => {
   const chartTitle = `Admissions by ${translate("officer")}`;
+  const includeWarning = false;
 
   return (
     <RevocationsByDimension
       chartId={`${translate("revocations")}by${translate("Officer")}`}
       apiUrl={`${stateCode}/newRevocations`}
       apiFile="revocations_matrix_distribution_by_officer"
+      includeWarning={includeWarning}
       renderChart={({
         chartId,
         data,
@@ -76,6 +78,7 @@ const RevocationsByOfficer = ({
                 ? translate("percentOfPopulationRevoked")
                 : `Percent ${translate("revoked")} out of all exits`
             }
+            includeWarning={includeWarning}
           />
         );
       }}

--- a/src/components/charts/new_revocations/RevocationsByOfficer/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByOfficer/createGenerateChartData.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import pattern from "patternomaly";
 import pipe from "lodash/fp/pipe";
 import groupBy from "lodash/fp/groupBy";
 import values from "lodash/fp/values";
@@ -26,13 +25,12 @@ import orderBy from "lodash/fp/orderBy";
 import { calculateRate } from "../helpers/rate";
 
 import { translate } from "../../../../views/tenants/utils/i18nSettings";
-import { isDenominatorStatisticallySignificant } from "../../../../utils/charts/significantStatistics";
 import { sumCounts } from "../utils/sumCounts";
 import getNameFromOfficerId from "../utils/getNameFromOfficerId";
 import { COLORS } from "../../../../assets/scripts/constants/colors";
 import { filterOptimizedDataFormat } from "../../../../utils/charts/dataFilters";
 
-const generatePercentChartData = (apiData, currentDistricts, mode) => {
+const generatePercentChartData = (apiData, mode) => {
   const [fieldName, totalFieldName] =
     mode === "exits"
       ? ["exit_count", "total_exit_count"]
@@ -63,20 +61,10 @@ const generatePercentChartData = (apiData, currentDistricts, mode) => {
   const denominators = map("supervision_count", filteredData);
   const numerators = map("count", filteredData);
 
-  const getBarBackgroundColor = ({ dataIndex }) => {
-    let color = COLORS["lantern-orange"];
-
-    if (!isDenominatorStatisticallySignificant(denominators[dataIndex])) {
-      color = pattern.draw("diagonal-right-left", color, "#ffffff", 5);
-    }
-
-    return color;
-  };
-
   const datasets = [
     {
       label: translate("percentOfPopulationRevoked"),
-      backgroundColor: getBarBackgroundColor,
+      backgroundColor: COLORS["lantern-orange"],
       data: dataPoints,
     },
   ];
@@ -121,7 +109,7 @@ const generateCountChartData = (apiData) => {
   return { data: { datasets, labels }, denominators: [] };
 };
 
-const createGenerateChartData = (dataFilter, currentDistricts) => (
+const createGenerateChartData = (dataFilter) => (
   apiData,
   mode,
   unflattenedValues
@@ -138,7 +126,7 @@ const createGenerateChartData = (dataFilter, currentDistricts) => (
     case "exits":
     case "rates":
     default:
-      return generatePercentChartData(filteredData, currentDistricts, mode);
+      return generatePercentChartData(filteredData, mode);
   }
 };
 

--- a/src/utils/charts/__tests__/toggles.test.js
+++ b/src/utils/charts/__tests__/toggles.test.js
@@ -548,6 +548,32 @@ describe("test for file toggles", () => {
     expect(tooltipTest).toBe("Percent revoked: 10.56% (19/180)");
   });
 
+  it("tooltip for rate metric with warning", () => {
+    const includeWarning = true;
+    tooltipItemRate.index = 4;
+    const tooltipTest = toggleMethods.tooltipForRateMetricWithCounts(
+      tooltipItemRate,
+      dataMetric,
+      [numbers],
+      [denominators],
+      includeWarning
+    );
+    expect(tooltipTest).toBe("Percent revoked: 10.56% (2/3) *");
+  });
+
+  it("tooltip for rate metric without warning", () => {
+    const includeWarning = false;
+    tooltipItemRate.index = 4;
+    const tooltipTest = toggleMethods.tooltipForRateMetricWithCounts(
+      tooltipItemRate,
+      dataMetric,
+      [numbers],
+      [denominators],
+      includeWarning
+    );
+    expect(tooltipTest).toBe("Percent revoked: 10.56% (2/3)");
+  });
+
   it("update tooltip for metric type", () => {
     const tooltipTest = toggleMethods.updateTooltipForMetricType(
       "rates",

--- a/src/utils/charts/toggles.js
+++ b/src/utils/charts/toggles.js
@@ -153,7 +153,8 @@ function tooltipForRateMetricWithCounts(
   tooltipItem,
   data,
   numerators,
-  denominators
+  denominators,
+  includeWarning
 ) {
   const { datasetIndex, index: dataPointIndex } = tooltipItem;
   const label = data.datasets[datasetIndex].label || "";
@@ -169,7 +170,11 @@ function tooltipForRateMetricWithCounts(
   if (numerator !== undefined && denominator !== undefined) {
     appendedCounts = ` (${numerator}/${denominator})`;
   }
-  const cue = isDenominatorStatisticallySignificant(denominator) ? "" : " *";
+
+  const cue =
+    includeWarning && !isDenominatorStatisticallySignificant(denominator)
+      ? " *"
+      : "";
 
   return `${label}: ${getTooltipWithoutTrendline(
     tooltipItem,


### PR DESCRIPTION
## Description of the change

This removes the warning icon from the officer/agent chart when viewing the chart in the "rates" mode. I opted to pass down the prop `includeWarning` from `RevocationsByOfficer` to `RevocationsByDimension` and `PercentRevokedChart`, but please let me know if this additional prop doesn't seem like the right approach. I also thought about adding chart-specific logic to a helper about whether or not to display the warning, which would include the `isDenominatorsMatrixStatisticallySignificant` check. 

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

> Closes #627 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
