### PR TITLE
Remove PageProvider error on lantern layout

### DIFF
--- a/src/lantern/hooks/usePageLayout.js
+++ b/src/lantern/hooks/usePageLayout.js
@@ -25,13 +25,6 @@ const usePageLayout = () => {
   const [lastOffset, setLastOffset] = useState(window.pageYOffset);
   const [scrollUpCount, setScrollUpCount] = useState(0);
 
-  if (hideTopBar === undefined) {
-    pageDispatch({
-      type: "update",
-      payload: { hideTopBar: false },
-    });
-  }
-
   useLayoutEffect(() => {
     const handler = () => {
       cancelAnimationFrame(frame.current);


### PR DESCRIPTION
## Description of the change

This removes dispatching a page update from within the `usePageLayout` hook which was outside the `useLayoutEffect` hook and causing a bad set state error. This seems to continue to work as expected without dispatching this update when `hideTopBar` is undefined, but let me know if I am missing something!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
