### PR TITLE
Add capacity line to overall incarcerated population chart

### DIFF
--- a/src/core/CoreConstants.scss
+++ b/src/core/CoreConstants.scss
@@ -15,6 +15,8 @@ $inset-shadow-30: inset 0px -1px 1px $box-shadow-color-30;
 $white: #fff;
 $crimson: #bf7474;
 $crimson-dark: #a43939;
+$crimson-dark-50: rgba(164, 57, 57, 0.5);
+$new-color: rgba(164, 57, 57, 0.5);
 $data-forest: #25636f;
 $data-forest-uncertainty: rgba(37, 99, 111, 0.15);
 $indigo: #4c6290;
@@ -54,6 +56,7 @@ $font-ui-serif-34: 400 2.125rem/3rem $serif;
 :export {
   crimson: $crimson;
   crimsonDark: $crimson-dark;
+  crimsonDark50: $crimson-dark-50;
   pine1: $pine-1;
   pine3: $pine-3;
   marble4: $marble-4;

--- a/src/core/CoreConstants.scss
+++ b/src/core/CoreConstants.scss
@@ -16,7 +16,6 @@ $white: #fff;
 $crimson: #bf7474;
 $crimson-dark: #a43939;
 $crimson-dark-50: rgba(164, 57, 57, 0.5);
-$new-color: rgba(164, 57, 57, 0.5);
 $data-forest: #25636f;
 $data-forest-uncertainty: rgba(37, 99, 111, 0.15);
 $indigo: #4c6290;
@@ -57,6 +56,7 @@ $font-ui-serif-34: 400 2.125rem/3rem $serif;
   crimson: $crimson;
   crimsonDark: $crimson-dark;
   crimsonDark50: $crimson-dark-50;
+  indigo: $indigo;
   pine1: $pine-1;
   pine3: $pine-3;
   marble4: $marble-4;
@@ -64,8 +64,8 @@ $font-ui-serif-34: 400 2.125rem/3rem $serif;
   slate30Opaque: $slate-30-opaque;
   slate80: $slate-80;
   slate60: $slate-60;
+  white: $white;
+
   fontUiSans16: $font-ui-sans-16;
   fontUiSans14: $font-ui-sans-14;
-  indigo: $indigo;
-  white: $white;
 }

--- a/src/core/CoreConstants.scss
+++ b/src/core/CoreConstants.scss
@@ -67,12 +67,5 @@ $font-ui-serif-34: 400 2.125rem/3rem $serif;
   fontUiSans16: $font-ui-sans-16;
   fontUiSans14: $font-ui-sans-14;
   indigo: $indigo;
-  marble4: $marble-4;
-  pine1: $pine-1;
-  pine3: $pine-3;
-  signalLinks: $signal-links;
-  slate30Opaque: $slate-30-opaque;
-  slate60: $slate-60;
-  slate80: $slate-80;
   white: $white;
 }

