### PR TITLE
Allow user to access views based on tenant id

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ import {
 import * as Sentry from "@sentry/react";
 
 import ProtectedRoute from "./ProtectedRoute";
+import RedirectHome from "./RedirectHome";
 import { PageProvider } from "./contexts/PageContext";
 import StoreProvider from "./components/StoreProvider";
 import NotFound from "./components/NotFound";
@@ -86,7 +87,7 @@ const App = () => (
                   <ProtectedRoute path="/facilities/projections" component={PageProjections} />
                   <ProtectedRoute path="/methodology" component={Methodology} />
                   <Route path="/profile" component={Profile} />
-                  <Redirect exact from="/" to="/goals" />
+                  <RedirectHome />
                   <Redirect from="/snapshots" to="/goals" />
                   <Redirect from="/revocations" to="/goals" />
                   <Redirect from="/reincarcerations" to="/goals" />

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -24,6 +24,7 @@ import {
 } from "react-router-dom";
 import * as Sentry from "@sentry/react";
 
+import ProtectedRoute from "./ProtectedRoute";
 import { PageProvider } from "./contexts/PageContext";
 import StoreProvider from "./components/StoreProvider";
 import NotFound from "./components/NotFound";
@@ -36,6 +37,7 @@ import Revocations from "./lantern/Revocations";
 import UsNdCommunityExplore from "./core/community/Explore";
 import UsNdFacilitiesExplore from "./core/facilities/Explore";
 import PageProjections from "./core/PageProjections";
+import CoreGoalsView from "./core/goals/CoreGoalsView";
 import initFontAwesome from "./utils/initFontAwesome";
 import initIntercomSettings from "./utils/initIntercomSettings";
 import { initI18n } from "./utils/i18nSettings";
@@ -46,7 +48,6 @@ import ErrorBoundary from "./components/ErrorBoundary";
 
 import "./assets/scripts/index";
 import "./assets/styles/index.scss";
-import CoreGoalsView from "./core/goals/CoreGoalsView";
 
 initFontAwesome();
 initIntercomSettings();
@@ -78,12 +79,12 @@ const App = () => (
 
               <CoreLayout tenantIds={CORE_TENANTS}>
                 <Switch>
-                  <Route path="/goals" component={CoreGoalsView} />
-                  <Route path="/community/explore" component={UsNdCommunityExplore} />
-                  <Route path="/community/projections" component={PageProjections} />
-                  <Route path="/facilities/explore" component={UsNdFacilitiesExplore} />
-                  <Route path="/facilities/projections" component={PageProjections} />
-                  <Route path="/methodology" component={Methodology} />
+                  <ProtectedRoute path="/goals" component={CoreGoalsView} />
+                  <ProtectedRoute path="/community/explore" component={UsNdCommunityExplore} />
+                  <ProtectedRoute path="/community/projections" component={PageProjections} />
+                  <ProtectedRoute path="/facilities/explore" component={UsNdFacilitiesExplore} />
+                  <ProtectedRoute path="/facilities/projections" component={PageProjections} />
+                  <ProtectedRoute path="/methodology" component={Methodology} />
                   <Route path="/profile" component={Profile} />
                   <Redirect exact from="/" to="/goals" />
                   <Redirect from="/snapshots" to="/goals" />

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,0 +1,45 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import React from "react";
+import { Route, useLocation } from "react-router-dom";
+import { observer } from "mobx-react-lite";
+import NotFound from "./components/NotFound";
+import { useRootStore } from "./components/StoreProvider";
+import tenants from "./tenants";
+
+interface ProtectedRouteProps {
+  component: React.FC;
+  children: React.ReactNode;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const rootStore = useRootStore();
+  const { pathname } = useLocation();
+  // @ts-ignore
+  const tenant = tenants[rootStore.currentTenantId];
+  if (!tenant.allowedPaths.includes(pathname)) {
+    return <NotFound />;
+  }
+  return (
+    <Route {...rest} render={(props) => <Component {...rest} {...props} />} />
+  );
+};
+
+export default observer(ProtectedRoute);

--- a/src/RedirectHome.tsx
+++ b/src/RedirectHome.tsx
@@ -15,35 +15,19 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import React from "react";
-import { Route, useLocation } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 import { observer } from "mobx-react-lite";
-import NotFound from "./components/NotFound";
 import { useRootStore } from "./components/StoreProvider";
 import { getPathsFromNavigation } from "./utils/navigation";
 
 import tenants from "./tenants";
 
-interface ProtectedRouteProps {
-  component: React.FC;
-  children: React.ReactNode;
-}
-
-const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
-  component: Component,
-  ...rest
-}) => {
+export const RedirectHome: React.FC = ({ ...rest }) => {
   const rootStore = useRootStore();
-  const { pathname } = useLocation();
   // @ts-ignore
   const tenant = tenants[rootStore.currentTenantId];
   const allowedPaths = getPathsFromNavigation(tenant.navigation);
-
-  if (!allowedPaths.includes(pathname)) {
-    return <NotFound />;
-  }
-  return (
-    <Route {...rest} render={(props) => <Component {...rest} {...props} />} />
-  );
+  return <Redirect {...rest} exact from="/" to={allowedPaths[0]} />;
 };
 
-export default observer(ProtectedRoute);
+export default observer(RedirectHome);

--- a/src/RootStore/TenantStore/coreTenants.js
+++ b/src/RootStore/TenantStore/coreTenants.js
@@ -16,5 +16,6 @@
 // =============================================================================
 
 export const US_ND = "US_ND";
+export const US_ID = "US_ID";
 
-export const CORE_TENANTS = [US_ND];
+export const CORE_TENANTS = [US_ND, US_ID];

--- a/src/RootStore/__tests__/RootStore.test.js
+++ b/src/RootStore/__tests__/RootStore.test.js
@@ -23,6 +23,7 @@ import { METADATA_NAMESPACE } from "../../constants";
 jest.mock("@auth0/auth0-spa-js");
 jest.mock("../../api/metrics");
 jest.mock("../DataStore/DataStore");
+jest.mock("../DistrictsStore");
 
 let rootStore;
 

--- a/src/core/CoreNavigation.tsx
+++ b/src/core/CoreNavigation.tsx
@@ -16,30 +16,25 @@
 // =============================================================================
 
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { useLocation, Link } from "react-router-dom";
+import { useRootStore } from "../components/StoreProvider";
 import CoreSectionSelector from "./CoreSectionSelector";
 import CorePageSelector from "./CorePageSelector";
 import TopBarUserMenuForAuthenticatedUser from "../components/TopBar/TopBarUserMenuForAuthenticatedUser";
 import flags from "../flags";
+import tenants from "../tenants";
 
 import recidivizLogo from "../assets/static/images/Logo.svg";
 import "./CoreNavigation.scss";
 
-const navigationLayout = flags.showMethodologyDropdown
-  ? {
-      community: ["explore", "projections"],
-      facilities: ["explore", "projections"],
-      goals: [],
-      methodology: [],
-    }
-  : {
-      community: ["explore", "projections"],
-      facilities: ["explore", "projections"],
-      goals: [],
-    };
-
 const CoreNavigation: React.FC = () => {
   const { pathname } = useLocation();
+  const { currentTenantId } = useRootStore();
+
+  // @ts-ignore
+  const navigationLayout = tenants[currentTenantId].navigation;
+
   const [currentSection, currentPage] = pathname.split("/").slice(1, 3);
   // @ts-ignore
   const pageOptions = navigationLayout[currentSection] ?? [];
@@ -82,4 +77,4 @@ const CoreNavigation: React.FC = () => {
   );
 };
 
-export default CoreNavigation;
+export default observer(CoreNavigation);

--- a/src/core/CoreNavigation.tsx
+++ b/src/core/CoreNavigation.tsx
@@ -55,7 +55,7 @@ const CoreNavigation: React.FC = () => {
     <nav className="CoreNavigation">
       <div className="CoreNavigation__left">
         <div className="CoreNavigation__logo">
-          <Link to="/goals">
+          <Link to="/">
             <img
               className="CoreNavigation__logo-image"
               src={recidivizLogo}

--- a/src/core/CoreNavigation.tsx
+++ b/src/core/CoreNavigation.tsx
@@ -32,6 +32,8 @@ const CoreNavigation: React.FC = () => {
   const { pathname } = useLocation();
   const { currentTenantId } = useRootStore();
 
+  if (!currentTenantId) return null;
+
   // @ts-ignore
   const navigationLayout = tenants[currentTenantId].navigation;
 

--- a/src/core/__tests__/CoreLayout.test.js
+++ b/src/core/__tests__/CoreLayout.test.js
@@ -24,6 +24,7 @@ import TopBarUserMenuForAuthenticatedUser from "../../components/TopBar/TopBarUs
 
 import mockWithTestId from "../../../__helpers__/mockWithTestId";
 import { PageProvider } from "../../contexts/PageContext";
+import StoreProvider from "../../components/StoreProvider";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(),
@@ -46,9 +47,11 @@ describe("CoreLayout tests", () => {
 
   const renderCoreLayout = () => {
     return render(
-      <PageProvider>
-        <CoreLayout>{mockChildren}</CoreLayout>
-      </PageProvider>
+      <StoreProvider>
+        <PageProvider>
+          <CoreLayout>{mockChildren}</CoreLayout>
+        </PageProvider>
+      </StoreProvider>
     );
   };
 

--- a/src/tenants.js
+++ b/src/tenants.js
@@ -17,6 +17,7 @@
 
 import * as lantern from "./RootStore/TenantStore/lanternTenants";
 import * as core from "./RootStore/TenantStore/coreTenants";
+import flags from "./flags";
 
 export default {
   // prettier-ignore
@@ -27,10 +28,26 @@ export default {
   [core.US_ND]: {
     name: "North Dakota",
     availableStateCodes: [core.US_ND],
+    allowedPaths: ["/community/explore", "/facilities/explore", "/goals"],
+    navigation: {
+      goals: [],
+      community: ["explore"],
+      facilities: ["explore"],
+    },
   },
   [core.US_ID]: {
     name: "Idaho",
     availableStateCodes: [core.US_ID],
+    allowedPaths: [
+      "/community/projections",
+      "/facilities/projections",
+      "/methodology",
+    ],
+    navigation: {
+      community: ["projections"],
+      facilities: ["projections"],
+      ...(flags.showMethodologyDropdown ? { methodology: [] } : {}),
+    },
   },
   [lantern.US_PA]: {
     name: "Pennsylvania",

--- a/src/tenants.js
+++ b/src/tenants.js
@@ -28,6 +28,10 @@ export default {
     name: "North Dakota",
     availableStateCodes: [core.US_ND],
   },
+  [core.US_ID]: {
+    name: "Idaho",
+    availableStateCodes: [core.US_ID],
+  },
   [lantern.US_PA]: {
     name: "Pennsylvania",
     availableStateCodes: [lantern.US_PA],

--- a/src/tenants.ts
+++ b/src/tenants.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,13 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-
 import * as lantern from "./RootStore/TenantStore/lanternTenants";
 import * as core from "./RootStore/TenantStore/coreTenants";
 import flags from "./flags";
 
 export default {
-  // prettier-ignore
   [lantern.US_MO]: {
     name: "Missouri",
     availableStateCodes: [lantern.US_MO],
@@ -28,7 +26,6 @@ export default {
   [core.US_ND]: {
     name: "North Dakota",
     availableStateCodes: [core.US_ND],
-    allowedPaths: ["/community/explore", "/facilities/explore", "/goals"],
     navigation: {
       goals: [],
       community: ["explore"],
@@ -38,11 +35,6 @@ export default {
   [core.US_ID]: {
     name: "Idaho",
     availableStateCodes: [core.US_ID],
-    allowedPaths: [
-      "/community/projections",
-      "/facilities/projections",
-      "/methodology",
-    ],
     navigation: {
       community: ["projections"],
       facilities: ["projections"],

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,27 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+export function getPathsFromNavigation(navigation: {
+  [k: string]: string[];
+}): string[] {
+  return Object.entries(navigation).flatMap((navItem) => {
+    const section: string = navItem[0];
+    const pages: string[] = navItem[1];
+    return pages.length
+      ? pages.map((page) => `/${section}/${page}`)
+      : [`/${section}`];
+  });
+}


### PR DESCRIPTION
## Description of the change

This PR adds a `ProtectedRoute` component for the CoreLayout that will only make the paths available to the tenant if they're in the `allowedPaths` list on the `tenants` constant. It also updates the CoreNavigation to use the tenant-specific navigation layouts.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #909 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
