### PR TITLE
Enable new race/gender charts for us_pa

### DIFF
--- a/src/flags.js
+++ b/src/flags.js
@@ -5,5 +5,4 @@ export default {
   enableCoreTabNavigation: true,
   enableVitalsDashboard: false,
   enableVitalsOfficerView: false,
-  enableUpdatedRaceGenderCharts: false,
 };

--- a/src/lantern/RevocationsByGender/RevocationsByGender.js
+++ b/src/lantern/RevocationsByGender/RevocationsByGender.js
@@ -27,7 +27,6 @@ import { useDataStore } from "../LanternStoreProvider";
 import { useRootStore } from "../../components/StoreProvider";
 import { genderValueToLabel } from "../../utils/formatStrings";
 import { US_PA } from "../../RootStore/TenantStore/lanternTenants";
-import flags from "../../flags";
 
 const DEFAULT_MODE = "MALE";
 
@@ -37,8 +36,7 @@ const RevocationsByGender = observer(
     const { revocationsChartStore } = useDataStore();
     const CHART_TITLE = translate("revocationsByGenderChartTitle");
     const CHART_ID = translate("revocationsByGenderChartId");
-    const stacked =
-      flags.enableUpdatedRaceGenderCharts && currentTenantId === US_PA;
+    const stacked = currentTenantId === US_PA;
 
     return (
       <RevocationsByDimension

--- a/src/lantern/RevocationsByRace/RevocationsByRace.js
+++ b/src/lantern/RevocationsByRace/RevocationsByRace.js
@@ -26,7 +26,6 @@ import { useRootStore } from "../../components/StoreProvider";
 import { useDataStore } from "../LanternStoreProvider";
 import HorizontalBarChartWithLabels from "../BarCharts/HorizontalBarChartWithLabels";
 import { US_PA } from "../../RootStore/TenantStore/lanternTenants";
-import flags from "../../flags";
 
 const DEFAULT_MODE = "WHITE";
 
@@ -36,8 +35,7 @@ const RevocationsByRace = observer(
     const { currentTenantId } = useRootStore();
     const CHART_TITLE = translate("revocationsByRaceChartTitle");
     const CHART_ID = translate("revocationsByRaceChartId");
-    const stacked =
-      flags.enableUpdatedRaceGenderCharts && currentTenantId === US_PA;
+    const stacked = currentTenantId === US_PA;
 
     return (
       <RevocationsByDimension


### PR DESCRIPTION
## Description of the change

Enables the new race and gender charts for US_PA now that the data is available.

Note: Deploying this requires a simultaneous copying of data from the staging -> prod bucket and refresh of the cache.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1039

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
