### PR TITLE
Design polish for the summary metric cards

### DIFF
--- a/src/@types/scss.d.ts
+++ b/src/@types/scss.d.ts
@@ -1,0 +1,1 @@
+declare module "*.scss";

--- a/src/core/CoreConstants.scss
+++ b/src/core/CoreConstants.scss
@@ -8,3 +8,15 @@ $core-breakpoint-xs: 600px;
 $core-max-view-width: 93rem;
 
 $core-font-color: #00413e;
+$pine-1: rgba(1, 35, 34, 1);
+$slate-80: rgba(53, 83, 98, 0.8);
+// Shorthand font property: font-style font-variant font-weight font-size/line-height font-family
+$font-ui-sans-16: 500 1rem/1.5rem Libre Franklin;
+$font-ui-sans-14: 500 0.875rem/1.5rem Libre Franklin;
+
+:export {
+  pine1: $pine-1;
+  slate80: $slate-80;
+  fontUiSans16: $font-ui-sans-16;
+  fontUiSans14: $font-ui-sans-14;
+}

--- a/src/core/MetricsCard/MetricsCard.tsx
+++ b/src/core/MetricsCard/MetricsCard.tsx
@@ -16,23 +16,31 @@
 // =============================================================================
 import React from "react";
 import styled from "styled-components/macro";
-import { Card, CardSection, H4 } from "@recidiviz/case-triage-components";
+import { Card, CardSection } from "@recidiviz/case-triage-components";
+import * as fontStyles from "../CoreConstants.scss";
 
 const MetricsCardComponent = styled(Card)`
   width: 100%;
   margin: 1rem;
 `;
 
+const MetricHeading = styled.h4`
+  color: ${fontStyles.pine1};
+  font: ${fontStyles.fontUiSans16};
+  letter-spacing: -0.01em;
+`;
+
 const MetricSubHeading = styled.div`
-  font-size: 0.9rem;
-  line-height: 1.5;
+  color: ${fontStyles.slate80};
+  font: ${fontStyles.fontUiSans14};
+  letter-spacing: -0.01em;
 `;
 
 const HeadingContainer = styled.div`
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;
-  padding: 25px 40px;
+  padding: 20px 40px;
   height: 64px;
 `;
 
@@ -51,7 +59,7 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
     <MetricsCardComponent stacked>
       <CardSection>
         <HeadingContainer>
-          <H4>{heading}</H4>
+          <MetricHeading>{heading}</MetricHeading>
           {subheading && <MetricSubHeading>{subheading}</MetricSubHeading>}
         </HeadingContainer>
       </CardSection>

--- a/src/core/PopulationSummaryMetrics/PopulationSummaryMetrics.scss
+++ b/src/core/PopulationSummaryMetrics/PopulationSummaryMetrics.scss
@@ -33,6 +33,7 @@
   flex-flow: row nowrap;
   justify-content: flex-start;
   height: 168px;
+  padding: 24px 0 32px;
 }
 
 .MissingProjectionData {

--- a/src/core/PopulationSummaryMetrics/SummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/SummaryMetrics.tsx
@@ -27,19 +27,18 @@ import type {
 const MetricContainer = styled.div`
   display: flex;
   flex-flow: column;
-  padding: 20px 40px;
+  padding: 0 40px;
   width: 30%;
 `;
 
-const Value = styled.div`
-  padding: 4px;
-`;
+const Value = styled.div``;
 
 // TODO(#908): Use typography components from component library
 export const MetricTitle = styled.div`
   font-family: "Libre Franklin";
   font-size: 0.9rem;
-  line-height: 1rem;
+  line-height: 1.5rem;
+  letter-spacing: -0.01em;
   font-weight: 500;
   color: rgba(53, 83, 98, 0.85);
   white-space: nowrap;
@@ -48,8 +47,10 @@ const MetricValue = styled.div`
   font-family: "Libre Baskerville";
   font-size: 2rem;
   line-height: 40px;
+  letter-spacing: -0.04em;
   font-weight: 400;
   color: #00413e;
+  padding: 8px 0 0;
 `;
 const MetricDelta = styled.div<{ color: string }>`
   display: flex;
@@ -60,6 +61,11 @@ const MetricDelta = styled.div<{ color: string }>`
   font-size: 0.9rem;
   line-height: 16px;
   font-weight: 500;
+  padding: 2px 0 0;
+
+  > ${Value} {
+    padding: 0 5px;
+  }
 `;
 const MetricMinMax = styled.div`
   font-family: "Libre Franklin";
@@ -68,6 +74,7 @@ const MetricMinMax = styled.div`
   font-weight: 400;
   color: rgba(53, 83, 98, 0.85);
   white-space: nowrap;
+  padding: 5px 0 0;
 `;
 
 interface SummaryMetricProps {
@@ -135,7 +142,7 @@ const SummaryMetric: React.FC<SummaryMetricProps> = ({
           height={10}
           fill={deltaColorMap[deltaDirection]}
         />
-        <Value>{formatPercent(percentChange)}</Value>
+        <Value>{formatPercent(Math.abs(percentChange))}</Value>
       </MetricDelta>
       {projectedMinMax && (
         <MetricMinMax>


### PR DESCRIPTION
## Description of the change

This is a design polish PR to update the summary metric cards to more closely match the figma mocks. I added font and color variables to `CoreConstants` that I expect we'll eventually update to use from the component library.

<img width="2484" alt="design_review_3 17 21" src="https://user-images.githubusercontent.com/5402804/111997754-bb5b3400-8af1-11eb-9c89-81cca9e95df0.png">


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #929 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
