### PR TITLE
throw more descriptive error if data response payload for file is empty

### DIFF
--- a/src/api/metrics/__tests__/fileParser.test.js
+++ b/src/api/metrics/__tests__/fileParser.test.js
@@ -170,6 +170,13 @@ describe("Test fileParser.parseResponseByFileFormat", () => {
     );
     expect(parsedResponse).toEqual(response.my_metric_file);
   });
+
+  it("throws an error if the response payload for given file is empty", () => {
+    const response = {};
+    expect(() => {
+      methods.parseResponseByFileFormat(response, "my_metric_file");
+    }).toThrow("Response payload for file my_metric_file is empty");
+  });
 });
 
 describe("Test fileParser.parseResponsesByFileFormat", () => {

--- a/src/api/metrics/fileParser.js
+++ b/src/api/metrics/fileParser.js
@@ -34,6 +34,9 @@ export function unflattenValues(metricFile) {
 const parseResponseByFileFormat = (responseData, file, eagerExpand = true) => {
   const metricFile = responseData[file];
 
+  if (!metricFile)
+    throw new Error(`Response payload for file ${file} is empty`);
+
   // If it's in the expanded json format that is ready to go, return that.
   // The metricFile format should be { data, metadata } for all dashboards except US_ND
   if (Array.isArray(metricFile.data)) {


### PR DESCRIPTION
## Description of the change

We have been seeing some errors in Sentry where the fetch is successful, but the response contains an empty object. I think that this probably has to do with a corrupt cache. We have implemented but not deployed better API error reporting that should help us stay on top of cache refresh issues.

This PR just throws a more descriptive error with the metric name so that we can keep better track of which metrics have cache errors to try to see if there is a pattern.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #841

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
