### PR TITLE
set skippedFilters when changing revocation chart

### DIFF
--- a/src/RootStore/DataStore/RevocationsChartStore.js
+++ b/src/RootStore/DataStore/RevocationsChartStore.js
@@ -71,6 +71,7 @@ export default class RevocationsChartStore extends BaseDataStore {
 
   setSelectedChart(chartId) {
     this.selectedChart = chartId;
+    this.skippedFilters = CHARTS[chartId].skippedFilters || [];
   }
 
   get filteredData() {


### PR DESCRIPTION
## Description of the change

All of the RevocationsByDimension charts currently have `skippedFilters=[District]` because that is the default selected chart. Update the skipped filters when `setSelectedChart` is called.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #744

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
