### PR TITLE
Process restrictedAccess fetch results after caching

### DIFF
--- a/server/core/filterRestrictedAccessEmails.js
+++ b/server/core/filterRestrictedAccessEmails.js
@@ -15,22 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-const { default: fetchMetrics } = require("./fetchMetrics");
-
 /**
- * Fetches and processes the supervision_location_restricted_access_emails.
+ * Processes the supervision_location_restricted_access_emails.
  * Returns an object that contains the restricted district matching
  * userEmail param, or an empty object if none of the values match.
  */
-function fetchAndProcessRestrictedAccessEmails(
-  stateCode,
-  metricType,
-  file,
-  isDemo,
-  userEmail
-) {
-  return fetchMetrics(stateCode, metricType, file, isDemo).then((result) => {
+function filterRestrictedAccessEmails(userEmail, file) {
+  return (result) => {
     const restrictedEmails = result[file];
+
     return restrictedEmails
       ? {
           [file]: restrictedEmails.find((u) => {
@@ -40,7 +33,7 @@ function fetchAndProcessRestrictedAccessEmails(
           }),
         }
       : {};
-  });
+  };
 }
 
-exports.default = fetchAndProcessRestrictedAccessEmails;
+exports.default = filterRestrictedAccessEmails;

--- a/server/core/index.js
+++ b/server/core/index.js
@@ -27,8 +27,8 @@
  */
 const { default: fetchMetrics } = require("./fetchMetrics");
 const {
-  default: fetchAndProcessRestrictedAccessEmails,
-} = require("./fetchAndProcessRestrictedAccessEmails");
+  default: filterRestrictedAccessEmails,
+} = require("./filterRestrictedAccessEmails");
 const { default: refreshRedisCache } = require("./refreshRedisCache");
 const { default: fetchMetricsFromLocal } = require("./fetchMetricsFromLocal");
 const { default: fetchMetricsFromGCS } = require("./fetchMetricsFromGCS");
@@ -37,7 +37,7 @@ const { cacheResponse } = require("./cacheManager");
 
 module.exports = {
   fetchMetrics,
-  fetchAndProcessRestrictedAccessEmails,
+  filterRestrictedAccessEmails,
   fetchMetricsFromLocal,
   fetchMetricsFromGCS,
   getFilesByMetricType,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -55,9 +55,13 @@ function responder(res) {
  * processResultFn before passing the processed result to
  * the responder function.
  */
-function processAndRespond(responderFn, processResultFn) {
+function processAndRespond(responderFn, processResultsFn) {
   return (err, data) => {
-    responderFn(err, processResultFn(data));
+    if (data) {
+      responderFn(null, processResultsFn(data));
+    } else {
+      responderFn(err, null);
+    }
   };
 }
 


### PR DESCRIPTION
## Description of the change

We were caching the already processed result of the restrictedAccess endpoint, instead of the full file contents. This adds a new `processAndRespond` callback to process the cached value before responding.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #729

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
