### PR TITLE
Add intercom app to core dashboard

### DIFF
--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -59,9 +59,10 @@ describe("App tests", () => {
 
   const RevocationsMock = Revocations.type;
   const LanternLayoutMock = LanternLayout.type;
+  const CoreLayoutMock = CoreLayout.type;
 
   LanternLayoutMock.mockImplementation(({ children }) => children);
-  CoreLayout.mockImplementation(({ children }) => children);
+  CoreLayoutMock.mockImplementation(({ children }) => children);
   StoreProvider.mockImplementation(({ children }) => children);
   RevocationsMock.mockReturnValue(mockWithTestId(mockRevocationsId));
   UsNDCommunityGoals.mockReturnValue(mockWithTestId(mockNDCommunityGoalsId));
@@ -103,7 +104,7 @@ describe("App tests", () => {
 
     const { getByTestId } = render(<App />);
 
-    expect(CoreLayout).toHaveBeenCalledTimes(1);
+    expect(CoreLayoutMock).toHaveBeenCalledTimes(1);
     expect(LanternLayoutMock).toHaveBeenCalledTimes(0);
     expect(getByTestId(mockNDCommunityGoalsId)).toBeInTheDocument();
   });
@@ -119,7 +120,7 @@ describe("App tests", () => {
     const { getByTestId } = render(<App />);
 
     expect(LanternLayoutMock).toHaveBeenCalledTimes(1);
-    expect(CoreLayout).toHaveBeenCalledTimes(0);
+    expect(CoreLayoutMock).toHaveBeenCalledTimes(0);
     expect(getByTestId(mockRevocationsId)).toBeInTheDocument();
   });
 

--- a/src/core/CoreLayout.js
+++ b/src/core/CoreLayout.js
@@ -16,14 +16,17 @@
 // =============================================================================
 
 import React from "react";
+import { observer } from "mobx-react-lite";
 
 import PropTypes from "prop-types";
 import Footer from "../components/Footer";
 import CoreNavigation from "./CoreNavigation";
+import useIntercom from "../hooks/useIntercom";
 
 import "./CoreLayout.scss";
 
 const CoreLayout = ({ children }) => {
+  useIntercom();
   return (
     <div id="app" className="CoreLayout">
       <div className="page-container">
@@ -44,4 +47,4 @@ CoreLayout.propTypes = {
   ]).isRequired,
 };
 
-export default CoreLayout;
+export default observer(CoreLayout);

--- a/src/core/__tests__/CoreLayout.test.js
+++ b/src/core/__tests__/CoreLayout.test.js
@@ -25,6 +25,7 @@ import TopBarUserMenuForAuthenticatedUser from "../../components/TopBar/TopBarUs
 import mockWithTestId from "../../../__helpers__/mockWithTestId";
 import { PageProvider } from "../../contexts/PageContext";
 import StoreProvider from "../../components/StoreProvider";
+import useIntercom from "../../hooks/useIntercom";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(),
@@ -33,6 +34,7 @@ jest.mock("react-router-dom", () => ({
   NavLink: jest.fn().mockReturnValue(null),
 }));
 jest.mock("../../components/TopBar/TopBarUserMenuForAuthenticatedUser");
+jest.mock("../../hooks/useIntercom");
 
 describe("CoreLayout tests", () => {
   TopBarUserMenuForAuthenticatedUser.mockReturnValue(null);
@@ -59,5 +61,10 @@ describe("CoreLayout tests", () => {
     const { getByTestId } = renderCoreLayout();
 
     expect(getByTestId(mockChildrenId)).toBeInTheDocument();
+  });
+
+  it("should use Intercom for Core layout", () => {
+    renderCoreLayout();
+    expect(useIntercom).toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/useIntercom.test.js
+++ b/src/hooks/__tests__/useIntercom.test.js
@@ -17,9 +17,9 @@
 
 import { renderHook } from "@testing-library/react-hooks";
 import useIntercom from "../useIntercom";
-import { useRootStore } from "../../../components/StoreProvider";
+import { useRootStore } from "../../components/StoreProvider";
 
-jest.mock("../../../components/StoreProvider");
+jest.mock("../../components/StoreProvider");
 
 describe("useIntercom hook tests", () => {
   const mockName = "some user name";

--- a/src/hooks/useIntercom.js
+++ b/src/hooks/useIntercom.js
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { useEffect } from "react";
-import { useRootStore } from "../../components/StoreProvider";
+import { useRootStore } from "../components/StoreProvider";
 
 const useIntercom = () => {
   const { userStore, tenantStore } = useRootStore();

--- a/src/lantern/LanternLayout.js
+++ b/src/lantern/LanternLayout.js
@@ -25,7 +25,7 @@ import TopBarLogo from "../components/TopBar/TopBarLogo";
 import TopBarUserMenuForAuthenticatedUser from "../components/TopBar/TopBarUserMenuForAuthenticatedUser";
 import Footer from "../components/Footer";
 import usePageLayout from "./hooks/usePageLayout";
-import useIntercom from "./hooks/useIntercom";
+import useIntercom from "../hooks/useIntercom";
 import { setTranslateLocale } from "../utils/i18nSettings";
 import { useRootStore } from "../components/StoreProvider";
 

--- a/src/lantern/__tests__/LanternLayout.test.js
+++ b/src/lantern/__tests__/LanternLayout.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import LanternLayout from "../LanternLayout";
-import useIntercom from "../hooks/useIntercom";
+import useIntercom from "../../hooks/useIntercom";
 import usePageLayout from "../hooks/usePageLayout";
 import TopBarUserMenuForAuthenticatedUser from "../../components/TopBar/TopBarUserMenuForAuthenticatedUser";
 import mockWithTestId from "../../../__helpers__/mockWithTestId";
@@ -14,7 +14,7 @@ jest.mock("react-router-dom", () => {
     Link: ({ children }) => children,
   };
 });
-jest.mock("../hooks/useIntercom");
+jest.mock("../../hooks/useIntercom");
 jest.mock("../hooks/usePageLayout");
 jest.mock("../../components/TopBar/TopBarUserMenuForAuthenticatedUser");
 jest.mock("../../components/StoreProvider");


### PR DESCRIPTION
## Description of the change

This adds the Intercom app hook to the core dashboard. I'll check with @chrispmlee today to see if we need to do any other configuration on the app side for this to work well on both dashboards, and see if we can do a test run. 

TODO:
- [x] Check with Chris to do a test from staging or local environment

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes https://github.com/Recidiviz/recidiviz-data/issues/6241

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
