### PR TITLE
Add a fetchWithRetry for restricted district

### DIFF
--- a/src/api/metrics/__tests__/metricsClient.test.js
+++ b/src/api/metrics/__tests__/metricsClient.test.js
@@ -127,7 +127,9 @@ describe("metricsClient", () => {
       process.env = Object.assign(process.env, {
         REACT_APP_API_URL: "test-url",
       });
-      global.fetch.mockResolvedValueOnce({
+
+      global.fetch.mockClear();
+      global.fetch.mockResolvedValue({
         ok: false,
         status: 400,
         statusText: "Bad Request",
@@ -135,6 +137,20 @@ describe("metricsClient", () => {
           .fn()
           .mockResolvedValue({ status: 400, errors: ["API error"] }),
       });
+    });
+
+    it("retries 2 more times before throwing an error", async () => {
+      expect.assertions(2);
+      try {
+        await callRestrictedAccessApi(endpoint, userEmail, getTokenSilently);
+      } catch (error) {
+        expect(global.fetch.mock.calls.length).toEqual(3);
+        expect(error).toEqual(
+          new Error(
+            `Fetching data from API failed.\nStatus: 400 - Bad Request\nErrors: ["API error"]`
+          )
+        );
+      }
     });
 
     it("throws an error", async () => {


### PR DESCRIPTION
## Description of the change

Adds a `fetchWithRetry` function to use for the restricted district API. This fixes an error we were seeing where the API would sometimes fail to fetch and then the resulting auth error would lock a user out of the dashboard. This will try to fetch 3 times before throwing an error. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #834

[Sentry Issue](https://sentry.io/organizations/recidiviz-inc/issues/2238192173/?project=5385222&referrer=github_integration
)
## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
