### PR TITLE
Rework and shrink the header bar on Lantern pages

### DIFF
--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -33,23 +33,23 @@ ul.explore-choices {
 .nav.nav-tabs > li.disabled { pointer-events: none; a { color: silver; } }
 
 #chartjs-tooltip {
-	opacity: 1;
-	position: absolute;
-	background: rgba(0, 0, 0, .7);
-	color: white;
-	border-radius: 3px;
-	-webkit-transition: all .1s ease;
-	transition: all .1s ease;
-	pointer-events: none;
-	-webkit-transform: translate(-50%, 0);
-	transform: translate(-50%, 0);
+  opacity: 1;
+  position: absolute;
+  background: rgba(0, 0, 0, .7);
+  color: white;
+  border-radius: 3px;
+  -webkit-transition: all .1s ease;
+  transition: all .1s ease;
+  pointer-events: none;
+  -webkit-transform: translate(-50%, 0);
+  transform: translate(-50%, 0);
 }
 
 .chartjs-tooltip-key {
-	display: inline-block;
-	width: 10px;
-	height: 10px;
-	margin-right: 10px;
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 10px;
 }
 
 .logo-icon-holder {
@@ -78,10 +78,6 @@ ul.explore-choices {
 
 .auth-hidden {
   display: none;
-}
-
-.header.wide-navbar {
-  width: 100%;
 }
 
 .wide-page-container {

--- a/src/assets/styles/spec/components/topbar.scss
+++ b/src/assets/styles/spec/components/topbar.scss
@@ -18,9 +18,19 @@
   margin-bottom: 0;
   padding: 0;
   position: fixed;
-  transition: all 0.2s ease;
+  transform: translateY(0);
+  transition: all 0.2s ease, transform 0.6s;
   width: calc(100% - #{$offscreen-size});
   z-index: 800;
+
+  &.hidden-navbar {
+    overflow: hidden;
+    transform: translateY(-100%);
+  }
+
+  &.wide-navbar {
+    width: 100%;
+  }
 
   @include to($breakpoint-md) {
     width: 100%;
@@ -136,8 +146,8 @@
       .dropdown {
         .dropdown-toggle {
           ul {
-            margin-left: 0px;
-            padding-left: 0px;
+            margin-left: 0;
+            padding-left: 0;
           }
         }
       }

--- a/src/assets/styles/spec/components/topbar.scss
+++ b/src/assets/styles/spec/components/topbar.scss
@@ -23,15 +23,6 @@
   width: calc(100% - #{$offscreen-size});
   z-index: 800;
 
-  &.hidden-navbar {
-    overflow: hidden;
-    transform: translateY(-100%);
-  }
-
-  &.wide-navbar {
-    width: 100%;
-  }
-
   @include to($breakpoint-md) {
     width: 100%;
   }
@@ -213,6 +204,18 @@
     }
   }
 }
+
+.TopBar {
+  &--hidden {
+    overflow: hidden;
+    transform: translateY(-100%);
+  }
+
+  &--wide {
+    width: 100%;
+  }
+}
+
 
 // ---------------------------------------------------------
 // @Collapsed State

--- a/src/components/Revocations.js
+++ b/src/components/Revocations.js
@@ -41,10 +41,12 @@ import {
 import { useRootStore } from "../StoreProvider";
 
 import "./Revocations.scss";
+import { usePageState } from "../contexts/PageContext";
 
 const Revocations = () => {
   const { filtersStore } = useRootStore();
   const { filters, filterOptions } = filtersStore;
+  const { hideTopBar } = usePageState();
 
   const timeDescription = getTimeDescription(
     get(filters, METRIC_PERIOD_MONTHS),
@@ -54,7 +56,10 @@ const Revocations = () => {
 
   return (
     <main className="Revocations">
-      <Sticky style={{ zIndex: 700, top: 65 }}>
+      <Sticky
+        className="FilterBar"
+        style={{ zIndex: 700, top: hideTopBar ? 0 : 65 }}
+      >
         <ErrorBoundary>
           <div className="top-level-filters d-f">
             <ToggleBarFilter

--- a/src/components/Revocations.scss
+++ b/src/components/Revocations.scss
@@ -3,6 +3,10 @@
   padding-bottom: 5px;
   background-color: #f9fafb;
 
+  .FilterBar {
+    transition: top 0.6s;
+  }
+
   &__matrix {
     background-color: #ffffff;
     padding: 20px;

--- a/src/components/__tests__/Revocations.test.js
+++ b/src/components/__tests__/Revocations.test.js
@@ -41,6 +41,7 @@ import {
   SUPERVISION_TYPE,
 } from "../../constants/filterTypes";
 import { useRootStore } from "../../StoreProvider";
+import { PageProvider } from "../../contexts/PageContext";
 
 jest.mock("../charts/new_revocations/ToggleBar/ToggleBarFilter");
 jest.mock("../charts/new_revocations/ToggleBar/DistrictFilter");
@@ -115,7 +116,11 @@ describe("Revocations component tests", () => {
   });
 
   it("should render Revocations component with proper filters and charts", () => {
-    const { getByTestId } = render(<Revocations />);
+    const { getByTestId } = render(
+      <PageProvider>
+        <Revocations />
+      </PageProvider>
+    );
 
     expect(getByTestId(`${toggleBarIdPrefix}Time Period`)).toBeInTheDocument();
     expect(getByTestId(`${toggleBarIdPrefix}Case Type`)).toBeInTheDocument();
@@ -141,7 +146,11 @@ describe("Revocations component tests", () => {
     filterOptionsMap[mockTenantId][CHARGE_CATEGORY].componentEnabled = false;
     filterOptionsMap[mockTenantId][ADMISSION_TYPE].componentEnabled = false;
     filterOptionsMap[mockTenantId][ADMISSION_TYPE].filterEnabled = false;
-    const { queryByTestId } = render(<Revocations />);
+    const { queryByTestId } = render(
+      <PageProvider>
+        <Revocations />
+      </PageProvider>
+    );
 
     expect(queryByTestId(`${toggleBarIdPrefix}Supervision Level`)).toBeNull();
     expect(queryByTestId(`${toggleBarIdPrefix}Supervision Type`)).toBeNull();

--- a/src/components/charts/new_revocations/Chip.js
+++ b/src/components/charts/new_revocations/Chip.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,17 +19,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import cn from "classnames";
 
-import { usePageState } from "../../../contexts/PageContext";
 import "./Chip.scss";
 
-const Chip = ({ label, onClick, onDelete, isSelected, isShrinkable }) => {
-  const { isTopBarShrinking } = usePageState();
-
+const Chip = ({ label, onClick, onDelete, isSelected, isSmall }) => {
   return (
     <div
       className={cn("Chip", {
         "Chip--selected": isSelected,
-        "Chip--shrinking": isTopBarShrinking && isShrinkable,
+        "Chip--small": isSmall,
       })}
     >
       <button type="button" className="Chip__label" onClick={onClick}>
@@ -52,7 +49,7 @@ Chip.defaultProps = {
   onClick: () => {},
   onDelete: null,
   isSelected: false,
-  isShrinkable: false,
+  isSmall: false,
 };
 
 Chip.propTypes = {
@@ -60,7 +57,7 @@ Chip.propTypes = {
   onClick: PropTypes.func,
   onDelete: PropTypes.func,
   isSelected: PropTypes.bool,
-  isShrinkable: PropTypes.bool,
+  isSmall: PropTypes.bool,
 };
 
 export default Chip;

--- a/src/components/charts/new_revocations/Chip.scss
+++ b/src/components/charts/new_revocations/Chip.scss
@@ -18,9 +18,9 @@
     background-color: $color1;
   }
 
-  &--shrinking {
+  &--small {
     height: 28px;
-    border-radius: 24px;
+    border-radius: 14px;
   }
 
   &__label {
@@ -42,13 +42,14 @@
       background-color: $color1;
     }
 
-    .Chip--shrinking & {
+    .Chip--small & {
       line-height: 18px;
+      font-size: 0.75rem;
+      font-weight: 600;
     }
   }
 
   &__delete-button {
-    margin-left: 4px;
     margin-top: 2px;
     border: none;
     background: transparent;
@@ -60,8 +61,9 @@
       color: $color2;
     }
 
-    .Chip--shrinking & {
+    .Chip--small & {
       margin-top: 0;
+      transform: scale(0.7);
     }
   }
 }

--- a/src/components/charts/new_revocations/ToggleBar/FilterField.js
+++ b/src/components/charts/new_revocations/ToggleBar/FilterField.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,24 +19,10 @@ import PropTypes from "prop-types";
 import cn from "classnames";
 import "./FilterField.scss";
 
-import { usePageState } from "../../../../contexts/PageContext";
-
 const FilterField = ({ label, children, className }) => {
-  const { isTopBarShrinking } = usePageState();
-
   return (
-    <div
-      className={cn("FilterField", `${className}`, {
-        "FilterField--shrink": isTopBarShrinking,
-      })}
-    >
-      <h4
-        className={cn("FilterField__label", {
-          "FilterField__label--shrink": isTopBarShrinking,
-        })}
-      >
-        {label}
-      </h4>
+    <div className={cn("FilterField", `${className}`)}>
+      <h4 className={cn("FilterField__label")}>{label}</h4>
       {children}
     </div>
   );

--- a/src/components/charts/new_revocations/ToggleBar/FilterField.scss
+++ b/src/components/charts/new_revocations/ToggleBar/FilterField.scss
@@ -1,7 +1,7 @@
 .FilterField {
   display: flex;
   flex-direction: column;
-  padding: 1.5rem 3rem;
+  padding: 0.8rem 2rem 1.1rem 2rem;
   flex-grow: 1;
   flex-basis: 100%;
   border-right: 1px solid rgba(0, 0, 0, 0.0625);
@@ -23,6 +23,8 @@
 
   &--additional {
     display: inline-block;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
 
     .FilterField__label {
       display: inline;
@@ -32,9 +34,12 @@
 
   &__label {
     @media (max-width: 768px) {
-      font-size: 0.9rem;
+      font-size: 0.6rem;
     }
 
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
     vertical-align: middle;
 
     &--shrink {

--- a/src/components/charts/new_revocations/ToggleBar/ViolationFilter.js
+++ b/src/components/charts/new_revocations/ToggleBar/ViolationFilter.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -70,7 +70,7 @@ const ViolationFilter = () => {
         <Chip
           label={formattedMatrixFilters}
           onDelete={clearViolationFilters}
-          isShrinkable
+          isSmall
         />
       </FilterField>
     </div>

--- a/src/components/layouts/LanternLayout.js
+++ b/src/components/layouts/LanternLayout.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ const LanternLayout = ({ children }) => {
         />
       </Helmet>
       <div className="wide-page-container">
-        <TopBar isWide>
+        <TopBar isHidable isWide>
           <TopBarLogo />
           <ul className="nav-right">
             <TopBarUserMenuForAuthenticatedUser />

--- a/src/components/layouts/__tests__/CoreLayout.test.js
+++ b/src/components/layouts/__tests__/CoreLayout.test.js
@@ -7,6 +7,7 @@ import TopBarUserMenuForAuthenticatedUser from "../../topbar/TopBarUserMenuForAu
 import useSideBar from "../../../hooks/useSideBar";
 
 import mockWithTestId from "../../../../__helpers__/mockWithTestId";
+import { PageProvider } from "../../../contexts/PageContext";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(),
@@ -32,14 +33,22 @@ describe("CoreLayout tests", () => {
     jest.clearAllMocks();
   });
 
+  const renderCoreLayout = () => {
+    return render(
+      <PageProvider>
+        <CoreLayout>{mockChildren}</CoreLayout>
+      </PageProvider>
+    );
+  };
+
   it("should render children", () => {
-    const { getByTestId } = render(<CoreLayout>{mockChildren}</CoreLayout>);
+    const { getByTestId } = renderCoreLayout();
 
     expect(getByTestId(mockChildrenId)).toBeInTheDocument();
   });
 
   it("should call useSideBar hook and collapse layout", () => {
-    const { container } = render(<CoreLayout>{mockChildren}</CoreLayout>);
+    const { container } = renderCoreLayout();
 
     expect(useSideBar).toHaveBeenCalled();
     expect(container.firstChild.className).toContain("is-collapsed");
@@ -50,7 +59,7 @@ describe("CoreLayout tests", () => {
       isSideBarCollapsed: false,
       toggleSideBar: jest.fn(),
     });
-    const { container } = render(<CoreLayout>{mockChildren}</CoreLayout>);
+    const { container } = renderCoreLayout();
 
     expect(useSideBar).toHaveBeenCalled();
     expect(container.firstChild.className).not.toContain("is-collapsed");
@@ -58,13 +67,13 @@ describe("CoreLayout tests", () => {
 
   it("should hide the SideBar on the profile page", () => {
     matchPath.mockReturnValueOnce(true);
-    const { container } = render(<CoreLayout>{mockChildren}</CoreLayout>);
+    const { container } = renderCoreLayout();
 
     expect(container.firstChild.className).toContain("is-hidden");
   });
 
   it("should show right pathname in TopBarTitle", () => {
-    const { getByText } = render(<CoreLayout>{mockChildren}</CoreLayout>);
+    const { getByText } = renderCoreLayout();
 
     expect(getByText("Some > Nested > Pathname")).toBeInTheDocument();
   });

--- a/src/components/layouts/__tests__/LanternLayout.test.js
+++ b/src/components/layouts/__tests__/LanternLayout.test.js
@@ -7,6 +7,7 @@ import TopBarUserMenuForAuthenticatedUser from "../../topbar/TopBarUserMenuForAu
 import mockWithTestId from "../../../../__helpers__/mockWithTestId";
 import StoreProvider, { useRootStore } from "../../../StoreProvider";
 import { US_MO } from "../../../views/tenants/utils/lanternTenants";
+import { PageProvider } from "../../../contexts/PageContext";
 
 jest.mock("react-router-dom");
 jest.mock("../../../hooks/useIntercom");
@@ -26,9 +27,11 @@ describe("LanternLayout tests", () => {
       currentTenantId: US_MO,
     });
     result = render(
-      <StoreProvider>
-        <LanternLayout>{mockChildren}</LanternLayout>
-      </StoreProvider>
+      <PageProvider>
+        <StoreProvider>
+          <LanternLayout>{mockChildren}</LanternLayout>
+        </StoreProvider>
+      </PageProvider>
     );
   });
 

--- a/src/components/topbar/TopBar.js
+++ b/src/components/topbar/TopBar.js
@@ -19,22 +19,31 @@ import React from "react";
 import PropTypes from "prop-types";
 import cn from "classnames";
 
-const TopBar = ({ children, isWide = false }) => (
-  <div
-    className={cn("TopBar", "header", "navbar", {
-      "wide-navbar": isWide,
-    })}
-  >
-    <div className="TopBar__container header-container">{children}</div>
-  </div>
-);
+import { usePageState } from "../../contexts/PageContext";
+
+const TopBar = ({ children, isHidable = false, isWide = false }) => {
+  const { hideTopBar } = usePageState();
+
+  return (
+    <div
+      className={cn("TopBar", "header", "navbar", {
+        "wide-navbar": isWide,
+        "hidden-navbar": hideTopBar && isHidable,
+      })}
+    >
+      <div className="TopBar__container header-container">{children}</div>
+    </div>
+  );
+};
 
 TopBar.defaultProps = {
+  isHidable: false,
   isWide: false,
 };
 
 TopBar.propTypes = {
   children: PropTypes.node.isRequired,
+  isHidable: PropTypes.bool,
   isWide: PropTypes.bool,
 };
 

--- a/src/components/topbar/TopBar.js
+++ b/src/components/topbar/TopBar.js
@@ -27,8 +27,8 @@ const TopBar = ({ children, isHidable = false, isWide = false }) => {
   return (
     <div
       className={cn("TopBar", "header", "navbar", {
-        "wide-navbar": isWide,
-        "hidden-navbar": hideTopBar && isHidable,
+        "TopBar--wide": isWide,
+        "TopBar--hidden": hideTopBar && isHidable,
       })}
     >
       <div className="TopBar__container header-container">{children}</div>

--- a/src/hooks/usePageLayout.js
+++ b/src/hooks/usePageLayout.js
@@ -52,7 +52,7 @@ const usePageLayout = () => {
           });
         } else if (
           hideTopBar &&
-          (scrollUpCount > 3 || window.pageYOffset < 25)
+          (scrollUpCount > 2 || window.pageYOffset < 60)
         ) {
           pageDispatch({
             type: "update",

--- a/src/hooks/usePageLayout.js
+++ b/src/hooks/usePageLayout.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,30 +15,51 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { usePageState, usePageDispatch } from "../contexts/PageContext";
 
 const usePageLayout = () => {
   const pageDispatch = usePageDispatch();
-  const { isTopBarShrinking } = usePageState();
+  const { hideTopBar } = usePageState();
   const frame = useRef(0);
+  const [lastOffset, setLastOffset] = useState(window.pageYOffset);
+  const [scrollUpCount, setScrollUpCount] = useState(0);
+
+  if (hideTopBar === undefined) {
+    pageDispatch({
+      type: "update",
+      payload: { hideTopBar: false },
+    });
+  }
 
   useLayoutEffect(() => {
     const handler = () => {
       cancelAnimationFrame(frame.current);
       frame.current = requestAnimationFrame(() => {
-        if (!isTopBarShrinking && window.pageYOffset > 90) {
-          pageDispatch({
-            type: "update",
-            payload: { isTopBarShrinking: true },
-          });
-        } else if (isTopBarShrinking && window.pageYOffset < 5) {
-          pageDispatch({
-            type: "update",
-            payload: { isTopBarShrinking: false },
-          });
-          window.scrollTo({ top: 0, behavior: "smooth" });
+        if (window.pageYOffset < lastOffset) {
+          setScrollUpCount(scrollUpCount + 1);
+        } else if (window.pageYOffset > lastOffset) {
+          setScrollUpCount(0);
         }
+        if (
+          !hideTopBar &&
+          window.pageYOffset > 90 &&
+          window.pageYOffset > lastOffset
+        ) {
+          pageDispatch({
+            type: "update",
+            payload: { hideTopBar: true },
+          });
+        } else if (
+          hideTopBar &&
+          (scrollUpCount > 3 || window.pageYOffset < 25)
+        ) {
+          pageDispatch({
+            type: "update",
+            payload: { hideTopBar: false },
+          });
+        }
+        setLastOffset(window.pageYOffset);
       });
     };
 


### PR DESCRIPTION
## Description of the change

- Collapses the Lantern header bar when scrolling down. 
- Returns the bar when scrolling back up.
- Slims down the filter bar.
- Fixes a bug where the filter chip would slightly change size while scrolling.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #628

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
