### PR TITLE
Sort table by clicking on summary metric cards + design polish

### DIFF
--- a/src/core/CoreConstants.scss
+++ b/src/core/CoreConstants.scss
@@ -22,6 +22,7 @@ $pine-3: #00413e;
 $signal-links: #006c67;
 $signal-tooltip: #082249;
 $slate-20: rgba(53, 83, 98, 0.2);
+$slate-30: rgba(53, 83, 98, 0.3);
 $slate-30-opaque: #c2cbd0;
 $slate-60: rgba(53, 83, 98, 0.6);
 $slate-80: rgba(53, 83, 98, 0.8);
@@ -33,6 +34,7 @@ $serif: Libre Baskerville, serif;
 $font-ui-sans-14: 500 0.875rem/1.5rem $sans-serif;
 $font-ui-sans-16: 500 1rem/1.5rem $sans-serif;
 $font-ui-sans-24: 1.5rem/2.5rem $sans-serif;
+$font-ui-serif-34: 400 2.125rem/3rem $serif;
 
 :export {
   crimsonDark: $crimson-dark;

--- a/src/core/PageVitals/helpers.ts
+++ b/src/core/PageVitals/helpers.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { SummaryCard, SummaryStatus } from "./types";
+import { SummaryCard, SummaryStatus, METRIC_TYPES } from "./types";
 import { VitalsSummaryRecord, VitalsTimeSeriesRecord } from "../models/types";
 
 export function getSummaryStatus(value: number): SummaryStatus {
@@ -32,7 +32,7 @@ export const getSummaryCards: (
     description: "Average timeliness across all metrics",
     value: summary.overall,
     status: getSummaryStatus(summary.overall),
-    id: "OVERALL",
+    id: METRIC_TYPES.OVERALL,
   },
   {
     title: "Timely discharge",
@@ -40,7 +40,7 @@ export const getSummaryCards: (
      supervision discharge date`,
     value: summary.timelyDischarge,
     status: getSummaryStatus(summary.timelyDischarge),
-    id: "DISCHARGE",
+    id: METRIC_TYPES.DISCHARGE,
   },
   {
     title: "Timely FTR enrollment",
@@ -48,7 +48,7 @@ export const getSummaryCards: (
       "of clients are not pending enrollment in Free Through Recovery",
     value: summary.timelyFtrEnrollment,
     status: getSummaryStatus(summary.timelyFtrEnrollment),
-    id: "FTR_ENROLLMENT",
+    id: METRIC_TYPES.FTR_ENROLLMENT,
   },
   {
     title: "Timely contacts",
@@ -57,7 +57,7 @@ export const getSummaryCards: (
      minimum, medium, and maximum supervision levels respectively`,
     value: summary.timelyContact,
     status: getSummaryStatus(summary.timelyContact),
-    id: "CONTACT",
+    id: METRIC_TYPES.CONTACT,
   },
   {
     title: "Timely risk assessments",
@@ -65,7 +65,7 @@ export const getSummaryCards: (
       reassessment within 212 days`,
     value: summary.timelyRiskAssessment,
     status: getSummaryStatus(summary.timelyRiskAssessment),
-    id: "RISK_ASSESSMENT",
+    id: METRIC_TYPES.RISK_ASSESSMENT,
   },
 ];
 

--- a/src/core/PageVitals/index.tsx
+++ b/src/core/PageVitals/index.tsx
@@ -24,6 +24,7 @@ import VitalsWeeklyChange from "../VitalsWeeklyChange";
 import VitalsSummaryChart from "../VitalsSummaryChart";
 import VitalsSummaryDetail from "../VitalsSummaryDetail";
 import Loading from "../../components/Loading";
+import { MetricType, METRIC_TYPES } from "./types";
 import { useRootStore } from "../../components/StoreProvider";
 import { VitalsSummaryRecord, VitalsTimeSeriesRecord } from "../models/types";
 import { ChartDataType } from "../types/charts";
@@ -42,7 +43,9 @@ import "./PageVitals.scss";
 const PageVitals: React.FC = () => {
   const { tenantStore } = useRootStore();
   const { stateName } = tenantStore;
-  const [selectedCardId, setSelectedCardId] = useState("OVERALL");
+  const [selectedCardId, setSelectedCardId] = useState<MetricType>(
+    METRIC_TYPES.OVERALL
+  );
   const [currentEntity] = useState("STATE_DOC");
   const { isLoading, isError, apiData }: ChartDataType = useChartData(
     "us_nd/vitals"
@@ -69,7 +72,7 @@ const PageVitals: React.FC = () => {
     apiData.vitals_time_series.data
   );
 
-  const handleSelectCard: (id: string) => () => void = (id) => () => {
+  const handleSelectCard: (id: MetricType) => () => void = (id) => () => {
     setSelectedCardId(id);
   };
 
@@ -104,7 +107,10 @@ const PageVitals: React.FC = () => {
         </div>
       </div>
       <div className="PageVitals__Table">
-        <VitalsSummaryTable summaries={childEntitySummaries} />
+        <VitalsSummaryTable
+          selectedSortBy={selectedCardId}
+          summaries={childEntitySummaries}
+        />
       </div>
     </PageTemplate>
   );

--- a/src/core/PageVitals/types.ts
+++ b/src/core/PageVitals/types.ts
@@ -23,9 +23,19 @@ export type SummaryStatus =
   | "EXCELLENT";
 
 export type SummaryCard = {
-  id: string;
+  id: MetricType;
   title: string;
   description: string;
   value: number;
   status: SummaryStatus;
 };
+
+export type MetricType = keyof typeof METRIC_TYPES;
+
+export const METRIC_TYPES = {
+  OVERALL: "OVERALL",
+  DISCHARGE: "DISCHARGE",
+  FTR_ENROLLMENT: "FTR_ENROLLMENT",
+  CONTACT: "CONTACT",
+  RISK_ASSESSMENT: "RISK_ASSESSMENT",
+} as const;

--- a/src/core/VitalsSummaryCards/VitalsSummaryCard.scss
+++ b/src/core/VitalsSummaryCards/VitalsSummaryCard.scss
@@ -44,27 +44,23 @@
     border-radius: 0.5rem 0.5rem 0 0;
   }
   &__title {
-    font-family: "Libre Franklin", sans-serif;
-    font-weight: 500;
-    line-height: 1.25rem;
-    font-size: 1rem;
-    color: #355362;
+    font: $font-ui-sans-16;
+    color: $slate-80;
     opacity: 0.8;
     width: 50%;
     padding: 0 0.12rem 0 1.56rem;
   }
 
   &__percent {
-    display: flex;
-    justify-content: center;
     align-items: center;
-    width: 50%;
+    color: $pine-3;
+    display: flex;
+    font: $font-ui-serif-34;
     height: 100%;
-    font-family: serif;
-    font-size: 2.12rem;
-    font-weight: 400;
-    line-height: 2.5rem;
-    color: #00413e;
+    justify-content: center;
+    letter-spacing: -0.025em;
+    width: 50%;
+
     span {
       padding-left: 1rem;
     }

--- a/src/core/VitalsSummaryCards/VitalsSummaryCard.scss
+++ b/src/core/VitalsSummaryCards/VitalsSummaryCard.scss
@@ -53,13 +53,15 @@
 
   &__percent {
     align-items: center;
+    background-size: cover;
+    background-position-y: bottom;
     color: $pine-3;
     display: flex;
     font: $font-ui-serif-34;
     height: 100%;
     justify-content: center;
     letter-spacing: -0.025em;
-    width: 50%;
+    width: 100%;
 
     span {
       padding-left: 1rem;

--- a/src/core/VitalsSummaryCards/index.tsx
+++ b/src/core/VitalsSummaryCards/index.tsx
@@ -18,12 +18,12 @@
 import React from "react";
 
 import VitalsSummaryCard from "./VitalsSummaryCard";
-import { SummaryCard } from "../PageVitals/types";
+import { SummaryCard, MetricType } from "../PageVitals/types";
 
 type PropTypes = {
   summaryCards: SummaryCard[];
-  selected: string;
-  onClick: (id: string) => () => void;
+  selected: MetricType;
+  onClick: (id: MetricType) => () => void;
 };
 
 const VitalsSummaryCards: React.FC<PropTypes> = ({

--- a/src/core/VitalsSummaryChart/VitalsSummaryChart.scss
+++ b/src/core/VitalsSummaryChart/VitalsSummaryChart.scss
@@ -6,7 +6,7 @@
   font-weight: 500;
   letter-spacing: -0.01em;
   line-height: 1.5rem;
-  padding: 20px 0;
+  padding: 20px 0 40px;
   width: 100%;
 
   .background-graphics {

--- a/src/core/VitalsSummaryTable/DeltaTableCell.tsx
+++ b/src/core/VitalsSummaryTable/DeltaTableCell.tsx
@@ -16,19 +16,12 @@
 // =============================================================================
 import React from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
-import { formatPercent } from "../../utils";
+import PercentDelta from "../controls/PercentDelta";
 
 const DeltaTableCell: React.FC<{ value: number }> = ({ value }) => {
-  const deltaDirectionClassName = cx({
-    "VitalsSummaryTable__arrow--decreasing": value < 0,
-    "VitalsSummaryTable__arrow--increasing": value > 0,
-    "VitalsSummaryTable__arrow--hidden": value === 0,
-  });
   return (
     <div className="VitalsSummaryTable__change">
-      <div className={deltaDirectionClassName} />
-      {formatPercent(value)}
+      <PercentDelta value={value} width={14} height={12} improvesOnIncrease />
     </div>
   );
 };

--- a/src/core/VitalsSummaryTable/VitalsSummaryTable.scss
+++ b/src/core/VitalsSummaryTable/VitalsSummaryTable.scss
@@ -16,12 +16,14 @@
 // =============================================================================
 @import "../CoreConstants.scss";
 
-$border-styles: 1px solid #d7dde0;
+$border-styles: 1px solid $slate-20;
 
 .VitalsSummaryTable {
   background: $white;
   border-radius: 8px;
   box-shadow: $inset-shadow-30;
+  font: $font-ui-sans-16;
+  letter-spacing: -0.01em;
   margin: 1rem 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -31,7 +33,6 @@ $border-styles: 1px solid #d7dde0;
     background: $white;
     width: 100%;
     text-align: center;
-    font-size: 1rem;
     line-height: 150%;
     font-style: normal;
     letter-spacing: -0.01em;
@@ -39,77 +40,75 @@ $border-styles: 1px solid #d7dde0;
   }
 
   &__table-head {
+    /* Top header row */
     & > :first-child {
-      color: #536d7a;
+      color: $slate-80;
+      font: $font-ui-sans-16;
 
       & > th {
         padding-top: 2rem;
+        font-weight: 500;
       }
 
       & > :first-child {
         border-right: $border-styles;
       }
-    }
 
-    & > :last-child {
-      color: #00413e;
-      font-size: 0.875rem;
-      line-height: 171%;
-      font-weight: 500;
-
-      & > th {
-        padding: 2rem 0;
-      }
-
-      & > :first-child {
-        border-right: $border-styles;
-      }
-    }
-  }
-
-  &__row {
-    :nth-child(n) {
-      font-weight: 300;
-    }
-
-    &:first-child {
       & > :nth-child(2) {
         border-right: $border-styles;
       }
     }
 
-    &:last-child {
-      border-bottom: $border-styles;
+    /* Sortable header row */
+    & > :last-child {
+      color: $pine-3;
+      font: $font-ui-sans-14;
+
+      & > th {
+        padding: 2rem 0;
+        font-weight: 500;
+      }
+
+      & > :first-child {
+        border-right: $border-styles;
+        width: 200px;
+      }
+
       & > :nth-child(4) {
         border-right: $border-styles;
       }
-    }
 
+      & > :nth-child(n + 1) {
+        width: 175px;
+      }
+    }
+  }
+
+  &__row {
     &--value {
       border-top: $border-styles;
+      color: $pine-3;
+      font: $font-ui-sans-16;
+
       & > :first-child {
         border-right: $border-styles;
       }
 
       td {
+        font-weight: 500;
         padding: 20px 0 20px 0;
       }
 
-      :nth-child(n) {
+      :nth-child(n + 5) {
+        font: $font-ui-sans-14;
         font-weight: 400;
-        color: #006c67;
+        color: $pine-3;
       }
+
       &:first-child {
         :nth-child(2) {
           border: none;
         }
-      }
-
-      :nth-child(5),
-      :nth-child(6),
-      :nth-child(7),
-      :nth-child(8) {
-        color: #00413e;
       }
 
       :nth-child(4) {
@@ -132,11 +131,11 @@ $border-styles: 1px solid #d7dde0;
     padding: 3px 0;
 
     &--70 {
-      border-color: #a43939;
+      border-color: $crimson-dark;
     }
 
     &--80 {
-      border-color: #bf7474;
+      border-color: $crimson;
     }
 
     &--90 {
@@ -144,11 +143,11 @@ $border-styles: 1px solid #d7dde0;
     }
 
     &--100 {
-      border-color: #006c67;
+      border-color: $signal-links;
     }
   }
 
-  &__sortable {
+  &__sortable-header {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -160,50 +159,34 @@ $border-styles: 1px solid #d7dde0;
     justify-content: center;
   }
 
-  &__arrow--increasing {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 0 7px 12px 7px;
-    border-color: transparent transparent #006c67 transparent;
-    margin-right: 0.5rem;
-  }
-  &__arrow--decreasing {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 12px 7px 0 7px;
-    margin-right: 0.5rem;
-    border-color: #a43939 transparent transparent transparent;
-  }
-}
+  &__sort {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 0 0.5rem;
 
-.triangle-switcher {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding-left: 0.5rem;
-  &__button {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    margin: 1px;
-    &--up {
-      border-width: 0 5px 5px 5px;
-      border-color: transparent transparent rgba(53, 83, 98, 0.3) transparent;
+    &__button {
+      width: 0;
+      height: 0;
+      border-style: solid;
+      margin: 1px;
+      &--up {
+        border-width: 0 5px 5px 5px;
+        border-color: transparent transparent $slate-30 transparent;
 
-      &.triangle-switcher__button--active {
-        border-color: transparent transparent #006c67 transparent;
+        &.VitalsSummaryTable__sort__button--active {
+          border-color: transparent transparent $signal-links transparent;
+        }
       }
-    }
 
-    &--down {
-      border-width: 5px 5px 0 5px;
-      border-color: rgba(53, 83, 98, 0.3) transparent transparent transparent;
+      &--down {
+        border-width: 5px 5px 0 5px;
+        border-color: rgba(53, 83, 98, 0.3) transparent transparent transparent;
 
-      &.triangle-switcher__button--active {
-        border-color: #006c67 transparent transparent transparent;
+        &.VitalsSummaryTable__sort__button--active {
+          border-color: $signal-links transparent transparent transparent;
+        }
       }
     }
   }

--- a/src/core/VitalsSummaryTable/VitalsSummaryTable.tsx
+++ b/src/core/VitalsSummaryTable/VitalsSummaryTable.tsx
@@ -117,23 +117,23 @@ const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
               {headerGroup.headers.map((column) => (
                 <th {...column.getHeaderProps(column.getSortByToggleProps())}>
                   {column.canSort ? (
-                    <div className="VitalsSummaryTable__sortable">
+                    <div className="VitalsSummaryTable__sortable-header">
                       {column.render("Header")}
-                      <div className="triangle-switcher">
+                      <div className="VitalsSummaryTable__sort">
                         <div
                           className={cx(
-                            "triangle-switcher__button triangle-switcher__button--up",
+                            "VitalsSummaryTable__sort__button VitalsSummaryTable__sort__button--up",
                             {
-                              "triangle-switcher__button--active":
+                              "VitalsSummaryTable__sort__button--active":
                                 column.isSorted && column.isSortedDesc,
                             }
                           )}
                         />
                         <div
                           className={cx(
-                            "triangle-switcher__button triangle-switcher__button--down",
+                            "VitalsSummaryTable__sort__button VitalsSummaryTable__sort__button--down",
                             {
-                              "triangle-switcher__button--active":
+                              "VitalsSummaryTable__sort__button--active":
                                 column.isSorted && !column.isSortedDesc,
                             }
                           )}
@@ -141,7 +141,9 @@ const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
                       </div>
                     </div>
                   ) : (
-                    column.render("Header")
+                    <div className="VitalsSummaryTable__header">
+                      {column.render("Header")}
+                    </div>
                   )}
                 </th>
               ))}

--- a/src/core/VitalsSummaryTable/VitalsSummaryTable.tsx
+++ b/src/core/VitalsSummaryTable/VitalsSummaryTable.tsx
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect } from "react";
 import { useTable, useSortBy } from "react-table";
 import cx from "classnames";
 import BubbleTableCell from "./BubbleTableCell";
 import DeltaTableCell from "./DeltaTableCell";
+import { METRIC_TYPES } from "../PageVitals/types";
 import { formatPercent } from "../../utils";
 
 import "./VitalsSummaryTable.scss";
@@ -26,9 +27,13 @@ import { VitalsSummaryRecord } from "../models/types";
 
 type PropTypes = {
   summaries: VitalsSummaryRecord[];
+  selectedSortBy: string;
 };
 
-const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
+const VitalsSummaryTable: React.FC<PropTypes> = ({
+  summaries,
+  selectedSortBy,
+}) => {
   const createBubbleTableCell = ({ value }: { value: number }) => (
     <BubbleTableCell value={value} />
   );
@@ -37,6 +42,7 @@ const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
     <DeltaTableCell value={value} />
   );
 
+  const data = useMemo(() => summaries, [summaries]);
   const columns = useMemo(
     () => [
       {
@@ -53,6 +59,7 @@ const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
         columns: [
           {
             Header: "Overall score",
+            id: METRIC_TYPES.OVERALL,
             accessor: "overall",
             Cell: ({ value }: { value: number }) => formatPercent(value),
           },
@@ -73,21 +80,25 @@ const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
         columns: [
           {
             Header: "Timely discharge",
+            id: METRIC_TYPES.DISCHARGE,
             accessor: "timelyDischarge",
             Cell: createBubbleTableCell,
           },
           {
             Header: "Program availability",
+            id: METRIC_TYPES.FTR_ENROLLMENT,
             accessor: "timelyFtrEnrollment",
             Cell: createBubbleTableCell,
           },
           {
             Header: "Timely contacts",
+            id: METRIC_TYPES.CONTACT,
             accessor: "timelyContact",
             Cell: createBubbleTableCell,
           },
           {
             Header: "Timely risk assessments",
+            id: METRIC_TYPES.RISK_ASSESSMENT,
             accessor: "timelyRiskAssessment",
             Cell: createBubbleTableCell,
           },
@@ -97,13 +108,29 @@ const VitalsSummaryTable: React.FC<PropTypes> = ({ summaries }) => {
     []
   );
 
+  const sortBy = useMemo(() => ({ id: selectedSortBy, desc: false }), [
+    selectedSortBy,
+  ]);
+
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
     rows,
+    setSortBy,
     prepareRow,
-  } = useTable({ columns, data: summaries }, useSortBy);
+  } = useTable(
+    {
+      columns,
+      data,
+      initialState: { sortBy: [sortBy] },
+    },
+    useSortBy
+  );
+
+  useEffect(() => {
+    setSortBy([sortBy]);
+  }, [setSortBy, sortBy]);
 
   return (
     <div className="VitalsSummaryTable">


### PR DESCRIPTION
## Description of the change

This PR adds:
- `PercentDelta` component on the vitals table
- Sort functionality from the summary cards 
- Initial design polish 

I chatted with @soniachokshi about the table sorting behavior and she said the way its currently working should be fine for launch. The way I implemented this, the `selectedSortBy` prop is passed to the table when a card is clicked, and we use the `react-table`'s hook `setSortBy` to manually set the sort by option. The behavior gets a little strange when the user clicks on any of the other column headers to update the sortBy option and then tries to re-click on an already selected summary card. Re-selecting the already selected summary card won't change the sort. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #942 
> Closes #962 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
