### PR TITLE
remove sumCountsAcrossRiskLevels from race and gender charts

### DIFF
--- a/src/components/charts/new_revocations/RevocationsByGender/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByGender/createGenerateChartData.js
@@ -27,9 +27,7 @@ import {
   genderValueToLabel,
 } from "../../../../utils/transforms/labels";
 import getCounts from "../utils/getCounts";
-import createPopulationMap, {
-  sumCountsAcrossRiskLevels,
-} from "../utils/createPopulationMap";
+import createPopulationMap from "../utils/createPopulationMap";
 
 export const generateDatasets = (dataPoints, denominators) => {
   return Object.values(genderValueToLabel).map((genderLabel, index) => ({
@@ -47,7 +45,6 @@ const createGenerateChartData = ({ filteredData, statePopulationData }) => (
 ) => {
   const genders = Object.keys(genderValueToLabel);
   const { dataPoints, numerators, denominators } = pipe(
-    reduce(sumCountsAcrossRiskLevels("gender"), []),
     reduce(createPopulationMap("gender"), {}),
     (data) =>
       getCounts(

--- a/src/components/charts/new_revocations/RevocationsByRace/createGenerateChartData.js
+++ b/src/components/charts/new_revocations/RevocationsByRace/createGenerateChartData.js
@@ -23,9 +23,7 @@ import {
   getStatePopulationsLabels,
 } from "../../../../utils/transforms/labels";
 import getCounts from "../utils/getCounts";
-import createPopulationMap, {
-  sumCountsAcrossRiskLevels,
-} from "../utils/createPopulationMap";
+import createPopulationMap from "../utils/createPopulationMap";
 import { translate } from "../../../../utils/i18nSettings";
 import { COLORS_LANTERN_SET } from "../../../../assets/scripts/constants/colors";
 import { applyStatisticallySignificantShadingToDataset } from "../../../../utils/charts/significantStatistics";
@@ -49,7 +47,6 @@ const createGenerateChartData = ({ filteredData, statePopulationData }) => (
   const raceLabelMap = translate("raceLabelMap");
   const races = Object.keys(raceLabelMap);
   const { dataPoints, numerators, denominators } = pipe(
-    reduce(sumCountsAcrossRiskLevels("race"), []),
     reduce(createPopulationMap("race"), {}),
     (data) =>
       getCounts(

--- a/src/components/charts/new_revocations/utils/__tests__/createPopulationMap.test.js
+++ b/src/components/charts/new_revocations/utils/__tests__/createPopulationMap.test.js
@@ -17,7 +17,7 @@
 // =============================================================================
 import reduce from "lodash/fp/reduce";
 
-import createPopulationMap, { sumCountsAcrossRiskLevels } from "../createPopulationMap";
+import createPopulationMap from "../createPopulationMap";
 
 describe("#createPopulationMap", () => {
   const revocationData = [
@@ -67,127 +67,6 @@ describe("#createPopulationMap", () => {
       }
     }
     const map = reduce(createPopulationMap("gender"), {})
-    expect(map(revocationData)).toEqual(expected);
-  });
-});
-
-
-describe("#sumCountsAcrossRiskLevels", () => {
-  const revocationData = [
-    {
-      revocation_count: 1,
-      supervision_population_count: 1,
-      gender: "MALE",
-      revocation_count_all: 10,
-      supervision_count_all: 100,
-      district: "01",
-      risk_level: "HIGH",
-    },
-    {
-      revocation_count: 2,
-      supervision_population_count: 2,
-      gender: "MALE",
-      revocation_count_all: 20,
-      supervision_count_all: 200,
-      district: "02",
-      risk_level: "HIGH",
-    },
-    {
-      revocation_count: 1,
-      supervision_population_count: 1,
-      gender: "MALE",
-      revocation_count_all: 10,
-      supervision_count_all: 100,
-      district: "01",
-      risk_level: "MEDIUM",
-    },
-    {
-      revocation_count: 2,
-      supervision_population_count: 2,
-      gender: "MALE",
-      revocation_count_all: 20,
-      supervision_count_all: 200,
-      district: "02",
-      risk_level: "MEDIUM",
-    },
-    {
-      revocation_count: 3,
-      supervision_population_count: 3,
-      gender: "FEMALE",
-      revocation_count_all: 30,
-      supervision_count_all: 300,
-      district: "01",
-      risk_level: "HIGH",
-    },
-    {
-      revocation_count: 4,
-      supervision_population_count: 4,
-      gender: "FEMALE",
-      revocation_count_all: 40,
-      supervision_count_all: 400,
-      district: "02",
-      risk_level: "HIGH",
-    },
-    {
-      revocation_count: 3,
-      supervision_population_count: 3,
-      gender: "FEMALE",
-      revocation_count_all: 30,
-      supervision_count_all: 300,
-      district: "01",
-      risk_level: "MEDIUM",
-    },
-    {
-      revocation_count: 4,
-      supervision_population_count: 4,
-      gender: "FEMALE",
-      revocation_count_all: 40,
-      supervision_count_all: 400,
-      district: "02",
-      risk_level: "MEDIUM",
-    },
-  ];
-
-  it("sums across risk levels", () => {
-    const expected = [
-      {
-        "district": "01",
-        "gender": "MALE",
-        "revocation_count": 2,
-        "revocation_count_all": 10,
-        "risk_level": "HIGH",
-        "supervision_count_all": 100,
-        "supervision_population_count": 2
-      },
-      {
-        "district": "02",
-        "gender": "MALE",
-        "revocation_count": 4,
-        "revocation_count_all": 20,
-        "risk_level": "HIGH",
-        "supervision_count_all": 200,
-        "supervision_population_count": 4
-      },
-      {
-        "district": "01",
-        "gender": "FEMALE",
-        "revocation_count": 6,
-        "revocation_count_all": 30,
-        "risk_level": "HIGH",
-        "supervision_count_all": 300,
-        "supervision_population_count": 6,
-      },
-      {
-        "district": "02",
-        "gender": "FEMALE",
-        "revocation_count": 8,
-        "revocation_count_all": 40,
-        "risk_level": "HIGH",
-        "supervision_count_all": 400,
-        "supervision_population_count": 8,
-     }
-    ]
-    const map = reduce(sumCountsAcrossRiskLevels("gender"), [])
     expect(map(revocationData)).toEqual(expected);
   });
 });

--- a/src/components/charts/new_revocations/utils/createPopulationMap.js
+++ b/src/components/charts/new_revocations/utils/createPopulationMap.js
@@ -23,26 +23,6 @@ import toInteger from "lodash/fp/toInteger";
 const NUMERATOR_KEYS = ["revocation_count", "supervision_population_count"];
 const DENOMINATOR_KEYS = ["revocation_count_all", "supervision_count_all"];
 
-// TODO # 784 once the risk_level dimension has been removed from race and gender
-// metric files, we can remove this sum function
-export const sumCountsAcrossRiskLevels = (field) => (acc, data) => {
-  if (acc.length === 0) acc.push({ ...data });
-  else {
-    const match = acc.find((dataPoint) => {
-      return (
-        dataPoint[field] === data[field] && dataPoint.district === data.district
-      );
-    });
-    if (match) {
-      NUMERATOR_KEYS.forEach((numeratorKey) => {
-        match[numeratorKey] =
-          parseInt(match[numeratorKey]) + parseInt(data[numeratorKey]);
-      });
-    } else acc.push({ ...data });
-  }
-  return acc;
-};
-
 /**
  * Transform to
  *   ASIAN: { REVOKED: [1, 4], SUPERVISION_POPULATION: [5, 9], ... } }


### PR DESCRIPTION
## Description of the change

Once the `risk_level` dimension was removed from the race and gender data, it caused a bug summing the numerators in those charts. This fixes that and cleans up a now unused function.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #784 and #859

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
