### PR TITLE
Create subset for revocations_matrix_by_month

### DIFF
--- a/server/constants/subsetManifest.js
+++ b/server/constants/subsetManifest.js
@@ -48,6 +48,7 @@ const FILES_WITH_SUBSETS = [
   "revocations_matrix_distribution_by_race",
   "revocations_matrix_distribution_by_risk_level",
   "revocations_matrix_distribution_by_violation",
+  "revocations_matrix_by_month",
 ];
 
 function validateSubsetManifest() {

--- a/server/filters/__tests__/filterHelpers.test.js
+++ b/server/filters/__tests__/filterHelpers.test.js
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+const { matchesAllFilters } = require("shared-filters");
+
 const { createSubsetFilters, getFilterFnByFile } = require("../filterHelpers");
-const { matchesAllFilters } = require("../../../shared-filters/dataFilters");
 
 jest.mock("../../constants/subsetManifest", () => {
   return {
@@ -34,9 +35,12 @@ jest.mock("../../constants/subsetManifest", () => {
     FILES_WITH_SUBSETS: ["revocations_matrix_distribution_by_district"],
   };
 });
-jest.mock("../../../shared-filters/dataFilters", () => {
+jest.mock("shared-filters/", () => {
   return {
     matchesAllFilters: jest.fn(),
+    getFilterKeys: () => {
+      return { METRIC_PERIOD_MONTHS: "metric_period_months" };
+    },
   };
 });
 

--- a/server/filters/__tests__/filterHelpers.test.js
+++ b/server/filters/__tests__/filterHelpers.test.js
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-const { createSubsetFilters } = require("../filterHelpers");
+const { createSubsetFilters, getFilterFnByFile } = require("../filterHelpers");
+const { matchesAllFilters } = require("../../../shared-filters/dataFilters");
 
 jest.mock("../../constants/subsetManifest", () => {
   return {
@@ -31,6 +32,11 @@ jest.mock("../../constants/subsetManifest", () => {
       ];
     }),
     FILES_WITH_SUBSETS: ["revocations_matrix_distribution_by_district"],
+  };
+});
+jest.mock("../../../shared-filters/dataFilters", () => {
+  return {
+    matchesAllFilters: jest.fn(),
   };
 });
 
@@ -70,6 +76,26 @@ describe("createSubsetFilters", () => {
       expect(createSubsetFilters({ filters })).toEqual({
         violation_type: ["all", "absconsion"],
         charge_category: ["sex_offense"],
+      });
+    });
+  });
+});
+
+describe("getFilterFnByFile", () => {
+  afterAll(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe("given file=revocations_matrix_by_month", () => {
+    const filters = {};
+    const file = "revocations_matrix_by_month";
+
+    it("matchesAllFilters is called with correct skippedFilters param", () => {
+      getFilterFnByFile(file, filters);
+      expect(matchesAllFilters).toHaveBeenCalledWith({
+        filters,
+        skippedFilters: ["metric_period_months"],
       });
     });
   });

--- a/server/filters/filterHelpers.js
+++ b/server/filters/filterHelpers.js
@@ -16,7 +16,7 @@
 // =============================================================================
 
 const { snakeCase } = require("lodash");
-const { matchesAllFilters } = require("shared-filters");
+const { matchesAllFilters, getFilterKeys } = require("shared-filters");
 const {
   getSubsetDimensionKeys,
   getSubsetDimensionValues,
@@ -58,6 +58,8 @@ function createSubsetFilters({ filters }) {
  * and returns whether or not the item should be filtered out.
  */
 const getFilterFnByFile = (file, subsetFilters) => {
+  const filterKeys = getFilterKeys();
+
   switch (file) {
     case "revocations_matrix_distribution_by_district":
     case "revocations_matrix_distribution_by_risk_level":
@@ -71,7 +73,7 @@ const getFilterFnByFile = (file, subsetFilters) => {
     case "revocations_matrix_by_month":
       return matchesAllFilters({
         filters: subsetFilters,
-        skippedFilters: "metric_period_months",
+        skippedFilters: [filterKeys.METRIC_PERIOD_MONTHS],
       });
     default:
       return () => true;

--- a/server/filters/filterHelpers.js
+++ b/server/filters/filterHelpers.js
@@ -68,6 +68,11 @@ const getFilterFnByFile = (file, subsetFilters) => {
       return matchesAllFilters({
         filters: subsetFilters,
       });
+    case "revocations_matrix_by_month":
+      return matchesAllFilters({
+        filters: subsetFilters,
+        skippedFilters: "metric_period_months",
+      });
     default:
       return () => true;
   }

--- a/shared-filters/index.js
+++ b/shared-filters/index.js
@@ -9,6 +9,7 @@ const {
 const { filterOptimizedDataFormat } = require("./filterOptimizedDataFormat");
 const { matchesAllFilters, matchesTopLevelFilters } = require("./dataFilters");
 const { isAllItem } = require("./dataPointComparisons");
+const { getFilterKeys } = require("./getFilterKeys");
 
 module.exports = {
   convertFromStringToUnflattenedMatrix,
@@ -21,4 +22,5 @@ module.exports = {
   matchesTopLevelFilters,
   unflattenValues,
   validateMetadata,
+  getFilterKeys,
 };


### PR DESCRIPTION
## Description of the change

Adds `revocations_matrix_by_month` to the `FILES_WITH_SUBSETS` list and adds custom filter function such that the "Revocations Over Time" chart data is subsetted with the correct `skippedFilters`. This improves performance on IE11 considerably because it cuts the data for that chart in ~ half.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #757

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
