### PR TITLE
[FE] Only request metric file if filter value is missing from the dimension manifest

### DIFF
--- a/src/RootStore/DataStore/BaseDataStore.js
+++ b/src/RootStore/DataStore/BaseDataStore.js
@@ -22,10 +22,16 @@ import {
   computed,
   toJS,
   autorun,
+  reaction,
 } from "mobx";
 
 import { callMetricsApi } from "../../api/metrics/metricsClient";
-import { processResponseData, getQueryStringFromFilters } from "./helpers";
+import {
+  processResponseData,
+  getQueryStringFromFilters,
+  dimensionManifestIncludesFilterValues,
+} from "./helpers";
+import { FILTER_TYPE_MAP, DISTRICT } from "../../constants/filterTypes";
 
 /**
  * BaseDataStore is an abstract class that should never be directly instantiated.
@@ -38,35 +44,53 @@ export default class BaseDataStore {
 
   isError = false;
 
-  apiData = [];
-
-  filteredData = [];
-
-  metadata = {};
+  apiData = {};
 
   file;
 
   eagerExpand = false;
 
-  constructor({ rootStore, file }) {
+  treatCategoryAllAsAbsent = false;
+
+  ignoredSubsetDimensions = [DISTRICT];
+
+  constructor({
+    rootStore,
+    file,
+    skippedFilters = [],
+    treatCategoryAllAsAbsent = false,
+  }) {
     makeObservable(this, {
       fetchData: flow,
-      apiData: observable.shallow,
-      filteredData: observable.shallow,
-      queryFilters: computed,
-      metadata: false,
+      apiData: observable.ref,
+      filteredData: computed,
+      filtersQueryParams: computed,
+      dimensionManifest: computed,
+      shouldFetchNewSubsetFile: computed,
       isLoading: true,
       isError: true,
       eagerExpand: true,
     });
 
     this.file = file;
-
+    this.skippedFilters = skippedFilters;
+    this.treatCategoryAllAsAbsent = treatCategoryAllAsAbsent;
     this.rootStore = rootStore;
 
-    autorun(() => {
-      const { userStore } = this.rootStore;
+    const { userStore } = this.rootStore;
 
+    reaction(
+      () => this.shouldFetchNewSubsetFile,
+      (shouldFetchNewSubsetFile) => {
+        if (!this.isLoading && !shouldFetchNewSubsetFile) {
+          this.fetchData({
+            tenantId: this.rootStore.currentTenantId,
+          });
+        }
+      }
+    );
+
+    autorun(() => {
       if (
         userStore &&
         !userStore.userIsLoading &&
@@ -74,38 +98,58 @@ export default class BaseDataStore {
       ) {
         this.fetchData({
           tenantId: this.rootStore.currentTenantId,
-          queryString: this.queryFilters,
         });
       }
     });
   }
 
-  get queryFilters() {
-    return getQueryStringFromFilters(
-      Object.fromEntries(toJS(this.rootStore.filters))
-    );
+  get shouldFetchNewSubsetFile() {
+    return dimensionManifestIncludesFilterValues({
+      filters: this.filters,
+      dimensionManifest: this.dimensionManifest,
+      skippedFilters: this.skippedFilters,
+      ignoredSubsetDimensions: this.ignoredSubsetDimensions,
+      treatCategoryAllAsAbsent: this.treatCategoryAllAsAbsent,
+    });
+  }
+
+  get filtersQueryParams() {
+    return getQueryStringFromFilters(this.filters);
+  }
+
+  get filters() {
+    return Object.fromEntries(toJS(this.rootStore.filters));
   }
 
   get getTokenSilently() {
     return this.rootStore.userStore.getTokenSilently;
   }
 
-  *fetchData({ tenantId, queryString }) {
-    const endpoint = `${tenantId}/newRevocations/${this.file}${queryString}`;
+  get dimensionManifest() {
+    if (!this.apiData.metadata) return null;
+
+    return this.apiData.metadata.dimension_manifest.reduce((acc, dimension) => {
+      const [name, values] = dimension;
+      if (FILTER_TYPE_MAP[name]) {
+        acc[FILTER_TYPE_MAP[name]] = values;
+      }
+      return acc;
+    }, {});
+  }
+
+  *fetchData({ tenantId }) {
+    const endpoint = `${tenantId}/newRevocations/${this.file}${this.filtersQueryParams}`;
     try {
       this.isLoading = true;
       const responseData = yield callMetricsApi(
         endpoint,
         this.getTokenSilently
       );
-      const processedData = processResponseData(
+      this.apiData = processResponseData(
         responseData,
         this.file,
         this.eagerExpand
       );
-      this.apiData = processedData.data;
-      this.metadata = processedData.metadata;
-      this.filteredData = this.filterData(processedData);
       this.isLoading = false;
       this.isError = false;
     } catch (error) {
@@ -113,10 +157,5 @@ export default class BaseDataStore {
       this.isError = true;
       this.isLoading = false;
     }
-  }
-
-  filterData() {
-    console.error(`filterData must be defined in the subclass.`);
-    this.filteredData = [];
   }
 }

--- a/src/RootStore/DataStore/BaseDataStore.js
+++ b/src/RootStore/DataStore/BaseDataStore.js
@@ -82,7 +82,7 @@ export default class BaseDataStore {
     reaction(
       () => this.shouldFetchNewSubsetFile,
       (shouldFetchNewSubsetFile) => {
-        if (!this.isLoading && !shouldFetchNewSubsetFile) {
+        if (!this.isLoading && shouldFetchNewSubsetFile) {
           this.fetchData({
             tenantId: this.rootStore.currentTenantId,
           });
@@ -104,7 +104,7 @@ export default class BaseDataStore {
   }
 
   get shouldFetchNewSubsetFile() {
-    return dimensionManifestIncludesFilterValues({
+    return !dimensionManifestIncludesFilterValues({
       filters: this.filters,
       dimensionManifest: this.dimensionManifest,
       skippedFilters: this.skippedFilters,
@@ -135,6 +135,11 @@ export default class BaseDataStore {
       }
       return acc;
     }, {});
+  }
+
+  get filteredData() {
+    console.error(`filteredData should be defined in the subclass.`);
+    return this.filteredData;
   }
 
   *fetchData({ tenantId }) {

--- a/src/RootStore/DataStore/BaseDataStore.js
+++ b/src/RootStore/DataStore/BaseDataStore.js
@@ -138,8 +138,7 @@ export default class BaseDataStore {
   }
 
   get filteredData() {
-    console.error(`filteredData should be defined in the subclass.`);
-    return this.filteredData;
+    throw new Error(`filteredData should be defined in the subclass.`, this);
   }
 
   *fetchData({ tenantId }) {

--- a/src/RootStore/DataStore/CaseTableStore.js
+++ b/src/RootStore/DataStore/CaseTableStore.js
@@ -20,17 +20,24 @@ import { filterOptimizedDataFormat } from "../../utils/charts/dataFilters";
 
 export default class CaseTableStore extends BaseDataStore {
   constructor({ rootStore }) {
-    super({ rootStore, file: `revocations_matrix_filtered_caseload` });
-  }
-
-  filterData({ data, metadata }) {
-    const { filters } = this.rootStore;
-    const dataFilter = matchesAllFilters({
-      filters,
+    super({
+      rootStore,
+      file: `revocations_matrix_filtered_caseload`,
       treatCategoryAllAsAbsent: true,
     });
+  }
+
+  get filteredData() {
+    if (!this.apiData.data) return [];
+    const { data, metadata } = this.apiData;
+    const { filters } = this.rootStore;
+
+    const dataFilter = matchesAllFilters({
+      filters,
+      treatCategoryAllAsAbsent: this.treatCategoryAllAsAbsent,
+    });
     return filterOptimizedDataFormat({
-      apiData: data,
+      apiData: [...data],
       metadata,
       filterFn: dataFilter,
     });

--- a/src/RootStore/DataStore/MatrixStore.js
+++ b/src/RootStore/DataStore/MatrixStore.js
@@ -23,11 +23,14 @@ export default class MatrixStore extends BaseDataStore {
     super({ rootStore, file: `revocations_matrix_cells` });
   }
 
-  filterData({ data, metadata }) {
+  get filteredData() {
+    if (!this.apiData.data) return [];
+    const { data, metadata } = this.apiData;
     const { filters } = this.rootStore;
     const dataFilter = matchesTopLevelFilters({ filters });
+
     return filterOptimizedDataFormat({
-      apiData: data,
+      apiData: [...data],
       metadata,
       filterFn: dataFilter,
     });

--- a/src/RootStore/DataStore/helpers.js
+++ b/src/RootStore/DataStore/helpers.js
@@ -2,7 +2,12 @@ import qs from "qs";
 import toInteger from "lodash/fp/toInteger";
 import { convertFromStringToUnflattenedMatrix } from "../../api/metrics/optimizedFormatHelpers";
 import { parseResponseByFileFormat } from "../../api/metrics/fileParser";
-import { VIOLATION_TYPE } from "../../constants/filterTypes";
+import {
+  FILTER_TYPE_MAP,
+  REPORTED_VIOLATIONS,
+  VIOLATION_TYPE,
+  DISTRICT,
+} from "../../constants/filterTypes";
 
 export function unflattenValues(metricFile) {
   const totalDataPoints = toInteger(metricFile.metadata.total_data_points);
@@ -52,5 +57,32 @@ export function getQueryStringFromFilters(filters = {}) {
       }
       return value !== "" ? value : undefined;
     },
+  });
+}
+
+export function dimensionManifestIncludesFilterValues({
+  filters,
+  dimensionManifest,
+  ignoredSubsetDimensions = [],
+  skippedFilters = [],
+  treatCategoryAllAsAbsent = false,
+}) {
+  if (!filters || !dimensionManifest) return false;
+  return Object.keys(filters).every((filterType) => {
+    if (
+      skippedFilters.includes(filterType) ||
+      ignoredSubsetDimensions.includes(filterType) ||
+      // TODO - remove these two specific checks once reported_violations
+      // and violation_type are unnested
+      (filterType === REPORTED_VIOLATIONS && filters[filterType] === "") ||
+      (filterType === VIOLATION_TYPE && filters[filterType] === "") ||
+      // This is for the CaseTable
+      (filters[filterType].toLowerCase() === "all" && treatCategoryAllAsAbsent)
+    ) {
+      return true;
+    }
+    return dimensionManifest[filterType].includes(
+      filters[filterType].toLowerCase()
+    );
   });
 }

--- a/src/RootStore/DataStore/helpers.js
+++ b/src/RootStore/DataStore/helpers.js
@@ -3,10 +3,8 @@ import toInteger from "lodash/fp/toInteger";
 import { convertFromStringToUnflattenedMatrix } from "../../api/metrics/optimizedFormatHelpers";
 import { parseResponseByFileFormat } from "../../api/metrics/fileParser";
 import {
-  FILTER_TYPE_MAP,
   REPORTED_VIOLATIONS,
   VIOLATION_TYPE,
-  DISTRICT,
 } from "../../constants/filterTypes";
 
 export function unflattenValues(metricFile) {
@@ -80,6 +78,11 @@ export function dimensionManifestIncludesFilterValues({
       (filters[filterType].toLowerCase() === "all" && treatCategoryAllAsAbsent)
     ) {
       return true;
+    }
+    if (dimensionManifest[filterType] === undefined) {
+      throw new Error(
+        `Expected to find ${filterType} in the dimension manifest. Should this filter be skipped?`
+      );
     }
     return dimensionManifest[filterType].includes(
       filters[filterType].toLowerCase()

--- a/src/RootStore/__tests__/BaseDataStore.test.js
+++ b/src/RootStore/__tests__/BaseDataStore.test.js
@@ -82,6 +82,12 @@ describe("BaseDataStore", () => {
       it("sets eagerExpand to false'", () => {
         expect(baseStore.eagerExpand).toBe(false);
       });
+
+      it("throws an error if filteredData is accessed by the parent class", () => {
+        expect(() => baseStore.filteredData).toThrowError(
+          `filteredData should be defined in the subclass.`
+        );
+      });
     });
 
     describe("fetchData", () => {

--- a/src/RootStore/__tests__/BaseDataStore.test.js
+++ b/src/RootStore/__tests__/BaseDataStore.test.js
@@ -35,7 +35,15 @@ jest.mock("../../api/metrics/metricsClient", () => {
         flattenedValueMatrix: "0,0",
         metadata: {
           total_data_points: 1,
-          dimension_manifest: [["reported_violations", ["0"]]],
+          dimension_manifest: [
+            ["metric_period_months", ["12"]],
+            ["charge_category", ["all"]],
+            ["reported_violations", ["0"]],
+            ["violation_type", ["felony"]],
+            ["supervision_level", ["all"]],
+            ["supervision_type", ["all"]],
+            ["district", ["all"]],
+          ],
           value_keys: ["population_count"],
         },
       },
@@ -66,10 +74,6 @@ describe("BaseDataStore", () => {
       baseStore = new BaseDataStore({ rootStore, file });
     });
 
-    afterAll(() => {
-      jest.resetAllMocks();
-    });
-
     describe("default store properties", () => {
       it("has a reference to the rootStore", () => {
         expect(baseStore.rootStore).toBeDefined();
@@ -98,8 +102,21 @@ describe("BaseDataStore", () => {
         expect(baseStore.isError).toEqual(false);
       });
 
-      it("sets apiData", () => {
-        expect(baseStore.apiData).toEqual([["0"], ["0"]]);
+      it("sets both the data and metadata values as apiData", () => {
+        expect(baseStore.apiData.data).toEqual([["0"], ["0"]]);
+        expect(baseStore.apiData.metadata).toEqual({
+          total_data_points: 1,
+          dimension_manifest: [
+            ["metric_period_months", ["12"]],
+            ["charge_category", ["all"]],
+            ["reported_violations", ["0"]],
+            ["violation_type", ["felony"]],
+            ["supervision_level", ["all"]],
+            ["supervision_type", ["all"]],
+            ["district", ["all"]],
+          ],
+          value_keys: ["population_count"],
+        });
       });
 
       describe("when API responds with an error", () => {
@@ -109,7 +126,7 @@ describe("BaseDataStore", () => {
         });
 
         it("does not set apiData", () => {
-          expect(baseStore.apiData).toStrictEqual([]);
+          expect(baseStore.apiData).toStrictEqual({});
         });
 
         it("sets isError to true and isLoading to false", () => {
@@ -117,6 +134,22 @@ describe("BaseDataStore", () => {
           expect(baseStore.isLoading).toBe(false);
         });
       });
+    });
+  });
+
+  describe("when a filter value is not included in the dimension manifest", () => {
+    it("fetches a new subset file with new filter query params", () => {
+      const expectedEndpoint = `${tenantId}/newRevocations/revocations_matrix_distribution_by_district?
+      metricPeriodMonths=12&chargeCategory=All&violationType=LAW&supervisionType=All&supervisionLevel=All
+      &district[0]=All`.replace(/\n\s+/g, "");
+
+      rootStore.filtersStore.setFilters({
+        violationType: "LAW",
+      });
+      expect(callMetricsApi).toHaveBeenCalledWith(
+        expectedEndpoint,
+        mockGetTokenSilently
+      );
     });
   });
 

--- a/src/RootStore/__tests__/helpers.test.js
+++ b/src/RootStore/__tests__/helpers.test.js
@@ -15,29 +15,189 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { getQueryStringFromFilters } from "../DataStore/helpers";
+import {
+  getQueryStringFromFilters,
+  dimensionManifestIncludesFilterValues,
+} from "../DataStore/helpers";
 
-describe("getQueryStringFromFilters", () => {
-  let filters;
+describe("DataStore helpers", () => {
+  describe("getQueryStringFromFilters", () => {
+    let filters;
 
-  beforeEach(() => {
-    filters = { district: ["All"], chargeCategory: "GENERAL" };
+    beforeEach(() => {
+      filters = { district: ["All"], chargeCategory: "GENERAL" };
+    });
+
+    it("returns an empty string when there are no filters", () => {
+      expect(getQueryStringFromFilters({})).toEqual("");
+    });
+
+    it("returns a query string", () => {
+      expect(getQueryStringFromFilters(filters)).toEqual(
+        "?district[0]=All&chargeCategory=GENERAL"
+      );
+    });
+
+    it("filters out empty values", () => {
+      filters = { ...filters, violationType: "", supervisionType: "All" };
+      expect(getQueryStringFromFilters(filters)).toEqual(
+        "?district[0]=All&chargeCategory=GENERAL&violationType=All&supervisionType=All"
+      );
+    });
   });
 
-  it("returns an empty string when there are no filters", () => {
-    expect(getQueryStringFromFilters({})).toEqual("");
-  });
+  describe("dimensionManifestIncludesFilterValues", () => {
+    let filters;
+    let dimensionManifest;
+    let skippedFilters;
+    let ignoredSubsetDimensions;
+    let treatCategoryAllAsAbsent;
 
-  it("returns a query string", () => {
-    expect(getQueryStringFromFilters(filters)).toEqual(
-      "?district[0]=All&chargeCategory=GENERAL"
-    );
-  });
+    it("returns true when the dimension manifest has all the filter values", () => {
+      filters = {
+        chargeCategory: "All",
+        violationType: "",
+        metricPeriodMonths: "12",
+      };
 
-  it("filters out empty values", () => {
-    filters = { ...filters, violationType: "", supervisionType: "All" };
-    expect(getQueryStringFromFilters(filters)).toEqual(
-      "?district[0]=All&chargeCategory=GENERAL&violationType=All&supervisionType=All"
-    );
+      dimensionManifest = {
+        chargeCategory: ["all", "domestic_violence", "general"],
+        violationType: ["absconded", "escaped", "felony"],
+        metricPeriodMonths: ["1", "12", "3", "36", "6"],
+      };
+      expect(
+        dimensionManifestIncludesFilterValues({ filters, dimensionManifest })
+      ).toEqual(true);
+    });
+
+    it("returns false when the dimension manifest is missing the filter value", () => {
+      filters = {
+        chargeCategory: "All",
+        violationType: "LAW",
+        metricPeriodMonths: "12",
+      };
+
+      dimensionManifest = {
+        chargeCategory: ["all", "domestic_violence", "general"],
+        violationType: ["absconded", "escaped", "felony"],
+        metricPeriodMonths: ["1", "12", "3", "36", "6"],
+      };
+      expect(
+        dimensionManifestIncludesFilterValues({ filters, dimensionManifest })
+      ).toEqual(false);
+    });
+
+    it("raises an error when the dimension manifest is missing a filter key", () => {
+      filters = {
+        chargeCategory: "All",
+        violationType: "",
+        metricPeriodMonths: "12",
+        supervisionType: "All",
+      };
+
+      dimensionManifest = {
+        chargeCategory: ["all", "domestic_violence", "general"],
+        violationType: ["absconded", "escaped", "felony"],
+        metricPeriodMonths: ["1", "12", "3", "36", "6"],
+      };
+      expect(() =>
+        dimensionManifestIncludesFilterValues({ filters, dimensionManifest })
+      ).toThrowError(
+        new Error(
+          `Expected to find supervisionType in the dimension manifest. Should this filter be skipped?`
+        )
+      );
+    });
+
+    describe("when there are skipped filters", () => {
+      beforeEach(() => {
+        filters = {
+          chargeCategory: "All",
+          violationType: "",
+          metricPeriodMonths: "9",
+        };
+
+        dimensionManifest = {
+          chargeCategory: ["all", "domestic_violence", "general"],
+          violationType: ["absconded", "escaped", "felony"],
+          metricPeriodMonths: ["1", "12", "3", "36", "6"],
+        };
+
+        skippedFilters = ["metricPeriodMonths"];
+      });
+
+      it("ignores that filter type when all other values match the dimension manifest", () => {
+        expect(
+          dimensionManifestIncludesFilterValues({
+            filters,
+            dimensionManifest,
+            skippedFilters,
+          })
+        ).toEqual(true);
+      });
+
+      it("only ignores the skipped filter type", () => {
+        filters.violationType = "LAW";
+        expect(
+          dimensionManifestIncludesFilterValues({
+            filters,
+            dimensionManifest,
+            skippedFilters,
+          })
+        ).toEqual(false);
+      });
+    });
+
+    describe("when there are ignored subset dimensions", () => {
+      it("ignores that filter type when all other values match the dimension manifest", () => {
+        filters = {
+          chargeCategory: "All",
+          violationType: "",
+          metricPeriodMonths: "12",
+          district: "01",
+        };
+
+        dimensionManifest = {
+          district: ["all", "02"],
+          chargeCategory: ["all", "domestic_violence", "general"],
+          violationType: ["absconded", "escaped", "felony"],
+          metricPeriodMonths: ["1", "12", "3", "36", "6"],
+        };
+
+        ignoredSubsetDimensions = ["district"];
+        expect(
+          dimensionManifestIncludesFilterValues({
+            filters,
+            dimensionManifest,
+            ignoredSubsetDimensions,
+          })
+        ).toEqual(true);
+      });
+    });
+
+    describe("when the 'All' filter value should be ignored", () => {
+      it("ignores that filter type when all other values match the dimension manifest", () => {
+        filters = {
+          chargeCategory: "All",
+          violationType: "ABSCONDED",
+          metricPeriodMonths: "12",
+        };
+
+        dimensionManifest = {
+          chargeCategory: ["domestic_violence", "general"],
+          violationType: ["absconded", "escaped", "felony"],
+          metricPeriodMonths: ["1", "12", "3", "36", "6"],
+        };
+
+        treatCategoryAllAsAbsent = true;
+        expect(
+          dimensionManifestIncludesFilterValues({
+            filters,
+            dimensionManifest,
+            treatCategoryAllAsAbsent,
+          })
+        ).toEqual(true);
+      });
+    });
   });
 });

--- a/src/constants/filterTypes.js
+++ b/src/constants/filterTypes.js
@@ -1,3 +1,20 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
 export const METRIC_PERIOD_MONTHS = "metricPeriodMonths";
 export const CHARGE_CATEGORY = "chargeCategory";
 export const DISTRICT = "district";
@@ -8,3 +25,29 @@ export const SUPERVISION_LEVEL = "supervisionLevel";
 export const REPORTED_VIOLATIONS = "reportedViolations";
 export const VIOLATION_TYPE = "violationType";
 export const ADMISSION_TYPE = "admissionType";
+
+export const FILTER_TYPES = [
+  METRIC_PERIOD_MONTHS,
+  CHARGE_CATEGORY,
+  DISTRICT,
+  LEVEL_1_SUPERVISION_LOCATION,
+  LEVEL_2_SUPERVISION_LOCATION,
+  SUPERVISION_TYPE,
+  SUPERVISION_LEVEL,
+  REPORTED_VIOLATIONS,
+  VIOLATION_TYPE,
+  ADMISSION_TYPE,
+];
+
+export const FILTER_TYPE_MAP = {
+  metric_period_months: METRIC_PERIOD_MONTHS,
+  charge_category: CHARGE_CATEGORY,
+  district: DISTRICT,
+  level_1_supervision_location: LEVEL_1_SUPERVISION_LOCATION,
+  level_2_supervision_location: LEVEL_2_SUPERVISION_LOCATION,
+  supervision_type: SUPERVISION_TYPE,
+  supervision_level: SUPERVISION_LEVEL,
+  reported_violations: REPORTED_VIOLATIONS,
+  violation_type: VIOLATION_TYPE,
+  admission_type: ADMISSION_TYPE,
+};


### PR DESCRIPTION
## Description of the change

Currently on staging we are making a request to the API on every filter change. This PR changes that flow so that we will only request a new metric file if the value from the filter is not in the dimension manifest found in the file's metadata.

When we start using the subset files, the dimension manifest sent from the API will be updated to include only the values found in that subset. That way when a filter changes, it will only request a new subset file when it needs to.  

Some notable changes:

- I changed the observable value for `apiData` to be an `observable.ref` and removed the separate metadata property. The new apiData value looks like this: `this.apiData = { data, metadata }`. This is because I wanted to make `metadata` observable, and I did not want the `filteredData` to be computed twice (once for the metadata value change and again for the apiData value change). This way, when `this.apiData` changes, the data is only filtered once.  
- I changed `filteredData` to be a computed value. This is so it can be computed when either apiData or filters change. This does however remove the `isLoading` state when filtering...I was trying to think of a way to add that back and I'm not sure the best place to put that yet... 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #658

NOTE: This PR should merge before #728 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
