### PR TITLE
Fix export image for RevocationsOverTime chart

### DIFF
--- a/src/components/charts/new_revocations/RevocationsOverTime.js
+++ b/src/components/charts/new_revocations/RevocationsOverTime.js
@@ -47,7 +47,7 @@ import RevocationsByDimensionComponent from "./RevocationsByDimension/Revocation
 const RevocationsOverTime = ({ timeDescription }) => {
   const { filters, dataStore } = useRootStore();
   const store = dataStore.revocationsOverTimeStore;
-  const chartId = `${translate("revocations")}OverTime`;
+  const chartId = `admissionsOverTime`;
   const { containerHeight, containerRef } = useContainerHeight();
 
   if (store.isLoading) {
@@ -180,7 +180,7 @@ const RevocationsOverTime = ({ timeDescription }) => {
         chartTitle={translate("revocationsOverTimeXAxis")}
         timeDescription={timeDescription}
         labels={chartLabels}
-        chartId="admissionsOverTime"
+        chartId={chartId}
         datasets={datasets}
         metricTitle={translate("revocationsOverTimeXAxis")}
         chart={chart}


### PR DESCRIPTION
## Description of the change

We were sending the wrong chart ID when querying the DOM for the canvas when exporting the image. This PR updates the chart ID so that we can export the image correctly. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #835 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
