### PR TITLE
Add legend to Violations chart

### DIFF
--- a/src/components/charts/new_revocations/BarChartWithLabels/BarChartWithLabels.js
+++ b/src/components/charts/new_revocations/BarChartWithLabels/BarChartWithLabels.js
@@ -25,6 +25,18 @@ import { tooltipForRateMetricWithCounts } from "../../../../utils/charts/toggles
 import { generateLabelsWithCustomColors } from "./helpers";
 import { COLORS } from "../../../../assets/scripts/constants/colors";
 
+const getDefaultLegendOptions = (labelColors) => {
+  return labelColors.length
+    ? {
+        position: "bottom",
+        labels: {
+          generateLabels: (ch) =>
+            generateLabelsWithCustomColors(ch, labelColors),
+        },
+      }
+    : { display: false };
+};
+
 const BarChartWithLabels = ({
   id,
   data,
@@ -33,20 +45,13 @@ const BarChartWithLabels = ({
   yAxisLabel,
   numerators,
   denominators,
+  legendOptions,
 }) => (
   <Bar
     id={id}
     data={data}
     options={{
-      legend: labelColors.length
-        ? {
-            position: "bottom",
-            labels: {
-              generateLabels: (ch) =>
-                generateLabelsWithCustomColors(ch, labelColors),
-            },
-          }
-        : { display: false },
+      legend: legendOptions || getDefaultLegendOptions(labelColors),
       responsive: true,
       maintainAspectRatio: false,
       scales: {
@@ -94,6 +99,7 @@ const BarChartWithLabels = ({
 
 BarChartWithLabels.defaultProps = {
   labelColors: [],
+  legendOptions: null,
 };
 
 BarChartWithLabels.propTypes = {
@@ -121,5 +127,16 @@ BarChartWithLabels.propTypes = {
     PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number])
   ).isRequired,
   labelColors: PropTypes.arrayOf(PropTypes.string),
+  legendOptions: PropTypes.shape({
+    position: PropTypes.string,
+    align: PropTypes.string,
+    rtl: PropTypes.bool,
+    reverse: PropTypes.bool,
+    labels: PropTypes.shape({
+      usePointStyle: PropTypes.bool,
+      boxWidth: PropTypes.number,
+      generateLabels: PropTypes.func,
+    }),
+  }),
 };
 export default BarChartWithLabels;

--- a/src/components/charts/new_revocations/RevocationsByViolation/RevocationsByViolation.js
+++ b/src/components/charts/new_revocations/RevocationsByViolation/RevocationsByViolation.js
@@ -25,12 +25,35 @@ import BarChartWithLabels from "../BarChartWithLabels";
 import { translate } from "../../../../views/tenants/utils/i18nSettings";
 import { useRootStore } from "../../../../StoreProvider";
 import { VIOLATION_TYPE } from "../../../../constants/filterTypes";
+import { COLORS } from "../../../../assets/scripts/constants/colors";
 
 const RevocationsByViolation = observer(
   ({ containerHeight, timeDescription }, ref) => {
     const { filtersStore, dataStore } = useRootStore();
     const { revocationsChartStore } = dataStore;
     const violationTypes = filtersStore.filterOptions[VIOLATION_TYPE].options;
+    const violationLegend = {
+      position: "top",
+      align: "start",
+      rtl: true,
+      reverse: true,
+      labels: {
+        usePointStyle: true,
+        boxWidth: 8,
+        generateLabels: () => [
+          {
+            text: "Technical",
+            fillStyle: COLORS["lantern-medium-blue"],
+            lineWidth: 0,
+          },
+          {
+            text: "Law",
+            fillStyle: COLORS["lantern-orange"],
+            lineWidth: 0,
+          },
+        ],
+      },
+    };
 
     return (
       <RevocationsByDimension
@@ -46,6 +69,7 @@ const RevocationsByViolation = observer(
             id={chartId}
             yAxisLabel="Percent of total reported violations"
             xAxisLabel="Violation type and condition violated"
+            legendOptions={violationLegend}
           />
         )}
         generateChartData={createGenerateChartData(


### PR DESCRIPTION
## Description of the change

Add a legend to the RevocationsByViolation chart. Adds an optional prop `legendOptions` to `BarChartWithLabels` so that I can pass a legend object from the Violations chart to the `BarChartWithLabels` component. This will allow for multiple labels given a single dataset for Violations and to preserve existing legend functionality in the `BarChartWithLabels` compoennts Follows the styling in the new MO dashboard designs [here](https://www.figma.com/file/UTbkeYLUl6hD9EbLHEGJQk/MO-dashboard?node-id=40%3A684),

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #638 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
