### PR TITLE
Fix styling issue with loading summary metrics

### DIFF
--- a/src/core/PopulationSummaryMetrics/HistoricalSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/HistoricalSummaryMetrics.tsx
@@ -16,8 +16,7 @@
 // =============================================================================
 import React from "react";
 import MetricsCard from "../MetricsCard";
-import SummaryMetric, { getDeltaDirection } from "./SummaryMetric";
-import LoadingMetrics from "./LoadingMetrics";
+import SummaryMetrics from "./SummaryMetrics";
 
 import type { HistoricalSummaryRecord } from "../models/types";
 
@@ -25,46 +24,9 @@ const HistoricalSummaryMetrics: React.FC<{
   data?: HistoricalSummaryRecord;
   isLoading: boolean;
 }> = ({ data, isLoading }) => {
-  if (isLoading || !data) {
-    return (
-      <MetricsCard heading="Past 6 months">
-        <div className="SummaryMetrics">
-          <LoadingMetrics title="New arrivals" />
-          <LoadingMetrics title="Releases" />
-          <LoadingMetrics title="Total population" />
-        </div>
-      </MetricsCard>
-    );
-  }
   return (
     <MetricsCard heading="Past 6 months">
-      <div className="SummaryMetrics">
-        <SummaryMetric
-          title="New arrivals"
-          value={data.admissionCount}
-          percentChange={data.admissionPercentChange}
-          deltaDirection={getDeltaDirection({
-            percentChange: data.admissionPercentChange,
-          })}
-        />
-        <SummaryMetric
-          title="Releases"
-          value={data.releaseCount}
-          percentChange={data.releasePercentChange}
-          deltaDirection={getDeltaDirection({
-            percentChange: data.releasePercentChange,
-            improvesOnIncrease: true,
-          })}
-        />
-        <SummaryMetric
-          title="Total population"
-          value={data.totalPopulation}
-          percentChange={data.populationPercentChange}
-          deltaDirection={getDeltaDirection({
-            percentChange: data.populationPercentChange,
-          })}
-        />
-      </div>
+      <SummaryMetrics data={data} isLoading={isLoading} />
     </MetricsCard>
   );
 };

