### PR TITLE
Send consistent error responses with message and status code

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -87,6 +87,16 @@ function validateCronRequest(req, res, next) {
   }
 }
 
+function errorHandler(err, _req, res, next) {
+  if (err && err.message) {
+    res
+      .status(api.SERVER_ERROR)
+      .send({ status: api.SERVER_ERROR, errors: [err.message] });
+  } else {
+    next(err);
+  }
+}
+
 if (isDemoMode) {
   checkJwt = (req, res, next) => {
     next();
@@ -122,5 +132,7 @@ app.get("/_ah/warmup", () => {
   // eslint-disable-next-line no-console
   console.log("Responding to warmup request...");
 });
+
+app.use(errorHandler);
 
 module.exports = { app, port };

--- a/server/routes/__tests__/api.test.js
+++ b/server/routes/__tests__/api.test.js
@@ -322,5 +322,22 @@ describe("API GET tests", () => {
 
       expect(send).toHaveBeenCalledWith(data);
     });
+
+    it("should send the status and error message in the response body", () => {
+      const error = new Error("API error");
+      const callback = responder(res);
+      callback(error, null);
+      expect(send).toHaveBeenCalledWith({
+        status: 500,
+        errors: [error.message],
+      });
+    });
+
+    it("should send the validation errors in the response body", () => {
+      const error = { status: 400, errors: ["Validation errors"] };
+      const callback = responder(res);
+      callback(error, null);
+      expect(send).toHaveBeenCalledWith(error);
+    });
   });
 });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -219,4 +219,5 @@ module.exports = {
   programmingExplore,
   responder,
   refreshCache,
+  SERVER_ERROR,
 };

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -61,10 +61,13 @@ function responder(res) {
  */
 function processAndRespond(responderFn, processResultsFn) {
   return (err, data) => {
+    if (err) responderFn(err, null);
     if (data) {
-      responderFn(null, processResultsFn(data));
-    } else {
-      responderFn(err, null);
+      try {
+        responderFn(null, processResultsFn(data));
+      } catch (error) {
+        responderFn(error, null);
+      }
     }
   };
 }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -43,7 +43,11 @@ function responder(res) {
   return (err, data) => {
     if (err) {
       const status = err.status || err.code || SERVER_ERROR;
-      res.status(status).send(err);
+      const errors = err.message || err.errors;
+      res.status(status).send({
+        status,
+        errors: [].concat(errors),
+      });
     } else {
       res.send(data);
     }
@@ -73,7 +77,7 @@ function restrictedAccess(req, res) {
     responder(res)(
       {
         status: BAD_REQUEST,
-        errors: "request is missing userEmail parameter",
+        errors: validations.array(),
       },
       null
     );

--- a/server/routes/paramsValidation.js
+++ b/server/routes/paramsValidation.js
@@ -61,7 +61,9 @@ const newRevocationsParamValidations = [
   query("violationType").toLowerCase().optional().isIn(VIOLATION_TYPES),
 ];
 
-const restrictedAccessParamValidations = [body("userEmail").exists()];
+const restrictedAccessParamValidations = [
+  body("userEmail", "Request is missing userEmail parameter").exists(),
+];
 
 module.exports = {
   newRevocationsParamValidations,


### PR DESCRIPTION
## Description of the change

This PR updates the API `responder` to send the actual error message along with the API response. It also includes the status in the response body and adds an express middleware error handler so that errors from routes and the server match the same response format.

I tested this by throwing errors within `fetchMetricsFromGCS` from different levels and confirmed that we were seeing the error message in the API response:

- Errors thrown from `objectStorage` (downloading file & metadata from GCS)
- Errors thrown from the Promise `then` chain (parsing file contents & metadata)
- Errors thrown from the `fetchMetrics` then chain (`processMetricFile`)
- Errors thrown from the `fetchAndFilterNewRevocationFile` (creating subsets)
- Errors thrown from the `processResponseFn` in `api.js`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #590

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
