### PR TITLE
Center historic and projected data on chart

### DIFF
--- a/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
+++ b/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
@@ -17,6 +17,7 @@
 import React from "react";
 import { PopulationProjectionTimeSeriesRecord } from "../models/types";
 import "./PopulationProjectionLastUpdated.scss";
+import { getSimulationMonth } from "../PopulationTimeSeriesChart/helpers";
 
 type Props = {
   projectionTimeSeries: PopulationProjectionTimeSeriesRecord[];
@@ -25,18 +26,16 @@ type Props = {
 const PopulationProjectionLastUpdated: React.FC<Props> = ({
   projectionTimeSeries,
 }) => {
-  // Filter records
-  const { year, month } = projectionTimeSeries
-    .filter((d) => d.simulationTag === "HISTORICAL")
-    .sort((a, b) => (a.year === b.year ? a.month - b.month : a.year - b.year))
-    .slice(-1)[0];
-
-  const simulationDate = new Date(year, month - 1, 1);
+  const simulationDate = getSimulationMonth(projectionTimeSeries);
 
   return (
     <div className="PopulationProjectionLastUpdated">
       Historical and projected population data were generated{" "}
-      {simulationDate.toLocaleString("default", { month: "long" })} {year}.
+      {simulationDate.toLocaleString("default", {
+        month: "long",
+        year: "numeric",
+      })}
+      .
     </div>
   );
 };

--- a/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
+++ b/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
@@ -15,19 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import React from "react";
-import { PopulationProjectionTimeSeriesRecord } from "../models/types";
 import "./PopulationProjectionLastUpdated.scss";
-import { getSimulationMonth } from "../PopulationTimeSeriesChart/helpers";
 
 type Props = {
-  projectionTimeSeries: PopulationProjectionTimeSeriesRecord[];
+  simulationDate: Date;
 };
 
 const PopulationProjectionLastUpdated: React.FC<Props> = ({
-  projectionTimeSeries,
+  simulationDate,
 }) => {
-  const simulationDate = getSimulationMonth(projectionTimeSeries);
-
   return (
     <div className="PopulationProjectionLastUpdated">
       Historical and projected population data were generated{" "}

--- a/src/core/PageProjections/__tests__/PopulationProjectionLastUpdated.test.js
+++ b/src/core/PageProjections/__tests__/PopulationProjectionLastUpdated.test.js
@@ -20,53 +20,20 @@ import { mount } from "enzyme";
 import PopulationProjectionLastUpdated from "../PopulationProjectionLastUpdated";
 
 describe("Tests PopulationProjectionLastUpdated component", () => {
-  const createTimeSeries = (historicalDates, projectedDates) =>
-    historicalDates
-      .map(([year, month]) => ({ year, month, simulationTag: "HISTORICAL" }))
-      .concat(
-        projectedDates.map(([year, month]) => ({
-          year,
-          month,
-          simulationTag: "BASELINE",
-        }))
-      );
+  const render = (date) =>
+    mount(<PopulationProjectionLastUpdated simulationDate={date} />);
 
-  const render = (timeSeries) =>
-    mount(
-      <PopulationProjectionLastUpdated projectionTimeSeries={timeSeries} />
-    );
-
-  it("displays the latest date", () => {
-    const timeSeries = createTimeSeries(
-      [
-        [2020, 4],
-        [2020, 5],
-      ],
-      [
-        [2020, 6],
-        [2020, 7],
-      ]
-    );
-    const lastUpdated = render(timeSeries);
+  it("displays shot months correctly", () => {
+    const lastUpdated = render(new Date(2020, 4));
     expect(
       lastUpdated.find(".PopulationProjectionLastUpdated").text()
     ).toContain("May 2020");
   });
 
-  it("displays the latest date when data is out of order", () => {
-    const timeSeries = createTimeSeries(
-      [
-        [2021, 7],
-        [2021, 6],
-      ],
-      [
-        [2021, 8],
-        [2021, 9],
-      ]
-    );
-    const lastUpdated = render(timeSeries);
+  it("displays long months correctly", () => {
+    const lastUpdated = render(new Date(2022, 11));
     expect(
       lastUpdated.find(".PopulationProjectionLastUpdated").text()
-    ).toContain("July 2021");
+    ).toContain("December 2022");
   });
 });

--- a/src/core/PageProjections/index.tsx
+++ b/src/core/PageProjections/index.tsx
@@ -35,7 +35,6 @@ const PageProjections: React.FC = () => {
     isError,
     // TODO(recidiviz-data/issues/6185): Uncomment when summary table is valid
     // summaries,
-    timeSeries,
   } = metricsStore.projections;
 
   if (isLoading) {
@@ -65,7 +64,7 @@ const PageProjections: React.FC = () => {
       }
     >
       <PopulationSummaryMetrics isError={isError} />
-      <PopulationProjectionLastUpdated projectionTimeSeries={timeSeries} />
+      <PopulationProjectionLastUpdated />
       <PopulationTimeSeriesChart />
     </PageTemplate>
   );

--- a/src/core/PageProjections/index.tsx
+++ b/src/core/PageProjections/index.tsx
@@ -35,6 +35,7 @@ const PageProjections: React.FC = () => {
     isError,
     // TODO(recidiviz-data/issues/6185): Uncomment when summary table is valid
     // summaries,
+    simulationDate,
   } = metricsStore.projections;
 
   if (isLoading) {
@@ -64,7 +65,7 @@ const PageProjections: React.FC = () => {
       }
     >
       <PopulationSummaryMetrics isError={isError} />
-      <PopulationProjectionLastUpdated />
+      <PopulationProjectionLastUpdated simulationDate={simulationDate} />
       <PopulationTimeSeriesChart />
     </PageTemplate>
   );

--- a/src/core/PopulationSummaryMetrics/TempPopulationSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/TempPopulationSummaryMetrics.tsx
@@ -23,10 +23,7 @@ import { Card, CardSection } from "@recidiviz/case-triage-components";
 import { observer } from "mobx-react-lite";
 import { useLocation } from "react-router-dom";
 import PercentDelta from "../controls/PercentDelta";
-import {
-  CURRENT_YEAR,
-  CURRENT_MONTH,
-} from "../PopulationTimeSeriesChart/helpers";
+import { getSimulationMonth } from "../PopulationTimeSeriesChart/helpers";
 import { getViewFromPathname } from "../views";
 import { formatLargeNumber } from "../../utils/formatStrings";
 import { useCoreStore } from "../CoreStoreProvider";
@@ -140,8 +137,11 @@ const TempPopulationSummaryMetrics: React.FC<PropTypes> = ({
     );
   }
 
+  const simulationMonth = getSimulationMonth(timeSeries);
   const currentData = timeSeries.find(
-    (d) => d.year === CURRENT_YEAR && d.month === CURRENT_MONTH
+    (d) =>
+      d.year === simulationMonth.getFullYear() &&
+      d.month === simulationMonth.getMonth() + 1
   ) as PopulationProjectionTimeSeriesRecord;
 
   const historicalData = timeSeries[0];

--- a/src/core/PopulationSummaryMetrics/TempPopulationSummaryMetrics.tsx
+++ b/src/core/PopulationSummaryMetrics/TempPopulationSummaryMetrics.tsx
@@ -23,9 +23,8 @@ import { Card, CardSection } from "@recidiviz/case-triage-components";
 import { observer } from "mobx-react-lite";
 import { useLocation } from "react-router-dom";
 import PercentDelta from "../controls/PercentDelta";
-import { getSimulationMonth } from "../PopulationTimeSeriesChart/helpers";
 import { getViewFromPathname } from "../views";
-import { formatLargeNumber } from "../../utils/formatStrings";
+import { formatLargeNumber } from "../../utils";
 import { useCoreStore } from "../CoreStoreProvider";
 import type { PopulationProjectionTimeSeriesRecord } from "../models/types";
 import "./LoadingMetrics.scss";
@@ -137,11 +136,11 @@ const TempPopulationSummaryMetrics: React.FC<PropTypes> = ({
     );
   }
 
-  const simulationMonth = getSimulationMonth(timeSeries);
+  const { simulationDate } = metricsStore.projections;
   const currentData = timeSeries.find(
     (d) =>
-      d.year === simulationMonth.getFullYear() &&
-      d.month === simulationMonth.getMonth() + 1
+      d.year === simulationDate.getFullYear() &&
+      d.month === simulationDate.getMonth() + 1
   ) as PopulationProjectionTimeSeriesRecord;
 
   const historicalData = timeSeries[0];

--- a/src/core/PopulationTimeSeriesChart/helpers.ts
+++ b/src/core/PopulationTimeSeriesChart/helpers.ts
@@ -17,9 +17,6 @@
 
 import { PopulationProjectionTimeSeriesRecord } from "../models/types";
 
-export const CURRENT_YEAR = 2021;
-export const CURRENT_MONTH = 1;
-
 export type MonthOptions = 1 | 6 | 12 | 24 | 60;
 
 export type ChartPoint = {
@@ -106,4 +103,15 @@ export const getDateRange = (
   endDate.setDate(endDate.getDate() + offset);
 
   return { beginDate, endDate };
+};
+
+export const getSimulationMonth = (
+  projectionTimeSeries: PopulationProjectionTimeSeriesRecord[]
+): Date => {
+  return getDate(
+    projectionTimeSeries
+      .filter((d) => d.simulationTag === "HISTORICAL")
+      .sort((a, b) => (a.year === b.year ? a.month - b.month : a.year - b.year))
+      .slice(-1)[0]
+  );
 };

--- a/src/core/PopulationTimeSeriesChart/helpers.ts
+++ b/src/core/PopulationTimeSeriesChart/helpers.ts
@@ -32,7 +32,7 @@ export type PreparedData = {
   uncertainty: ChartPoint[];
 };
 
-const getDate = (d: PopulationProjectionTimeSeriesRecord): Date =>
+export const getRecordDate = (d: PopulationProjectionTimeSeriesRecord): Date =>
   new Date(d.year, d.month - 1);
 
 export const prepareData = (
@@ -41,7 +41,7 @@ export const prepareData = (
   const historicalPopulation = data
     .filter((d) => d.simulationTag === "HISTORICAL")
     .map((d) => ({
-      date: getDate(d),
+      date: getRecordDate(d),
       value: d.totalPopulation,
     }));
 
@@ -49,7 +49,7 @@ export const prepareData = (
     data
       .filter((d) => d.simulationTag === "BASELINE")
       .map((d) => ({
-        date: getDate(d),
+        date: getRecordDate(d),
         value: d.totalPopulation,
         lowerBound: d.totalPopulationMin,
         upperBound: d.totalPopulationMax,
@@ -60,10 +60,10 @@ export const prepareData = (
     historicalPopulation[historicalPopulation.length - 1],
     ...data
       .filter((d) => d.simulationTag !== "HISTORICAL")
-      .map((d) => ({ date: getDate(d), value: d.totalPopulationMax })),
+      .map((d) => ({ date: getRecordDate(d), value: d.totalPopulationMax })),
     ...data
       .filter((d) => d.simulationTag !== "HISTORICAL")
-      .map((d) => ({ date: getDate(d), value: d.totalPopulationMin }))
+      .map((d) => ({ date: getRecordDate(d), value: d.totalPopulationMin }))
       .reverse(),
     historicalPopulation[historicalPopulation.length - 1],
   ];
@@ -103,15 +103,4 @@ export const getDateRange = (
   endDate.setDate(endDate.getDate() + offset);
 
   return { beginDate, endDate };
-};
-
-export const getSimulationMonth = (
-  projectionTimeSeries: PopulationProjectionTimeSeriesRecord[]
-): Date => {
-  return getDate(
-    projectionTimeSeries
-      .filter((d) => d.simulationTag === "HISTORICAL")
-      .sort((a, b) => (a.year === b.year ? a.month - b.month : a.year - b.year))
-      .slice(-1)[0]
-  );
 };

--- a/src/core/models/ProjectionsMetrics.ts
+++ b/src/core/models/ProjectionsMetrics.ts
@@ -25,8 +25,7 @@ import {
 import { getCompartmentFromView } from "../views";
 import Metric, { BaseMetricProps } from "./Metric";
 import {
-  CURRENT_MONTH,
-  CURRENT_YEAR,
+  getSimulationMonth,
   MonthOptions,
 } from "../PopulationTimeSeriesChart/helpers";
 
@@ -114,7 +113,7 @@ export default class ProjectionsMetrics extends Metric<MetricRecords> {
     records: PopulationProjectionTimeSeriesRecord[],
     compartment: string
   ): PopulationProjectionTimeSeriesRecord[] {
-    if (!this.rootStore) return records;
+    if (!this.rootStore || !records.length) return records;
     const {
       gender,
       supervisionType,
@@ -127,9 +126,11 @@ export default class ProjectionsMetrics extends Metric<MetricRecords> {
       compartment === "SUPERVISION" ? supervisionType : legalStatus;
     const stepSize = range / 6;
 
+    const simulationMonth = getSimulationMonth(records);
     return records.filter((record: PopulationProjectionTimeSeriesRecord) => {
       const monthsOut =
-        (record.year - CURRENT_YEAR) * 12 + (record.month - CURRENT_MONTH);
+        (record.year - simulationMonth.getFullYear()) * 12 +
+        (record.month - (simulationMonth.getMonth() + 1));
       return (
         record.gender === gender &&
         record.compartment === compartment &&

--- a/src/core/models/ProjectionsMetrics.ts
+++ b/src/core/models/ProjectionsMetrics.ts
@@ -25,8 +25,8 @@ import {
 import { getCompartmentFromView } from "../views";
 import Metric, { BaseMetricProps } from "./Metric";
 import {
-  getSimulationMonth,
   MonthOptions,
+  getRecordDate,
 } from "../PopulationTimeSeriesChart/helpers";
 
 export function recordMatchesSimulationTag(
@@ -126,11 +126,11 @@ export default class ProjectionsMetrics extends Metric<MetricRecords> {
       compartment === "SUPERVISION" ? supervisionType : legalStatus;
     const stepSize = range / 6;
 
-    const simulationMonth = getSimulationMonth(records);
+    const { simulationDate } = this;
     return records.filter((record: PopulationProjectionTimeSeriesRecord) => {
       const monthsOut =
-        (record.year - simulationMonth.getFullYear()) * 12 +
-        (record.month - (simulationMonth.getMonth() + 1));
+        (record.year - simulationDate.getFullYear()) * 12 +
+        (record.month - (simulationDate.getMonth() + 1));
       return (
         record.gender === gender &&
         record.compartment === compartment &&
@@ -176,6 +176,14 @@ export default class ProjectionsMetrics extends Metric<MetricRecords> {
     // TODO(recidiviz-data/issues/6651): Sort data on backend
     return timeSeries.sort((a, b) =>
       a.year !== b.year ? a.year - b.year : a.month - b.month
+    );
+  }
+
+  get simulationDate(): Date {
+    return getRecordDate(
+      this.timeSeries
+        .filter((d) => d.simulationTag === "HISTORICAL")
+        .slice(-1)[0]
     );
   }
 }

--- a/src/core/models/__tests__/ProjectionsMetrics.test.ts
+++ b/src/core/models/__tests__/ProjectionsMetrics.test.ts
@@ -21,14 +21,15 @@ import { callMetricsApi } from "../../../api/metrics/metricsClient";
 import RootStore from "../../../RootStore";
 import ProjectionsMetrics from "../ProjectionsMetrics";
 import { CORE_VIEWS } from "../../views";
+import { PopulationProjectionTimeSeriesRecord } from "../types";
 
 const mockTenantId = "US_ND";
 const mockGetTokenSilently = jest.fn();
 const mockCoreStore = {} as CoreStore;
 const filtersStore = new FiltersStore({ rootStore: mockCoreStore });
 jest.mock("../../PopulationTimeSeriesChart/helpers", () => ({
-  CURRENT_MONTH: 1,
-  CURRENT_YEAR: 2016,
+  getSimulationMonth: (_: PopulationProjectionTimeSeriesRecord) =>
+    new Date(2016, 0),
 }));
 jest
   .spyOn(RootStore, "getTokenSilently", "get")

--- a/src/core/models/__tests__/ProjectionsMetrics.test.ts
+++ b/src/core/models/__tests__/ProjectionsMetrics.test.ts
@@ -21,16 +21,11 @@ import { callMetricsApi } from "../../../api/metrics/metricsClient";
 import RootStore from "../../../RootStore";
 import ProjectionsMetrics from "../ProjectionsMetrics";
 import { CORE_VIEWS } from "../../views";
-import { PopulationProjectionTimeSeriesRecord } from "../types";
 
 const mockTenantId = "US_ND";
 const mockGetTokenSilently = jest.fn();
 const mockCoreStore = {} as CoreStore;
 const filtersStore = new FiltersStore({ rootStore: mockCoreStore });
-jest.mock("../../PopulationTimeSeriesChart/helpers", () => ({
-  getSimulationMonth: (_: PopulationProjectionTimeSeriesRecord) =>
-    new Date(2016, 0),
-}));
 jest
   .spyOn(RootStore, "getTokenSilently", "get")
   .mockReturnValue(mockGetTokenSilently);
@@ -205,6 +200,10 @@ describe("ProjectionsMetrics", () => {
       { month: 1, year: 2016 },
       { month: 5, year: 2016 },
     ]);
+  });
+
+  it("finds the simulation month", () => {
+    expect(metric.simulationDate).toEqual(new Date(2016, 4));
   });
 
   describe("getFilteredDataByView", () => {


### PR DESCRIPTION
## Description of the change

Derive the center of the chart from the last "HISTORICAL" datapoint.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes recidiviz-data/#6749

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
