### PR TITLE
Run server tests on port 3002

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -31,7 +31,8 @@ const app = express();
 
 app.use(cors());
 
-const port = process.env.PORT || 3001;
+const port = process.env.NODE_ENV === "test" ? 3002 : process.env.PORT || 3001;
+
 app.set("port", port);
 
 const isDemoMode = process.env.IS_DEMO === "true";


### PR DESCRIPTION
## Description of the change

Tests fail locally when we have a server running on port 3001.  This update sets the port to 3002 for the test environment so that we can run tests without needing to stop the development server. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #691 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
