### PR TITLE
Fixes response payload empty bug

### DIFF
--- a/src/RootStore/DataStore/BaseDataStore.js
+++ b/src/RootStore/DataStore/BaseDataStore.js
@@ -192,7 +192,9 @@ export default class BaseDataStore {
       this.isError = false;
       return;
     }
-    const endpoint = `${tenantId}/newRevocations/${this.file}${this.filtersQueryParams}`;
+
+    const filename = this.file;
+    const endpoint = `${tenantId}/newRevocations/${filename}${this.filtersQueryParams}`;
     try {
       this.isLoading = true;
       const responseData = yield callMetricsApi(
@@ -201,7 +203,7 @@ export default class BaseDataStore {
       );
       this.apiData = parseResponseByFileFormat(
         responseData,
-        this.file,
+        filename,
         this.eagerExpand
       );
       this.isLoading = false;

--- a/src/api/metrics/fileParser.js
+++ b/src/api/metrics/fileParser.js
@@ -34,8 +34,12 @@ export function unflattenValues(metricFile) {
 const parseResponseByFileFormat = (responseData, file, eagerExpand = true) => {
   const metricFile = responseData[file];
 
-  if (!metricFile)
-    throw new Error(`Response payload for file ${file} is empty`);
+  if (!metricFile) {
+    const keys = Object.keys(responseData);
+    throw new Error(
+      `Response payload for file ${file} is empty. Response keys are: ${keys}`
+    );
+  }
 
   // If it's in the expanded json format that is ready to go, return that.
   // The metricFile format should be { data, metadata } for all dashboards except US_ND


### PR DESCRIPTION
## Description of the change

We have a bug where an error is thrown: `Response payload for file revocations_matrix_distribution_by_district is empty`. It turns out that this was happening when the user switches charts before a data fetch finishes, so `this.file` has changed and the response payload no longer matches the `BaseDataStore` file. This sets the filename as constant so that the response payload can be accessed with the same metric filename.

I was able to reproduce this with better logging to display the issue:
<img width="1774" alt="Screen Shot 2021-03-17 at 5 55 55 PM" src="https://user-images.githubusercontent.com/5872651/111557783-901bc200-874a-11eb-8f9f-256fbba46558.png">



## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #913

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
