### PR TITLE
Retry all metrics fetches before throwing error

### DIFF
--- a/src/api/metrics/metricsClient.js
+++ b/src/api/metrics/metricsClient.js
@@ -40,15 +40,16 @@ async function validateResponse(response) {
 async function callMetricsApi(endpoint, getTokenSilently) {
   const token = await getTokenSilently();
 
-  const response = await fetch(
+  const retryTimes = 3;
+  const responseJson = await fetchWithRetry(
     `${process.env.REACT_APP_API_URL}/api/${endpoint}`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
       },
-    }
+    },
+    retryTimes
   );
-  const responseJson = await validateResponse(response);
 
   return responseJson;
 }


### PR DESCRIPTION
## Description of the change

We have been seeing quite a few fetch errors in Sentry. This PR enables two retries on ALL metrics fetches before failing and throwing an error..

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #876

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
