### PR TITLE
UI tweaks in the matrix and dimension chart containers

### DIFF
--- a/src/components/charts/new_revocations/Matrix/Matrix.scss
+++ b/src/components/charts/new_revocations/Matrix/Matrix.scss
@@ -1,4 +1,6 @@
 .Matrix {
+  overflow-y: hidden;
+
   &__x-label {
     padding-top: 30px;
     padding-bottom: 30px;
@@ -10,8 +12,6 @@
     display: flex;
     @media screen and (max-width: 1350px) {
       width: 910px;
-      overflow-x: auto;
-      overflow-y: hidden;
     }
   }
 

--- a/src/components/charts/new_revocations/RevocationCharts/RevocationCharts.scss
+++ b/src/components/charts/new_revocations/RevocationCharts/RevocationCharts.scss
@@ -20,7 +20,7 @@
   margin: 20px;
   display: flex;
   &__labels {
-    width: 130px;
+    width: 135px;
     border-right: 1px solid rgba(0, 0, 0, 0.0625);
     padding: 20px;
   }
@@ -37,12 +37,16 @@
     text-align: left;
     &--selected {
       color: rgb(39, 128, 194);
-      border-color: rgb(39, 128, 194);
+      border-bottom: 2px solid rgb(39, 128, 194);
+    }
+    &:focus {
+      outline: none;
     }
   }
   &__chart {
     display: block;
     padding: 20px;
     flex: 1 1;
+    overflow-y: hidden;
   }
 }


### PR DESCRIPTION
## Description of the change

My QA uncovered a few little UI tweaks. 

1. Matrix refactoring we lost some overflow styling that caused the Matrix and dimension charts to not overflow properly on Tablet
2. Due to font change, the Risk Level label in the RevocationCharts was wrapping.
3. Also fixed a long standing UI issue of the RevocationCharts label having an awkward outline when focused.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #665 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