--- a/src/core/PageProjections/PopulationProjectionLastUpdated.scss
+++ b/src/core/PageProjections/PopulationProjectionLastUpdated.scss
@@ -1,6 +1,7 @@
 @import "../CoreConstants";
 
 .PopulationProjectionLastUpdated {
+  color: $slate-80;
   margin-top: -0.5rem;
   margin-bottom: 1.375rem;
   font: $font-ui-sans-14;

--- a/src/core/PageProjections/PopulationProjectionLastUpdated.scss
+++ b/src/core/PageProjections/PopulationProjectionLastUpdated.scss
@@ -1,0 +1,8 @@
+@import "../CoreConstants";
+
+.PopulationProjectionLastUpdated {
+  margin-top: -0.5rem;
+  margin-bottom: 1.375rem;
+  font: $font-ui-sans-14;
+  letter-spacing: -0.01em;
+}

--- a/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
+++ b/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
@@ -1,0 +1,44 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import React from "react";
+import { PopulationProjectionTimeSeriesRecord } from "../models/types";
+import "./PopulationProjectionLastUpdated.scss";
+
+type Props = {
+  projectionTimeSeries: PopulationProjectionTimeSeriesRecord[];
+};
+
+const PopulationProjectionLastUpdated: React.FC<Props> = ({
+  projectionTimeSeries,
+}) => {
+  // Filter records
+  const { year, month } = projectionTimeSeries
+    .filter((d) => d.simulationTag === "HISTORICAL")
+    .sort((a, b) => (a.year === b.year ? a.month - b.month : a.year - b.year))
+    .slice(-1)[0];
+
+  const simulationDate = new Date(year, month - 1, 1);
+
+  return (
+    <div className="PopulationProjectionLastUpdated">
+      Historical and projected population data were generated{" "}
+      {simulationDate.toLocaleString("default", { month: "long" })} {year}.
+    </div>
+  );
+};
+
+export default PopulationProjectionLastUpdated;

--- a/src/core/PageProjections/__tests__/PopulationProjectionLastUpdated.test.js
+++ b/src/core/PageProjections/__tests__/PopulationProjectionLastUpdated.test.js
@@ -1,0 +1,72 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+import { mount } from "enzyme";
+import PopulationProjectionLastUpdated from "../PopulationProjectionLastUpdated";
+
+describe("Tests PopulationProjectionLastUpdated component", () => {
+  const createTimeSeries = (historicalDates, projectedDates) =>
+    historicalDates
+      .map(([year, month]) => ({ year, month, simulationTag: "HISTORICAL" }))
+      .concat(
+        projectedDates.map(([year, month]) => ({
+          year,
+          month,
+          simulationTag: "BASELINE",
+        }))
+      );
+
+  const render = (timeSeries) =>
+    mount(
+      <PopulationProjectionLastUpdated projectionTimeSeries={timeSeries} />
+    );
+
+  it("displays the latest date", () => {
+    const timeSeries = createTimeSeries(
+      [
+        [2020, 4],
+        [2020, 5],
+      ],
+      [
+        [2020, 6],
+        [2020, 7],
+      ]
+    );
+    const lastUpdated = render(timeSeries);
+    expect(
+      lastUpdated.find(".PopulationProjectionLastUpdated").text()
+    ).toContain("May 2020");
+  });
+
+  it("displays the latest date when data is out of order", () => {
+    const timeSeries = createTimeSeries(
+      [
+        [2021, 7],
+        [2021, 6],
+      ],
+      [
+        [2021, 8],
+        [2021, 9],
+      ]
+    );
+    const lastUpdated = render(timeSeries);
+    expect(
+      lastUpdated.find(".PopulationProjectionLastUpdated").text()
+    ).toContain("July 2021");
+  });
+});

--- a/src/core/PageProjections/index.tsx
+++ b/src/core/PageProjections/index.tsx
@@ -27,6 +27,7 @@ import {
 } from "../models/types";
 // import { populationProjectionSummary } from "../models/PopulationProjectionSummaryMetric";
 import PopulationTimeSeriesChart from "../PopulationTimeSeriesChart";
+import PopulationProjectionLastUpdated from "./PopulationProjectionLastUpdated";
 import { populationProjectionTimeSeries } from "../models/PopulationProjectionTimeSeriesMetric";
 import PopulationFilterBar from "../PopulationFilterBar";
 import filterOptions from "../utils/filterOptions";
@@ -81,6 +82,9 @@ const PageProjections: React.FC = () => {
       <PopulationSummaryMetrics
         isError={isError}
         projectionSummaries={projectionTimeSeries}
+      />
+      <PopulationProjectionLastUpdated
+        projectionTimeSeries={projectionTimeSeries}
       />
       <PopulationTimeSeriesChart data={projectionTimeSeries} />
     </PageTemplate>

--- a/src/core/PopulationTimeSeriesChart/index.tsx
+++ b/src/core/PopulationTimeSeriesChart/index.tsx
@@ -183,7 +183,6 @@ const PopulationTimeSeriesChart: React.FC<PropTypes> = ({ data }) => {
               label: "Total Operational Capacity (includes CAPP): 8,008",
               align: "left",
               lineType: null,
-              // @ts-ignore
               color: styles.crimsonDark,
               wrap: 500,
             },

--- a/src/core/PopulationTimeSeriesChart/index.tsx
+++ b/src/core/PopulationTimeSeriesChart/index.tsx
@@ -49,6 +49,8 @@ type PropTypes = {
   data: PopulationProjectionTimeSeriesRecord[];
 };
 
+const TOTAL_INCARCERATED_LIMIT = 8008;
+
 const PopulationTimeSeriesChart: React.FC<PropTypes> = ({ data }) => {
   const filtersStore = usePopulationFiltersStore();
   const { gender, supervisionType, legalStatus } = filtersStore.filters;
@@ -170,7 +172,7 @@ const PopulationTimeSeriesChart: React.FC<PropTypes> = ({ data }) => {
               gender === "ALL" &&
               legalStatus === "ALL" &&
               compartment === "INCARCERATION"
-                ? 8008
+                ? TOTAL_INCARCERATED_LIMIT
                 : 1e6,
             // Need to send this line off of the chart when not looking at all
             // incarcerated people. We need to move it instead of deleting it
@@ -180,7 +182,7 @@ const PopulationTimeSeriesChart: React.FC<PropTypes> = ({ data }) => {
             disable: "connector",
             color: styles.crimsonDark50,
             note: {
-              label: "Total Operational Capacity (includes CAPP): 8,008",
+              label: `Total Operational Capacity (includes CAPP): ${TOTAL_INCARCERATED_LIMIT.toLocaleString()}`,
               align: "left",
               lineType: null,
               color: styles.crimsonDark,

--- a/src/core/PopulationTimeSeriesChart/index.tsx
+++ b/src/core/PopulationTimeSeriesChart/index.tsx
@@ -30,6 +30,7 @@ import "./PopulationTimeSeriesChart.scss";
 import PopulationTimeSeriesLegend from "./PopulationTimeSeriesLegend";
 import { CORE_VIEWS, getViewFromPathname } from "../views";
 import PopulationTimeSeriesTooltip from "./PopulationTimeSeriesTooltip";
+import * as styles from "../CoreConstants.scss";
 
 import {
   ChartPoint,
@@ -143,7 +144,6 @@ const PopulationTimeSeriesChart: React.FC<PropTypes> = ({ data }) => {
         summaries={projectionArea}
         summaryDataAccessor="data"
         summaryClass="projection-area"
-        renderOrder={["summaries", "lines"]}
         annotations={[
           {
             type: "area",
@@ -163,6 +163,32 @@ const PopulationTimeSeriesChart: React.FC<PropTypes> = ({ data }) => {
             connector: { end: "none" },
             dx: -49,
             dy: 370,
+          },
+          {
+            type: "y",
+            value:
+              gender === "ALL" &&
+              legalStatus === "ALL" &&
+              compartment === "INCARCERATION"
+                ? 8008
+                : 1e6,
+            // Need to send this line off of the chart when not looking at all
+            // incarcerated people. We need to move it instead of deleting it
+            // to prevent semiotic from deleting and rerendering the annotation
+            // layer which makes the uncertainty band just appear at its new location
+            // instead of transforming its way there
+            disable: "connector",
+            color: styles.crimsonDark50,
+            note: {
+              label: "Total Operational Capacity (includes CAPP): 8,008",
+              align: "left",
+              lineType: null,
+              // @ts-ignore
+              color: styles.crimsonDark,
+              wrap: 500,
+            },
+            dx: -40,
+            dy: -8,
           },
         ]}
         hoverAnnotation


### PR DESCRIPTION
## Description of the change

Add a lien to the population projection chart indicating the capacity of the system. Currently only displays when viewing the total incarcerated population.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes [recidiviz-data/#6748]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
