### PR TITLE
[FE] Add violationType=All to the revocations query params when no violation type filter is selected

### DIFF
--- a/src/RootStore/DataStore/helpers.js
+++ b/src/RootStore/DataStore/helpers.js
@@ -2,6 +2,7 @@ import qs from "qs";
 import toInteger from "lodash/fp/toInteger";
 import { convertFromStringToUnflattenedMatrix } from "../../api/metrics/optimizedFormatHelpers";
 import { parseResponseByFileFormat } from "../../api/metrics/fileParser";
+import { VIOLATION_TYPE } from "../../constants/filterTypes";
 
 export function unflattenValues(metricFile) {
   const totalDataPoints = toInteger(metricFile.metadata.total_data_points);
@@ -38,12 +39,17 @@ export function processResponseData(data, file, eagerExpand = true) {
  * @param {string} filters.supervisionType - Supervision Type or "All"
  * @param {string} filters.supervisionLevel - Supervision level or "All"
  * @param {string} filters.reportedViolations - Number of reported violations or "All"
- * @param {string} filters.violationType - Violation type or "All"
+ * @param {string} filters.violationType - Violation type
  */
 export function getQueryStringFromFilters(filters = {}) {
   return qs.stringify(filters, {
     encode: false,
     addQueryPrefix: true,
-    filter: (_, value) => (value !== "" ? value : undefined),
+    filter: (key, value) => {
+      if (key === VIOLATION_TYPE && value === "") {
+        return "All";
+      }
+      return value !== "" ? value : undefined;
+    },
   });
 }

--- a/src/RootStore/DataStore/helpers.js
+++ b/src/RootStore/DataStore/helpers.js
@@ -45,6 +45,7 @@ export function getQueryStringFromFilters(filters = {}) {
   return qs.stringify(filters, {
     encode: false,
     addQueryPrefix: true,
+    // TODO[#641]: Remove adding "All" for violationType when the values are available in the metric file.
     filter: (key, value) => {
       if (key === VIOLATION_TYPE && value === "") {
         return "All";

--- a/src/RootStore/__tests__/BaseDataStore.test.js
+++ b/src/RootStore/__tests__/BaseDataStore.test.js
@@ -82,7 +82,7 @@ describe("BaseDataStore", () => {
     describe("fetchData", () => {
       it("makes a request to the correct endpoint for the apiData", () => {
         const expectedEndpoint = `${tenantId}/newRevocations/revocations_matrix_distribution_by_district
-        ?metricPeriodMonths=12&chargeCategory=All&supervisionType=All
+        ?metricPeriodMonths=12&chargeCategory=All&violationType=All&supervisionType=All
         &supervisionLevel=All&district[0]=All`.replace(/\n\s+/g, "");
 
         expect(callMetricsApi).toHaveBeenCalledTimes(1);

--- a/src/RootStore/__tests__/RootStore.test.js
+++ b/src/RootStore/__tests__/RootStore.test.js
@@ -21,6 +21,7 @@ import RootStore from "../RootStore";
 import { METADATA_NAMESPACE } from "../../constants";
 
 jest.mock("@auth0/auth0-spa-js");
+jest.mock("../DataStore/DataStore");
 
 let rootStore;
 

--- a/src/RootStore/__tests__/TenantStore.test.js
+++ b/src/RootStore/__tests__/TenantStore.test.js
@@ -26,6 +26,7 @@ import { METADATA_NAMESPACE } from "../../constants";
 jest.mock("@auth0/auth0-spa-js");
 jest.mock("../utils/user");
 jest.mock("../../StoreProvider");
+jest.mock("../DataStore/DataStore");
 
 let rootStore;
 const metadataField = `${METADATA_NAMESPACE}app_metadata`;

--- a/src/RootStore/__tests__/helpers.test.js
+++ b/src/RootStore/__tests__/helpers.test.js
@@ -37,7 +37,7 @@ describe("getQueryStringFromFilters", () => {
   it("filters out empty values", () => {
     filters = { ...filters, violationType: "", supervisionType: "All" };
     expect(getQueryStringFromFilters(filters)).toEqual(
-      "?district[0]=All&chargeCategory=GENERAL&supervisionType=All"
+      "?district[0]=All&chargeCategory=GENERAL&violationType=All&supervisionType=All"
     );
   });
 });


### PR DESCRIPTION
## Description of the change

This PR is the FE work that will support #705. We need to send the violationType query param as "All" so that we can select the correct subset when the files are filtered. I'm not as familiar with the matrix filtering logic yet, but if you think it would make more sense to move this as the "defaultValue" inside filterOptions, let me know and I can make that work instead!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Relates to #654 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
