### PR TITLE
Use matrix cells to set districts to prevent resetting filters on filter change

### DIFF
--- a/src/RootStore/DataStore/BaseDataStore.js
+++ b/src/RootStore/DataStore/BaseDataStore.js
@@ -215,7 +215,7 @@ export default class BaseDataStore {
         this.file,
         this.eagerExpand
       );
-      // TODO: Remove this when supervision locations are filtered on the backend
+      // TODO #798: Remove this when supervision locations are filtered on the backend
       if (this.file === "revocations_matrix_cells") {
         this.districtsData = parseResponseByFileFormat(
           responseData,

--- a/src/RootStore/DataStore/BaseDataStore.js
+++ b/src/RootStore/DataStore/BaseDataStore.js
@@ -216,7 +216,7 @@ export default class BaseDataStore {
         this.eagerExpand
       );
       // TODO: Remove this when supervision locations are filtered on the backend
-      if (this.file === "revocations_matrix_by_month") {
+      if (this.file === "revocations_matrix_cells") {
         this.districtsData = parseResponseByFileFormat(
           responseData,
           this.file,

--- a/src/RootStore/FiltersStore.js
+++ b/src/RootStore/FiltersStore.js
@@ -122,7 +122,7 @@ export default class FiltersStore {
   }
 
   get districts() {
-    // TODO: Use apiData.data from districts store when supervision locations are
+    // TODO #798: Use apiData.data from districts store when supervision locations are
     // filtered on the backend
     const { filteredDistricts } = this.rootStore.districtsStore;
     if (!filteredDistricts) return [];


### PR DESCRIPTION
## Description of the change

There was a bug with the violation type filters where when we selected a new subset, the filter values would reset to the default values. This is because we were using `revocations_matrix_by_month` to set the districts and that file was being re-requested on those filter changes. This PR changes that to use `revocations_matrix_cells` which should never be re-fetched until a tenant changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #811

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
