### PR TITLE
use vertical line delimiter instead of comma in unflattenValues

### DIFF
--- a/shared-filters/__tests__/optimizedFormatHelpers.test.js
+++ b/shared-filters/__tests__/optimizedFormatHelpers.test.js
@@ -18,7 +18,7 @@
 const helpers = require("../optimizedFormatHelpers");
 
 const FLATTENED_VALUES =
-  "0,0,1,1,2,0,0,1,1,2,2,0,0,0,0,0,1,1,1,1,1,1,0,1,0,1,0,0,1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,100,68,73,41,10,30,36,51,38,15,4";
+  "0|0|1|1|2|0|0|1|1|2|2|0|0|0|0|0|1|1|1|1|1|1|0|1|0|1|0|0|1|0|1|0|1|0|0|0|0|0|0|0|0|0|0|0|100|68|73|41|10|30|36|51|38|15|4";
 
 const METADATA = {
   total_data_points: "11",
@@ -53,7 +53,7 @@ describe("Test getDimensionValue", () => {
 
 describe("Test unflattenValues", () => {
   it("unflattens a flat array into a proper number and size of arrays", () => {
-    const contents = FLATTENED_VALUES.split(",");
+    const contents = FLATTENED_VALUES.split("|");
     const unflattened = helpers.unflattenValues(contents, 11);
     expect(unflattened).toEqual([
       ["0", "0", "1", "1", "2", "0", "0", "1", "1", "2", "2"],

--- a/shared-filters/optimizedFormatHelpers.js
+++ b/shared-filters/optimizedFormatHelpers.js
@@ -61,7 +61,7 @@ const getValueKey = (valueKeys, valueIndex) => {
  * Converts the given optimized array as a singular string into an array of values.
  */
 const stringToArray = (contentsAsString) => {
-  return contentsAsString.split(",");
+  return contentsAsString.split("|");
 };
 
 /**


### PR DESCRIPTION
## Description of the change

Use vertical line delimiter instead of comma in unflattenValues since we have an officer name with a comma in it which was causing errors in the file parsing.

This is a breaking change, must be deployed in coordination with recidiviz-data [#6117](https://github.com/Recidiviz/recidiviz-data/pull/6117)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #836

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
