### PR TITLE
catch error in authorize of UserStore

### DIFF
--- a/src/RootStore/__tests__/UserStore.test.ts
+++ b/src/RootStore/__tests__/UserStore.test.ts
@@ -92,6 +92,19 @@ test("authorize requires Auth0 client settings", async () => {
   expect.hasAssertions();
 });
 
+test("error thrown in authorize sets authError", async () => {
+  mockCreateAuth0Client.mockResolvedValue("INALID_AUTH_OBJECT");
+  const store = new UserStore({
+    authSettings: testAuthSettings,
+  });
+  await store.authorize();
+  reactImmediately(() => {
+    const error = store.authError;
+    expect(error?.message).toBeDefined();
+  });
+  expect.hasAssertions();
+});
+
 test("authorized when authenticated", async () => {
   mockIsAuthenticated.mockResolvedValue(true);
   mockGetUser.mockResolvedValue({ email_verified: true, ...metadata });


### PR DESCRIPTION
## Description of the change

We have been seeing some unhandled authorization errors popping up in Sentry. This adds a catch block to the `authorize` function in the `UserStore` so that we can handle the error, and surface the error in the `AuthWall` appropriately.

I had toyed with the idea of `Sentry.captureException` in the catch block off authorize, but didn't think that additional context information there would be helpful since we cannot send user information to Sentry. Without adding that to the catch block, the error is just sent to the `AuthWall` which yields the error to the `ErrorBoundary` which will be notifying Sentry. I'm definitely open to thoughts on whether we should notify Sentry and provide more context closer to the error!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #697

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
