### PR TITLE
Update documentation to reference main branch instead of master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Related, include unit and//or integration tests to cover any new code. Update or
 remove existing test cases where appropriate.
 
 When you are passing linting and testing locally and are satisfied with the
-current state of your work, submit a pull request against `master`. However,
+current state of your work, submit a pull request against `main`. However,
 you can also submit Work In Progress ("WIP") pull requests to gather early
 feedback if you believe it would be helpful. If you do so, please format the
 title as "WIP: My title here" and place the PR in a "Draft" state via Github's UI.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulse Dashboard
 
-[![Build Status](https://travis-ci.org/Recidiviz/pulse-dashboard.svg?branch=master)](https://travis-ci.org/Recidiviz/pulse-dashboard) [![Coverage Status](https://coveralls.io/repos/github/Recidiviz/pulse-dashboard/badge.svg?branch=master)](https://coveralls.io/github/Recidiviz/pulse-dashboard?branch=master)
+[![Build Status](https://travis-ci.org/Recidiviz/pulse-dashboard.svg?branch=main)](https://travis-ci.org/Recidiviz/pulse-dashboard) [![Coverage Status](https://coveralls.io/repos/github/Recidiviz/pulse-dashboard/badge.svg?branch=main)](https://coveralls.io/github/Recidiviz/pulse-dashboard?branch=main)
 
 Bringing criminal justice analysis to decision makers to help reduce incarceration.
 

--- a/shared-filters/README.md
+++ b/shared-filters/README.md
@@ -1,6 +1,6 @@
 # Shared Filters Package
 
-Shared filtering functionality for filtering the optimized data formats on the [frontend](https://github.com/Recidiviz/pulse-dashboard/tree/master/src) and the [backend-server](https://github.com/Recidiviz/pulse-dashboard/tree/master/server).
+Shared filtering functionality for filtering the optimized data formats on the [frontend](https://github.com/Recidiviz/pulse-dashboard/tree/main/src) and the [backend-server](https://github.com/Recidiviz/pulse-dashboard/tree/main/server).
 
 Here's a short description for the some of the main exports:
 


### PR DESCRIPTION
## Description of the change

Updates documentation to reference `main` instead of `master` as the default branch for pulse-dashboard and links to main branch for build status and coverage icons in the README.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Part of #6688

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
