### PR TITLE
Add VitalsSummaryDetail next to the vitals chart

### DIFF
--- a/src/@types/react-table-config.d.ts
+++ b/src/@types/react-table-config.d.ts
@@ -116,8 +116,7 @@ declare module "react-table" {
       UseSortByColumnProps<D> {}
 
   export interface Cell<
-    D extends Record<string, unknown> = Record<string, unknown>,
-    V = any
+    D extends Record<string, unknown> = Record<string, unknown>
   > extends UseGroupByCellProps<D>,
       UseRowStateCellProps<D> {}
 

--- a/src/core/CoreConstants.scss
+++ b/src/core/CoreConstants.scss
@@ -23,9 +23,15 @@ $slate-20: rgba(53, 83, 98, 0.2);
 $slate-80: rgba(53, 83, 98, 0.8);
 $marble-3: #f4f5f5;
 $marble-4: #eff1f1;
+$crimson-dark: #a43939;
+$crimson: #bf7474;
+
 // Shorthand font property: font-style font-variant font-weight font-size/line-height font-family
-$font-ui-sans-16: 500 1rem/1.5rem Libre Franklin;
-$font-ui-sans-14: 500 0.875rem/1.5rem Libre Franklin;
+$sans-serif: Libre Franklin, sans serif;
+$serif: Libre Baskerville, serif;
+$font-ui-sans-16: 500 1rem/1.5rem $sans-serif;
+$font-ui-sans-14: 500 0.875rem/1.5rem $sans-serif;
+$font-ui-sans-24: 1.5rem/2.5rem $sans-serif;
 
 :export {
   pine1: $pine-1;

--- a/src/core/PageVitals/PageVitals.scss
+++ b/src/core/PageVitals/PageVitals.scss
@@ -63,7 +63,6 @@
     background: $white;
     border-radius: 0.5rem 0 0 0.5rem;
     box-shadow: inset 0px -1px 1px $box-shadow-color-20;
-    font-size: 96px;
     text-align: center;
     width: 30%;
   }

--- a/src/core/PageVitals/__tests__/helpers.test.ts
+++ b/src/core/PageVitals/__tests__/helpers.test.ts
@@ -1,0 +1,55 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import { getSummaryStatus } from "../helpers";
+
+describe("getSummaryStatus", () => {
+  describe("when value is less than 70", () => {
+    it("returns POOR", () => {
+      [0, 15, 25, 69].forEach((number) => {
+        expect(getSummaryStatus(number)).toEqual("POOR");
+      });
+    });
+  });
+  describe("when value is greater than or equal to 70 and less than 80", () => {
+    it("returns NEEDS_IMPROVEMENT", () => {
+      [70, 75, 79].forEach((number) => {
+        expect(getSummaryStatus(number)).toEqual("NEEDS_IMPROVEMENT");
+      });
+    });
+  });
+  describe("when value is greater than or equal to 80 and less than 90", () => {
+    it("returns GOOD", () => {
+      [80, 85, 89].forEach((number) => {
+        expect(getSummaryStatus(number)).toEqual("GOOD");
+      });
+    });
+  });
+  describe("when value is greater than or equal to 90 and less than 95", () => {
+    it("returns GREAT", () => {
+      [90, 94].forEach((number) => {
+        expect(getSummaryStatus(number)).toEqual("GREAT");
+      });
+    });
+  });
+  describe("when value is greater than 95", () => {
+    it("returns EXCELLENT", () => {
+      [95, 100].forEach((number) => {
+        expect(getSummaryStatus(number)).toEqual("EXCELLENT");
+      });
+    });
+  });
+});

--- a/src/core/PageVitals/helpers.ts
+++ b/src/core/PageVitals/helpers.ts
@@ -1,0 +1,79 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import { SummaryCard, SummaryStatus } from "./types";
+import { VitalsSummaryRecord } from "../models/types";
+
+export function getSummaryStatus(value: number): SummaryStatus {
+  if (value < 70) return "POOR";
+  if (value >= 70 && value < 80) return "NEEDS_IMPROVEMENT";
+  if (value >= 80 && value < 90) return "GOOD";
+  if (value >= 90 && value < 95) return "GREAT";
+  return "EXCELLENT";
+}
+export const getSummaryCards: (
+  summary: VitalsSummaryRecord
+) => SummaryCard[] = (summary) => [
+  {
+    title: "Overall",
+    description: "Average timeliness across all metrics",
+    value: summary.overall,
+    status: getSummaryStatus(summary.overall),
+    id: 1,
+  },
+  {
+    title: "Timely discharge",
+    description: `of clients were discharged at their earliest projected regular
+     supervision discharge date`,
+    value: summary.timelyDischarge,
+    status: getSummaryStatus(summary.timelyDischarge),
+    id: 2,
+  },
+  {
+    title: "Timely FTR enrollment",
+    description:
+      "of clients are not pending enrollment in Free Through Recovery",
+    value: summary.timelyFtrEnrollment,
+    status: getSummaryStatus(summary.timelyFtrEnrollment),
+    id: 3,
+  },
+  {
+    title: "Timely contacts",
+    description: `of clients received initial contact within 30 days of starting
+     supervision and a F2F contact every subsequent 90, 60, or 30 days for 
+     minimum, medium, and maximum supervision levels respectively`,
+    value: summary.timelyContacts,
+    status: getSummaryStatus(summary.timelyContacts),
+    id: 4,
+  },
+  {
+    title: "Timely risk assessments",
+    description: `of clients have had an initial assessment within 30 days and 
+      reassessment within 212 days`,
+    value: summary.timelyRiskAssessments,
+    status: getSummaryStatus(summary.timelyRiskAssessments),
+    id: 5,
+  },
+];
+
+export function getSummaryDetail(
+  summaryCards: SummaryCard[],
+  selectedCardId: number
+): SummaryCard {
+  return (
+    summaryCards.find((card) => card.id === selectedCardId) || summaryCards[0]
+  );
+}

--- a/src/core/PageVitals/index.tsx
+++ b/src/core/PageVitals/index.tsx
@@ -23,8 +23,8 @@ import VitalsSummaryTable from "../VitalsSummaryTable/VitalsSummaryTable";
 import VitalsSummaryChart from "../VitalsSummaryChart";
 import VitalsSummaryDetail from "../VitalsSummaryDetail";
 import { useRootStore } from "../../components/StoreProvider";
-import { SummaryCard, SummaryStatus } from "./types";
 import { VitalsSummaryRecord } from "../models/types";
+import { getSummaryCards, getSummaryDetail } from "./helpers";
 
 import "./PageVitals.scss";
 
@@ -39,67 +39,6 @@ const mockSummary: VitalsSummaryRecord = {
   timelyContacts: 34,
   timelyRiskAssessments: 75,
 };
-
-function getSummaryStatus(value: number): SummaryStatus {
-  if (value < 70) return "POOR";
-  if (value >= 70 && value < 80) return "NEEDS_IMPROVEMENT";
-  if (value >= 80 && value < 90) return "GOOD";
-  if (value >= 90 && value < 95) return "GREAT";
-  return "EXCELLENT";
-}
-const getSummaryCards: (summary: VitalsSummaryRecord) => SummaryCard[] = (
-  summary
-) => [
-  {
-    title: "Overall",
-    description: "Average timeliness across all metrics",
-    value: summary.overall,
-    status: getSummaryStatus(summary.overall),
-    id: 1,
-  },
-  {
-    title: "Timely discharge",
-    description: `of clients were discharged at their earliest projected regular
-     supervision discharge date`,
-    value: summary.timelyDischarge,
-    status: getSummaryStatus(summary.timelyDischarge),
-    id: 2,
-  },
-  {
-    title: "Timely FTR enrollment",
-    description:
-      "of clients are not pending enrollment in Free Through Recovery",
-    value: summary.timelyFtrEnrollment,
-    status: getSummaryStatus(summary.timelyFtrEnrollment),
-    id: 3,
-  },
-  {
-    title: "Timely contacts",
-    description: `of clients received initial contact within 30 days of starting
-     supervision and a F2F contact every subsequent 90, 60, or 30 days for 
-     minimum, medium, and maximum supervision levels respectively`,
-    value: summary.timelyContacts,
-    status: getSummaryStatus(summary.timelyContacts),
-    id: 4,
-  },
-  {
-    title: "Timely risk assessments",
-    description: `of clients have had an initial assessment within 30 days and 
-      reassessment within 212 days`,
-    value: summary.timelyRiskAssessments,
-    status: getSummaryStatus(summary.timelyRiskAssessments),
-    id: 5,
-  },
-];
-
-function getSummaryDetail(
-  summaryCards: SummaryCard[],
-  selectedCardId: number
-): SummaryCard {
-  return (
-    summaryCards.find((card) => card.id === selectedCardId) || summaryCards[0]
-  );
-}
 
 const PageVitals: React.FC = () => {
   const [selectedCardId, setSelectedCardId] = useState(1);

--- a/src/core/PageVitals/index.tsx
+++ b/src/core/PageVitals/index.tsx
@@ -15,27 +15,118 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
 import PageTemplate from "../PageTemplate";
 import VitalsSummaryCards from "../VitalsSummaryCards";
 import VitalsSummaryTable from "../VitalsSummaryTable/VitalsSummaryTable";
 import VitalsSummaryChart from "../VitalsSummaryChart";
+import VitalsSummaryDetail from "../VitalsSummaryDetail";
 import { useRootStore } from "../../components/StoreProvider";
+import { SummaryCard, SummaryStatus } from "./types";
+import { VitalsSummaryRecord } from "../models/types";
+
 import "./PageVitals.scss";
 
+const mockSummary: VitalsSummaryRecord = {
+  entityId: "1",
+  entityName: "North Dakota",
+  overall: 90,
+  overall7Day: 21,
+  overall28Day: 76,
+  timelyDischarge: 97,
+  timelyFtrEnrollment: 80,
+  timelyContacts: 34,
+  timelyRiskAssessments: 75,
+};
+
+function getSummaryStatus(value: number): SummaryStatus {
+  if (value < 70) return "POOR";
+  if (value >= 70 && value < 80) return "NEEDS_IMPROVEMENT";
+  if (value >= 80 && value < 90) return "GOOD";
+  if (value >= 90 && value < 95) return "GREAT";
+  return "EXCELLENT";
+}
+const getSummaryCards: (summary: VitalsSummaryRecord) => SummaryCard[] = (
+  summary
+) => [
+  {
+    title: "Overall",
+    description: "Average timeliness across all metrics",
+    value: summary.overall,
+    status: getSummaryStatus(summary.overall),
+    id: 1,
+  },
+  {
+    title: "Timely discharge",
+    description: `of clients were discharged at their earliest projected regular
+     supervision discharge date`,
+    value: summary.timelyDischarge,
+    status: getSummaryStatus(summary.timelyDischarge),
+    id: 2,
+  },
+  {
+    title: "Timely FTR enrollment",
+    description:
+      "of clients are not pending enrollment in Free Through Recovery",
+    value: summary.timelyFtrEnrollment,
+    status: getSummaryStatus(summary.timelyFtrEnrollment),
+    id: 3,
+  },
+  {
+    title: "Timely contacts",
+    description: `of clients received initial contact within 30 days of starting
+     supervision and a F2F contact every subsequent 90, 60, or 30 days for 
+     minimum, medium, and maximum supervision levels respectively`,
+    value: summary.timelyContacts,
+    status: getSummaryStatus(summary.timelyContacts),
+    id: 4,
+  },
+  {
+    title: "Timely risk assessments",
+    description: `of clients have had an initial assessment within 30 days and 
+      reassessment within 212 days`,
+    value: summary.timelyRiskAssessments,
+    status: getSummaryStatus(summary.timelyRiskAssessments),
+    id: 5,
+  },
+];
+
+function getSummaryDetail(
+  summaryCards: SummaryCard[],
+  selectedCardId: number
+): SummaryCard {
+  return (
+    summaryCards.find((card) => card.id === selectedCardId) || summaryCards[0]
+  );
+}
+
 const PageVitals: React.FC = () => {
+  const [selectedCardId, setSelectedCardId] = useState(1);
   const { tenantStore } = useRootStore();
   const { stateName } = tenantStore;
+
+  const handleSelectCard: (id: number) => () => void = (id) => () => {
+    setSelectedCardId(id);
+  };
+
+  const summaryCards = getSummaryCards(mockSummary);
+  const summaryDetail = getSummaryDetail(summaryCards, selectedCardId);
 
   return (
     <PageTemplate>
       <div className="PageVitals__Title">{stateName}</div>
       <div className="PageVitals__SummaryCards">
-        <VitalsSummaryCards />
+        <VitalsSummaryCards
+          onClick={handleSelectCard}
+          selected={selectedCardId}
+          summaryCards={getSummaryCards(mockSummary)}
+        />
       </div>
       <div className="PageVitals__SummarySection">
-        <div className="PageVitals__SummaryDetail">79%</div>
+        <div className="PageVitals__SummaryDetail">
+          <VitalsSummaryDetail summaryDetail={summaryDetail} />
+        </div>
         <div className="PageVitals__SummaryChart">
           <VitalsSummaryChart />
         </div>

--- a/src/core/PageVitals/types.ts
+++ b/src/core/PageVitals/types.ts
@@ -23,8 +23,9 @@ export type SummaryStatus =
   | "EXCELLENT";
 
 export type SummaryCard = {
-  title: string;
-  percent: number;
-  status: SummaryStatus;
   id: number;
+  title: string;
+  description: string;
+  value: number;
+  status: SummaryStatus;
 };

--- a/src/core/VitalsSummaryCards/VitalsSummaryCard.scss
+++ b/src/core/VitalsSummaryCards/VitalsSummaryCard.scss
@@ -105,6 +105,7 @@
     background-color: #f7fffc;
     &__percent {
       background-image: url("../../assets/static/images/wreath.svg");
+      background-repeat: no-repeat;
       border-radius: 0.5rem;
     }
     &__top-border {

--- a/src/core/VitalsSummaryCards/VitalsSummaryCard.tsx
+++ b/src/core/VitalsSummaryCards/VitalsSummaryCard.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import cn from "classnames";
-import { SummaryStatus } from "./types";
+import { SummaryStatus } from "../PageVitals/types";
 import { formatPercent } from "../../utils/formatStrings";
 import "./VitalsSummaryCard.scss";
 

--- a/src/core/VitalsSummaryDetail/VitalsSummaryDetail.scss
+++ b/src/core/VitalsSummaryDetail/VitalsSummaryDetail.scss
@@ -1,0 +1,53 @@
+@import "../CoreConstants.scss";
+
+.VitalsSummaryDetail {
+  color: $slate-80;
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  padding: 3rem 4rem 0;
+
+  &__title {
+    font: $font-ui-sans-24;
+    letter-spacing: -0.02em;
+    padding: 0 0 1rem;
+  }
+
+  &__status {
+    align-self: center;
+    border: 1px solid;
+    width: 4rem;
+
+    &--POOR {
+      border-color: $crimson-dark;
+    }
+
+    &--NEEDS_IMPROVEMENT {
+      border-color: $crimson;
+    }
+
+    &--GOOD {
+      border-color: #4d9895;
+    }
+
+    &--GREAT,
+    &--EXCELLENT {
+      border-color: #006c67;
+    }
+  }
+
+  &__value {
+    color: $pine-3;
+    font-family: $serif;
+    font-size: 6rem;
+    letter-spacing: -0.025em;
+    line-height: 100%;
+    padding: 3rem 0 1rem;
+  }
+
+  &__description {
+    font: $font-ui-sans-16;
+    letter-spacing: -0.01em;
+    text-align: center;
+  }
+}

--- a/src/core/VitalsSummaryDetail/index.tsx
+++ b/src/core/VitalsSummaryDetail/index.tsx
@@ -16,35 +16,28 @@
 // =============================================================================
 
 import React from "react";
-
-import VitalsSummaryCard from "./VitalsSummaryCard";
 import { SummaryCard } from "../PageVitals/types";
+import { formatPercent } from "../../utils/formatStrings";
+
+import "./VitalsSummaryDetail.scss";
 
 type PropTypes = {
-  summaryCards: SummaryCard[];
-  selected: number;
-  onClick: (id: number) => () => void;
+  summaryDetail: SummaryCard;
 };
-
-const VitalsSummaryCards: React.FC<PropTypes> = ({
-  summaryCards,
-  selected,
-  onClick,
-}) => {
+const VitalsSummaryDetail: React.FC<PropTypes> = ({ summaryDetail }) => {
   return (
-    <>
-      {summaryCards.map(({ title, value, status, id }) => (
-        <VitalsSummaryCard
-          key={id}
-          title={title}
-          percentage={value}
-          status={status}
-          selected={selected === id}
-          onClick={onClick(id)}
-        />
-      ))}
-    </>
+    <div className="VitalsSummaryDetail">
+      <div className="VitalsSummaryDetail__title">{summaryDetail.title}</div>
+      <div
+        className={`VitalsSummaryDetail__status VitalsSummaryDetail__status--${summaryDetail.status}`}
+      />
+      <div className="VitalsSummaryDetail__value">
+        {formatPercent(summaryDetail.value)}
+      </div>
+      <div className="VitalsSummaryDetail__description">
+        {summaryDetail.description}
+      </div>
+    </div>
   );
 };
-
-export default VitalsSummaryCards;
+export default VitalsSummaryDetail;

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -78,3 +78,16 @@ export type VitalsTimeseriesRecord = {
   weeklyAvg: number;
   parentWeeklyAvg: number;
 };
+
+export type VitalsSummaryRecord = {
+  entityId: string;
+  entityName: string; // i.e. "North Dakota" or "Oakes Office"
+  parentEntityId?: string; // not set for top-level
+  overall: number;
+  overall7Day: number;
+  overall28Day: number;
+  timelyDischarge: number;
+  timelyFtrEnrollment: number;
+  timelyContacts: number;
+  timelyRiskAssessments: number;
+};


### PR DESCRIPTION
## Description of the change

This PR adds the vitals summary detail next to the vitals chart. It also moves the state of the selected Vitals summary card to `PageVitals`, which switches the detail we're looking at when a different card is selected.

TODO
- [x] Send a preview app to Sonia for a design QA

Preview: https://recidiviz-dashboard-stag-e1108--vitals-eqtwof6b.web.app/community/vitals

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #946

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