--- a/src/core/PopulationSummaryMetrics/HistoricalSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/HistoricalSummaryMetrics.tsx
@@ -28,9 +28,11 @@ const HistoricalSummaryMetrics: React.FC<{
   if (isLoading || !data) {
     return (
       <MetricsCard heading="Past 6 months">
-        <LoadingMetrics title="New arrivals" />
-        <LoadingMetrics title="Releases" />
-        <LoadingMetrics title="Total population" />
+        <div className="SummaryMetrics">
+          <LoadingMetrics title="New arrivals" />
+          <LoadingMetrics title="Releases" />
+          <LoadingMetrics title="Total population" />
+        </div>
       </MetricsCard>
     );
   }

--- a/src/core/PopulationSummaryMetrics/LoadingMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/LoadingMetrics.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import React from "react";
-import { MetricTitle } from "./SummaryMetric";
+import { MetricTitle } from "./SummaryMetrics";
 import "./LoadingMetrics.scss";
 
 const LoadingMetrics: React.FC<{ title: string; showMinMax?: boolean }> = ({

--- a/src/core/PopulationSummaryMetrics/ProjectedSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/ProjectedSummaryMetrics.tsx
@@ -21,41 +21,54 @@ import LoadingMetrics from "./LoadingMetrics";
 import type { ProjectedSummaryRecord } from "../models/types";
 import "./PopulationSummaryMetrics.scss";
 
-const SummaryMetrics: React.FC<{ data: ProjectedSummaryRecord }> = ({
-  data,
-}) => (
+const SummaryMetrics: React.FC<{
+  isLoading: boolean;
+  data?: ProjectedSummaryRecord;
+}> = ({ isLoading, data }) => (
   <div className="SummaryMetrics">
-    <SummaryMetric
-      title="New arrivals"
-      value={data.admissionCount}
-      percentChange={data.admissionPercentChange}
-      deltaDirection={getDeltaDirection({
-        percentChange: data.admissionPercentChange,
-      })}
-      projectedMinMax={[data.admissionCountMin, data.admissionCountMax]}
-    />
-    <SummaryMetric
-      title="Releases"
-      value={data.releaseCount}
-      percentChange={data.releasePercentChange}
-      deltaDirection={getDeltaDirection({
-        percentChange: data.releasePercentChange,
-        improvesOnIncrease: true,
-      })}
-      projectedMinMax={[data.releaseCountMin, data.releaseCountMax]}
-    />
-    <SummaryMetric
-      title="Total population"
-      value={data.totalPopulation}
-      percentChange={data.populationPercentChange}
-      deltaDirection={getDeltaDirection({
-        percentChange: data.populationPercentChange,
-      })}
-      projectedMinMax={[
-        data.totalPopulationCountMin,
-        data.totalPopulationCountMax,
-      ]}
-    />
+    {isLoading ? (
+      <>
+        <LoadingMetrics title="New arrivals" showMinMax />
+        <LoadingMetrics title="Releases" showMinMax />
+        <LoadingMetrics title="Total population" showMinMax />
+      </>
+    ) : (
+      data && (
+        <>
+          <SummaryMetric
+            title="New arrivals"
+            value={data.admissionCount}
+            percentChange={data.admissionPercentChange}
+            deltaDirection={getDeltaDirection({
+              percentChange: data.admissionPercentChange,
+            })}
+            projectedMinMax={[data.admissionCountMin, data.admissionCountMax]}
+          />
+          <SummaryMetric
+            title="Releases"
+            value={data.releaseCount}
+            percentChange={data.releasePercentChange}
+            deltaDirection={getDeltaDirection({
+              percentChange: data.releasePercentChange,
+              improvesOnIncrease: true,
+            })}
+            projectedMinMax={[data.releaseCountMin, data.releaseCountMax]}
+          />
+          <SummaryMetric
+            title="Total population"
+            value={data.totalPopulation}
+            percentChange={data.populationPercentChange}
+            deltaDirection={getDeltaDirection({
+              percentChange: data.populationPercentChange,
+            })}
+            projectedMinMax={[
+              data.totalPopulationCountMin,
+              data.totalPopulationCountMax,
+            ]}
+          />
+        </>
+      )
+    )}
   </div>
 );
 
@@ -63,27 +76,15 @@ const ProjectedSummaryMetrics: React.FC<{
   data?: ProjectedSummaryRecord;
   isLoading: boolean;
 }> = ({ data, isLoading }) => {
-  if (isLoading) {
-    return (
-      <MetricsCard heading="Next 6 months" subheading="Projected">
-        <div className="SummaryMetrics">
-          <LoadingMetrics title="New arrivals" showMinMax />
-          <LoadingMetrics title="Releases" showMinMax />
-          <LoadingMetrics title="Total population" showMinMax />
-        </div>
-      </MetricsCard>
-    );
-  }
-
   return (
     <MetricsCard heading="Next 6 months" subheading="Projected">
-      {!data ? (
+      {!data && !isLoading ? (
         <div className="MissingProjectionData">
           There are not enough data to generate a projection for this subset of
           the population.
         </div>
       ) : (
-        <SummaryMetrics data={data} />
+        <SummaryMetrics isLoading={isLoading} data={data} />
       )}
     </MetricsCard>
   );

--- a/src/core/PopulationSummaryMetrics/ProjectedSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/ProjectedSummaryMetrics.tsx
@@ -16,61 +16,9 @@
 // =============================================================================
 import React from "react";
 import MetricsCard from "../MetricsCard/MetricsCard";
-import SummaryMetric, { getDeltaDirection } from "./SummaryMetric";
-import LoadingMetrics from "./LoadingMetrics";
+import SummaryMetrics from "./SummaryMetrics";
 import type { ProjectedSummaryRecord } from "../models/types";
 import "./PopulationSummaryMetrics.scss";
-
-const SummaryMetrics: React.FC<{
-  isLoading: boolean;
-  data?: ProjectedSummaryRecord;
-}> = ({ isLoading, data }) => (
-  <div className="SummaryMetrics">
-    {isLoading ? (
-      <>
-        <LoadingMetrics title="New arrivals" showMinMax />
-        <LoadingMetrics title="Releases" showMinMax />
-        <LoadingMetrics title="Total population" showMinMax />
-      </>
-    ) : (
-      data && (
-        <>
-          <SummaryMetric
-            title="New arrivals"
-            value={data.admissionCount}
-            percentChange={data.admissionPercentChange}
-            deltaDirection={getDeltaDirection({
-              percentChange: data.admissionPercentChange,
-            })}
-            projectedMinMax={[data.admissionCountMin, data.admissionCountMax]}
-          />
-          <SummaryMetric
-            title="Releases"
-            value={data.releaseCount}
-            percentChange={data.releasePercentChange}
-            deltaDirection={getDeltaDirection({
-              percentChange: data.releasePercentChange,
-              improvesOnIncrease: true,
-            })}
-            projectedMinMax={[data.releaseCountMin, data.releaseCountMax]}
-          />
-          <SummaryMetric
-            title="Total population"
-            value={data.totalPopulation}
-            percentChange={data.populationPercentChange}
-            deltaDirection={getDeltaDirection({
-              percentChange: data.populationPercentChange,
-            })}
-            projectedMinMax={[
-              data.totalPopulationCountMin,
-              data.totalPopulationCountMax,
-            ]}
-          />
-        </>
-      )
-    )}
-  </div>
-);
 
 const ProjectedSummaryMetrics: React.FC<{
   data?: ProjectedSummaryRecord;
@@ -84,7 +32,7 @@ const ProjectedSummaryMetrics: React.FC<{
           the population.
         </div>
       ) : (
-        <SummaryMetrics isLoading={isLoading} data={data} />
+        <SummaryMetrics isLoading={isLoading} data={data} showMinMax />
       )}
     </MetricsCard>
   );

--- a/src/core/PopulationSummaryMetrics/ProjectedSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/ProjectedSummaryMetrics.tsx
@@ -66,9 +66,11 @@ const ProjectedSummaryMetrics: React.FC<{
   if (isLoading) {
     return (
       <MetricsCard heading="Next 6 months" subheading="Projected">
-        <LoadingMetrics title="New arrivals" showMinMax />
-        <LoadingMetrics title="Releases" showMinMax />
-        <LoadingMetrics title="Total population" showMinMax />
+        <div className="SummaryMetrics">
+          <LoadingMetrics title="New arrivals" showMinMax />
+          <LoadingMetrics title="Releases" showMinMax />
+          <LoadingMetrics title="Total population" showMinMax />
+        </div>
       </MetricsCard>
     );
   }

--- a/src/core/PopulationSummaryMetrics/SummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/SummaryMetrics.tsx
@@ -18,6 +18,12 @@ import React from "react";
 import styled from "styled-components/macro";
 import { Icon, IconSVG } from "@recidiviz/case-triage-components";
 import { formatLargeNumber } from "../../utils/labels";
+import LoadingMetrics from "./LoadingMetrics";
+import type {
+  ProjectedSummaryRecord,
+  HistoricalSummaryRecord,
+} from "../models/types";
+import ProjectedSummaryMetrics from "./ProjectedSummaryMetrics";
 
 const MetricContainer = styled.div`
   display: flex;
@@ -140,4 +146,68 @@ const SummaryMetric: React.FC<SummaryMetricProps> = ({
     </MetricContainer>
   );
 };
-export default SummaryMetric;
+
+const SummaryMetrics: React.FC<{
+  isLoading: boolean;
+  data?: ProjectedSummaryRecord | HistoricalSummaryRecord;
+  showMinMax?: boolean;
+}> = ({ isLoading, data, showMinMax = false }) => {
+  return (
+    <div className="SummaryMetrics">
+      {isLoading ? (
+        <>
+          <LoadingMetrics title="New arrivals" showMinMax={showMinMax} />
+          <LoadingMetrics title="Releases" showMinMax={showMinMax} />
+          <LoadingMetrics title="Total population" showMinMax={showMinMax} />
+        </>
+      ) : (
+        data && (
+          <>
+            <SummaryMetric
+              title="New arrivals"
+              value={data.admissionCount}
+              percentChange={data.admissionPercentChange}
+              deltaDirection={getDeltaDirection({
+                percentChange: data.admissionPercentChange,
+              })}
+              projectedMinMax={
+                "admissionCountMin" in data
+                  ? [data.admissionCountMin, data.admissionCountMax]
+                  : undefined
+              }
+            />
+            <SummaryMetric
+              title="Releases"
+              value={data.releaseCount}
+              percentChange={data.releasePercentChange}
+              deltaDirection={getDeltaDirection({
+                percentChange: data.releasePercentChange,
+                improvesOnIncrease: true,
+              })}
+              projectedMinMax={
+                "releaseCountMin" in data
+                  ? [data.releaseCountMin, data.releaseCountMax]
+                  : undefined
+              }
+            />
+            <SummaryMetric
+              title="Total population"
+              value={data.totalPopulation}
+              percentChange={data.populationPercentChange}
+              deltaDirection={getDeltaDirection({
+                percentChange: data.populationPercentChange,
+              })}
+              projectedMinMax={
+                "totalPopulationCountMin" in data
+                  ? [data.totalPopulationCountMin, data.totalPopulationCountMax]
+                  : undefined
+              }
+            />
+          </>
+        )
+      )}
+    </div>
+  );
+};
+
+export default SummaryMetrics;

--- a/src/core/models/PopulationProjectionSummaryMetric.ts
+++ b/src/core/models/PopulationProjectionSummaryMetric.ts
@@ -29,7 +29,7 @@ export function populationProjectionSummary(
     if (record.simulation_tag === "HISTORICAL") {
       return {
         simulationTag: record.simulation_tag,
-        timePeriod: Number(record.metric_period_months),
+        timePeriod: record.metric_period_months,
         compartment: record.compartment,
         legalStatus: record.legal_status,
         gender: record.simulation_group,
@@ -43,7 +43,7 @@ export function populationProjectionSummary(
     }
     return {
       simulationTag: record.simulation_tag,
-      timePeriod: Number(record.metric_period_months),
+      timePeriod: record.metric_period_months,
       compartment: record.compartment,
       legalStatus: record.legal_status,
       gender: record.simulation_group,

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -45,7 +45,7 @@ export type ProjectedSummaryRecord = HistoricalSummaryRecord & {
 };
 
 export type HistoricalSummaryRecord = {
-  timePeriod?: number;
+  timePeriod?: string;
   compartment?: string;
   legalStatus?: string;
   gender?: string;


### PR DESCRIPTION
## Description of the change

This is a super small fix to adjust the display of the loading metrics (found after I deployed the preview app!). 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Related to https://github.com/Recidiviz/recidiviz-data/issues/6095

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
