### PR TITLE
[API] Replace functions that are unsupported in node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "react-scripts build",
     "build-staging": "env-cmd -f .env.development react-scripts build",
     "test-react": "TZ=UTC react-scripts test",
-    "test-server": "TZ=UTC jest ./server",
+    "test-server": "TZ=UTC jest ./server --forceExit",
     "test-filters": "TZ=UTC jest ./shared-filters",
     "test": "yarn test-server && yarn test-filters && yarn test-react",
     "spa": "react-scripts start",

--- a/server/core/__tests__/refreshRedisCache.test.js
+++ b/server/core/__tests__/refreshRedisCache.test.js
@@ -82,7 +82,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey
+        `${fileKey}.txt`
       ).then(() => {
         expect(responseErrors).toBeNull();
         expect(mockFetchValue).toHaveBeenCalledTimes(1);
@@ -101,7 +101,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey,
+        `${fileKey}.txt`,
         responseErrors
       ).then((errors) => {
         expect(mockCache.set).toHaveBeenCalledTimes(1);
@@ -125,7 +125,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey,
+        `${fileKey}.txt`,
         responseErrors
       ).then(() => {
         expect(responseErrors).toEqual([]);
@@ -158,7 +158,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey,
+        `${fileKey}.txt`,
         responseErrors
       ).then(() => {
         expect(responseErrors).toEqual([]);
@@ -188,7 +188,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey,
+        `${fileKey}.txt`,
         responseErrors
       ).then(() => {
         expect(responseErrors).toEqual([error.message]);
@@ -203,7 +203,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey,
+        `${fileKey}.txt`,
         responseErrors
       ).then(() => {
         expect(mockCache.set).toHaveBeenCalledTimes(6);
@@ -221,7 +221,7 @@ describe("refreshRedisCache", () => {
         mockFetchValue,
         stateCode,
         metricType,
-        fileKey,
+        `${fileKey}.txt`,
         responseErrors
       ).then(() => {
         expect(mockCache.set).toHaveBeenCalledTimes(0);

--- a/server/core/refreshRedisCache.js
+++ b/server/core/refreshRedisCache.js
@@ -74,7 +74,7 @@ function cacheFile({ file, cacheKeyPrefix, fileKey }) {
   return cachePromises;
 }
 
-function refreshRedisCache(
+async function refreshRedisCache(
   fetchMetrics,
   stateCode,
   metricType,
@@ -86,19 +86,23 @@ function refreshRedisCache(
 
   return fetchMetrics()
     .then((file) => {
-      return Promise.all(
-        cacheFile({ file, cacheKeyPrefix, fileKey, responseErrors })
-      );
+      return Promise.all(cacheFile({ file, cacheKeyPrefix, fileKey }));
     })
     .catch((error) => {
       console.error(
         `Error occurred while caching files for metricType: ${metricType}`,
         error
       );
-      responseErrors.push(error.message);
+      console.log(
+        "if responseErrors, push error.message: ",
+        responseErrors,
+        error.message
+      );
+      if (responseErrors) responseErrors.push(error.message);
       return responseErrors;
     })
     .finally(() => {
+      console.log({ responseErrors });
       return responseErrors;
     });
 }

--- a/server/core/refreshRedisCache.js
+++ b/server/core/refreshRedisCache.js
@@ -78,10 +78,11 @@ async function refreshRedisCache(
   fetchMetrics,
   stateCode,
   metricType,
-  fileKey,
+  fileName,
   responseErrors = null
 ) {
   const cacheKeyPrefix = `${stateCode.toUpperCase()}-${metricType}`;
+  const fileKey = fileName.replace(/.(txt|json)/g, "");
   console.log(`Handling call to refresh cache for ${cacheKeyPrefix}...`);
 
   return fetchMetrics()

--- a/server/filters/subsetFileHelpers.js
+++ b/server/filters/subsetFileHelpers.js
@@ -30,9 +30,10 @@ const getSubsetDimensionKeys = () =>
  * @param {boolean} useIndexValue - Whether or not to treat the value param as a value or an index.
  */
 const getSubsetDimensionValues = (key, value) => {
-  const subsets = Object.fromEntries(SUBSET_MANIFEST)[key];
-  if (typeof value === "number") return subsets[value];
-  return subsets.find((subset) => subset.includes(value.toLowerCase()));
+  const subset = SUBSET_MANIFEST.find((s) => s[0] === key);
+  if (typeof value === "number") return subset[1][value];
+  const subsetValues = subset[1].find((s) => s.includes(value.toLowerCase()));
+  return subsetValues;
 };
 
 /**
@@ -80,7 +81,7 @@ function createFlattenedValueMatrix(filteredDataPoints, subsetMetadata) {
       }
     }
   }
-  return unflattenedMatrix.flat().join(",");
+  return [].concat(...unflattenedMatrix).join(",");
 }
 
 /**

--- a/server/routes/__tests__/api.test.js
+++ b/server/routes/__tests__/api.test.js
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+
+const { getFileName } = require("../../utils/fileName");
+const { FILES_BY_METRIC_TYPE } = require("../../constants/filesByMetricType");
+
 const mockMetricFiles = {
   file_1: "content_1",
   file_2: "content_2",
@@ -141,13 +145,16 @@ describe("API GET tests", () => {
 
     it("refreshCache - calls fetchMetrics with the correct args", async () => {
       await fakeRequest(refreshCache);
-
-      expect(fetchMetrics).toHaveBeenCalledWith(
-        stateCode,
-        "newRevocation",
-        null,
-        false
-      );
+      const metricType = "newRevocation";
+      expect(fetchMetrics.mock.calls.length).toBe(10);
+      FILES_BY_METRIC_TYPE[metricType].forEach((file) => {
+        expect(fetchMetrics).toHaveBeenCalledWith(
+          stateCode,
+          metricType,
+          getFileName(file),
+          false
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Description of the change

This PR tries to fix the failing cron job we were seeing this past week. There are two issues it's trying to fix:

- Fetching all the data at once before filtering and caching every file's subset
- Errors on functions that are not supported in node 10

The next step is to see if this fixes the cron job. If it does, we want to undo the fix for fetching all the data at once and try to see if that really is causing the memory error we were seeing, or if it was just the unsupported functions causing a timeout. 

Side note -- I think we should update the `.nvmrc` to match the version we are deploying, thoughts @jovergaag ? Let me know if we should include that in this PR.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Related to #655 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
