### PR TITLE
Update Tooltips

### DIFF
--- a/src/lantern/BarCharts/HorizontalBarChartWithLabels.js
+++ b/src/lantern/BarCharts/HorizontalBarChartWithLabels.js
@@ -21,6 +21,7 @@ import { HorizontalBar } from "react-chartjs-2";
 import "chartjs-plugin-datalabels";
 
 import { tooltipForRateMetricWithCounts } from "../utils/tooltips";
+import { tooltipForFooterWithCounts } from "../utils/significantStatistics";
 import { COLORS } from "../../assets/scripts/constants/colors";
 
 const HorizontalBarChartWithLabels = ({
@@ -28,6 +29,7 @@ const HorizontalBarChartWithLabels = ({
   data,
   numerators,
   denominators,
+  includeWarning,
 }) => {
   return (
     <HorizontalBar
@@ -95,9 +97,13 @@ const HorizontalBarChartWithLabels = ({
                 tooltipItem,
                 tooltipData,
                 numerators,
-                denominators
+                denominators,
+                includeWarning
               );
             },
+            footer: (tooltipItem) =>
+              includeWarning &&
+              tooltipForFooterWithCounts(tooltipItem, denominators),
           },
         },
       }}
@@ -127,6 +133,11 @@ HorizontalBarChartWithLabels.propTypes = {
   denominators: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number])
   ).isRequired,
+  includeWarning: PropTypes.bool,
+};
+
+HorizontalBarChartWithLabels.defaultProps = {
+  includeWarning: true,
 };
 
 export default React.memo(HorizontalBarChartWithLabels);

--- a/src/lantern/ExportMenu.js
+++ b/src/lantern/ExportMenu.js
@@ -164,15 +164,6 @@ const ExportMenu = ({
             )}
           </Modal.Body>
         </div>
-        <Modal.Footer>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={hideModal}
-          >
-            Close
-          </button>
-        </Modal.Footer>
       </Modal>
     </span>
   );

--- a/src/lantern/utils/tooltips.js
+++ b/src/lantern/utils/tooltips.js
@@ -16,6 +16,7 @@
 // =============================================================================
 import { isDenominatorStatisticallySignificant } from "./significantStatistics";
 import { getTooltipWithoutTrendline } from "../../utils/trendline";
+import { formatLargeNumber } from "../../utils/labels";
 
 export function tooltipForRateMetricWithCounts(
   id,
@@ -36,7 +37,9 @@ export function tooltipForRateMetricWithCounts(
     : denominators[dataPointIndex];
   let appendedCounts = "";
   if (numerator !== undefined && denominator !== undefined) {
-    appendedCounts = ` (${numerator}/${denominator})`;
+    appendedCounts = ` (${formatLargeNumber(numerator)}/${formatLargeNumber(
+      denominator
+    )})`;
   }
 
   const cue =

--- a/src/utils/__tests__/labels.test.js
+++ b/src/utils/__tests__/labels.test.js
@@ -173,6 +173,7 @@ describe("test label", () => {
         expect(period36Month).toBe("Last 3 years");
       });
     });
+
     it("correctly formats the officer label", () => {
       const officerLabel = "01 - BARNEY RUBBLE";
       const result = labelsMethods.formatOfficerLabel(officerLabel);
@@ -183,6 +184,26 @@ describe("test label", () => {
       const officerLabel = undefined;
       const result = labelsMethods.formatOfficerLabel(officerLabel);
       expect(result).toEqual("");
+    });
+
+    describe("#formatLargeNumber", () => {
+      it("formats a number in the millions correctly", () => {
+        const number = 2540001;
+        const result = labelsMethods.formatLargeNumber(number);
+        expect(result).toEqual("2.5M");
+      });
+
+      it("formats a number in the thousands correctly", () => {
+        const number = 2501;
+        const result = labelsMethods.formatLargeNumber(number);
+        expect(result).toEqual("2,501");
+      });
+
+      it("formats a number in the hundreds correctly", () => {
+        const number = 25;
+        const result = labelsMethods.formatLargeNumber(number);
+        expect(result).toEqual("25");
+      });
     });
   });
 });

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -136,6 +136,13 @@ const formatOfficerLabel = (label) => {
   return `${groups[0]} - ${toTitleCase(groups[1])}`;
 };
 
+const formatLargeNumber = (number) => {
+  const ONE_MILLION = 1000000;
+  return Math.abs(number) >= ONE_MILLION
+    ? `${(number / ONE_MILLION).toFixed(1)}M`
+    : number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+
 export {
   getPeriodLabelFromMetricPeriodMonthsFilter,
   getTrailingLabelFromMetricPeriodMonthsFilter,
@@ -155,4 +162,5 @@ export {
   getStatePopulations,
   getStatePopulationsLabels,
   formatOfficerLabel,
+  formatLargeNumber,
 };


### PR DESCRIPTION
## Description of the change

- Adds statistically significant indicator and footer in Race and Gender chart tooltips
- Formats numerators and denominators in all tooltips to display  “XX.XM/XX.XM” if the numbers are in the millions, and "X,XXX" if the number is in the thousands (adds comma)
- Sneaks in another change - removing the "Close" button from the Additional Info modal.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #884

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
