### PR TITLE
Add tooltip to population chart

### DIFF
--- a/src/core/PopulationTimeseriesChart/PopulationTimeseriesChart.scss
+++ b/src/core/PopulationTimeseriesChart/PopulationTimeseriesChart.scss
@@ -59,7 +59,7 @@
     font-weight: 400;
   }
 
-  .annotation-area{
+  .annotation-layer{
     .uncertainty {
       fill: #25636F;
       fill-opacity: 0.2;
@@ -68,6 +68,11 @@
     .projection-area {
       fill: #EFF1F1;
       fill-opacity: 0.46;
+    }
+
+    .frame-hover {
+      fill: #082249;
+      r: 0.25rem;
     }
   }
 }

--- a/src/core/PopulationTimeseriesChart/PopulationTimeseriesTooltip.scss
+++ b/src/core/PopulationTimeseriesChart/PopulationTimeseriesTooltip.scss
@@ -1,0 +1,16 @@
+.PopulationTimeseriesTooltip {
+  background: #082249;
+  border-radius: 0.25rem;
+  color: #fff;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transform: translate(-50%, 1rem);
+  width: 8rem;
+
+  &__Date,
+  &__Range {
+    opacity: 0.8;
+  }
+}

--- a/src/core/PopulationTimeseriesChart/PopulationTimeseriesTooltip.tsx
+++ b/src/core/PopulationTimeseriesChart/PopulationTimeseriesTooltip.tsx
@@ -1,0 +1,51 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+
+import "./PopulationTimeseriesTooltip.scss";
+
+type PropTypes = {
+  d: {
+    date: Date;
+    value: number;
+    lowerBound?: number;
+    upperBound?: number;
+  };
+};
+
+const PopulationTimeseriesTooltip: React.FC<PropTypes> = ({ d }) => {
+  const { date, value, lowerBound, upperBound } = d;
+
+  return (
+    <div className="PopulationTimeseriesTooltip">
+      <div className="PopulationTimeseriesTooltip__Date">
+        {date.toLocaleString("default", { month: "long", year: "numeric" })}
+      </div>
+      <div className="PopulationTimeseriesTooltip__Value">
+        {value.toLocaleString("default", { maximumFractionDigits: 0 })}
+      </div>
+      {lowerBound && upperBound && (
+        <div className="PopulationTimeseriesTooltip__Range">
+          ({Math.round(lowerBound)}, {Math.round(upperBound)})
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PopulationTimeseriesTooltip;

--- a/src/core/PopulationTimeseriesChart/index.tsx
+++ b/src/core/PopulationTimeseriesChart/index.tsx
@@ -29,6 +29,7 @@ import {
 import "./PopulationTimeseriesChart.scss";
 import PopulationTimeseriesLegend from "./PopulationTimeseriesLegend";
 import { CORE_VIEWS, getViewFromPathname } from "../views";
+import PopulationTimeseriesTooltip from "./PopulationTimeseriesTooltip";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
 const ResponsiveXYFrame = require("semiotic/lib/ResponsiveXYFrame") as any;
@@ -41,8 +42,6 @@ type PropTypes = {
 
 const CURRENT_YEAR = 2021;
 const CURRENT_MONTH = 1;
-
-const SELECTED_COMPARTMENT = "SUPERVISION";
 
 const filterData = (
   monthRange: number,
@@ -70,6 +69,8 @@ const filterData = (
 type ChartPoint = {
   date: Date;
   value: number;
+  lowerBound?: number;
+  upperBound?: number;
 };
 
 type PreparedData = {
@@ -103,6 +104,8 @@ const prepareData = (
       .map((d) => ({
         date: getDate(d),
         value: d.totalPopulation,
+        lowerBound: d.totalPopulationMin,
+        upperBound: d.totalPopulationMax,
       }))
   );
 
@@ -269,6 +272,8 @@ const PopulationTimeseriesChart: React.FC<PropTypes> = ({ data }) => {
             dy: 24,
           },
         ]}
+        hoverAnnotation
+        tooltipContent={(d: any) => <PopulationTimeseriesTooltip d={d} />}
         lines={[historicalLine, projectedLine]}
         lineDataAccessor="data"
         lineStyle={(l: PlotLine) => ({


### PR DESCRIPTION
## Description of the change

Adds the tooltip hover box to the chart. Does not add the error bar to the selected point on hover.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

More towards https://github.com/Recidiviz/recidiviz-data/issues/6097

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
