### PR TITLE
Only apply restricted district treatment for RESTRICTED_DISTRICT_TENANTS

### DIFF
--- a/src/RootStore/TenantStore/TenantStore.js
+++ b/src/RootStore/TenantStore/TenantStore.js
@@ -18,7 +18,7 @@
 import { computed, makeAutoObservable, when } from "mobx";
 
 import { getAvailableStateCodes, doesUserHaveAccess } from "../utils/user";
-import { LANTERN_TENANTS } from "./lanternTenants";
+import { LANTERN_TENANTS, RESTRICTED_DISTRICT_TENANTS } from "./lanternTenants";
 import getTenantMappings from "./tenants";
 import methodology from "./methodology";
 
@@ -66,6 +66,10 @@ export default class TenantStore {
 
   get isLanternTenant() {
     return LANTERN_TENANTS.includes(this.currentTenantId);
+  }
+
+  get isRestrictedDistrictTenant() {
+    return RESTRICTED_DISTRICT_TENANTS.includes(this.currentTenantId);
   }
 
   get tenantMappings() {

--- a/src/RootStore/TenantStore/lanternTenants.js
+++ b/src/RootStore/TenantStore/lanternTenants.js
@@ -24,6 +24,8 @@ export const US_PA = "US_PA";
 
 export const LANTERN_TENANTS = [US_MO, US_PA];
 
+export const RESTRICTED_DISTRICT_TENANTS = [US_MO];
+
 export const TRANSLATIONS = {
   US_MO: US_MO_TRANSLATIONS,
   US_PA: US_PA_TRANSLATIONS,

--- a/src/RootStore/UserStore.ts
+++ b/src/RootStore/UserStore.ts
@@ -194,7 +194,7 @@ export default class UserStore {
     this: UserStore,
     tenantId: string
   ) {
-    if (!this.rootStore?.tenantStore.isLanternTenant) {
+    if (!this.rootStore?.tenantStore.isRestrictedDistrictTenant) {
       this.restrictedDistrictIsLoading = false;
       return;
     }

--- a/src/RootStore/__tests__/UserStore.test.ts
+++ b/src/RootStore/__tests__/UserStore.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
       currentTenantId: tenantId,
       tenantStore: {
         isLanternTenant: true,
+        isRestrictedDistrictTenant: true,
       },
       districtsStore: {
         isLoading: false,
@@ -434,11 +435,11 @@ describe("fetchRestrictedDistrictData", () => {
     });
   });
 
-  describe("when the tenant is not a Lantern tenant", () => {
+  describe("when the tenant is not in RESTRICTED_DISTRICT_TENANTS", () => {
     beforeEach(async () => {
       mockRootStore.mockImplementationOnce(() => {
         return {
-          currentTenantId: "US_ND",
+          currentTenantId: "US_PA",
           tenantStore: {
             isLanternTenant: false,
           },


### PR DESCRIPTION
## Description of the change

Only apply restricted district treatment for tenants in `RESTRICTED_DISTRICT_TENANTS` (US_MO). We have been seeing quite a few "Unauthorized" errors. This will ensure that the PA dashboard has a smooth login process.

The issue prompts for an investigation into why we are seeing so many "Unauthorized" errors. I did some investigation and it seems like often, before the `fetchRestrictedDistrictData` error there was an error with `fetchDistricts`. Restricted district validation depends on the districts list. #880 adds functionality to retry all fetches, including fetching districts so this should reduce the number of restricted district fetch errors considerably.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #879

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
