### PR TITLE
Shared filters refresh script

### DIFF
--- a/refresh_shared_filters.sh
+++ b/refresh_shared_filters.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "Refreshing shared-filters link"
+rm -r node_modules/shared-filters/
+yarn install
+cd shared-filters && yarn link
+cd ../src && yarn link shared-filters
+cd ../server && yarn link shared-filters


### PR DESCRIPTION
## Description of the change

I have occasionally been experiencing times when changes to files in the `shared-filters` linked package do not show up in the FE or API immediately. Changes to the filters, or even logging within the package does not immediately appear 100% of the time. I added this quick script that refreshes the shared-filters package and re-links it if we ever get into that state. Now that I have run the script, changes are showing up immediately, but it will be nice to have the script for future use.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #861

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
