### PR TITLE
[FE] Format currentDistrict to lowercase for comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "server:demo": "IS_DEMO=true yarn server:dev",
     "redis-server": "redis-server",
     "lint": "tsc && eslint '**/*.{js,ts,tsx}'",
-    "dev": "npm-run-all --parallel spa server:dev"
+    "dev": "npm-run-all --parallel spa server:dev",
+    "demo": "npm-run-all --parallel spa server:demo"
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.12.1",

--- a/src/components/charts/new_revocations/RevocationsByDistrict/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByDistrict/createGenerateChartData.js
@@ -65,7 +65,8 @@ const generatePercentChartData = (filteredData, currentDistricts, mode) => {
       currentDistricts &&
       labels[dataIndex] &&
       currentDistricts.find(
-        (currentDistrict) => currentDistrict === labels[dataIndex].toLowerCase()
+        (currentDistrict) =>
+          currentDistrict.toLowerCase() === labels[dataIndex].toLowerCase()
       )
         ? COLORS["lantern-light-blue"]
         : COLORS["lantern-orange"];


### PR DESCRIPTION
## Description of the change

Some districts were not highlighted blue when viewing the District chart in percentage mode. This was because we were comparing the currently selected district name, which sometimes includes names like "04B", to the chart's lowercased data label. This PR fixes that bug by also formatting the current district's name as lowercase before making a comparison.

I also added a new script `yarn demo` to more easily run the FE & BE in demo mode together. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #738 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
