### PR TITLE
Fix numerators/denominators in stacked horizontal bar chart

### DIFF
--- a/src/lantern/RevocationsByGender/__tests__/createGenerateChartData.test.js
+++ b/src/lantern/RevocationsByGender/__tests__/createGenerateChartData.test.js
@@ -91,76 +91,121 @@ describe("createGenerateChartData", () => {
     expect(chartData.denominators).toEqual(expected.denominators);
   });
 
-  it("does not sum the denominator when there are more than one admission_type", () => {
-    const filteredData = [
-      {
-        admission_type: "SCI_6",
-        level_2_supervision_location: "03",
-        revocation_count: "1",
-        revocation_count_all: "100",
-        gender: "FEMALE",
-        supervision_population_count: "200",
-        supervision_count_all: "220",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-      {
-        admission_type: "SCI_6",
-        level_2_supervision_location: "04",
-        revocation_count: "4",
-        revocation_count_all: "104",
-        gender: "FEMALE",
-        supervision_population_count: "400",
-        supervision_count_all: "440",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-      {
-        admission_type: "SCI_12",
-        level_2_supervision_location: "03",
-        revocation_count: "2",
-        revocation_count_all: "101",
-        gender: "FEMALE",
-        supervision_population_count: "200",
-        supervision_count_all: "220",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-      {
-        admission_type: "SCI_12",
-        level_2_supervision_location: "04",
-        revocation_count: "6",
-        revocation_count_all: "106",
-        gender: "FEMALE",
-        supervision_population_count: "400",
-        supervision_count_all: "4440",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-    ];
-    const statePopulationData = [
-      {
-        gender: "MALE",
-        population_count: "30000",
-        total_state_population_count: "3000000",
-      },
-      {
-        gender: "FEMALE",
-        population_count: "40000",
-        total_state_population_count: "4000000",
-      },
-    ];
-    const expected = {
-      data: ["3.16", "90.91", "1.00"],
-      denominators: [411, 660, 4000000],
-      numerators: [13, 600, 40000],
-    };
-    const chartData = createGenerateChartData({
-      filteredData,
-      statePopulationData,
-    })("FEMALE");
-    expect(chartData.data.datasets[0].data).toEqual(expected.data);
-    expect(chartData.numerators).toEqual(expected.numerators);
-    expect(chartData.denominators).toEqual(expected.denominators);
+  describe("when there are more than one admission_type", () => {
+    let filteredData = [];
+    let statePopulationData = [];
+
+    beforeEach(() => {
+      filteredData = [
+        {
+          admission_type: "SCI_6",
+          level_2_supervision_location: "03",
+          revocation_count: "1",
+          revocation_count_all: "100",
+          gender: "FEMALE",
+          supervision_population_count: "200",
+          supervision_count_all: "220",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+        {
+          admission_type: "SCI_6",
+          level_2_supervision_location: "04",
+          revocation_count: "4",
+          revocation_count_all: "104",
+          gender: "FEMALE",
+          supervision_population_count: "400",
+          supervision_count_all: "440",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+        {
+          admission_type: "SCI_12",
+          level_2_supervision_location: "03",
+          revocation_count: "2",
+          revocation_count_all: "101",
+          gender: "FEMALE",
+          supervision_population_count: "200",
+          supervision_count_all: "220",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+        {
+          admission_type: "SCI_12",
+          level_2_supervision_location: "04",
+          revocation_count: "6",
+          revocation_count_all: "106",
+          gender: "FEMALE",
+          supervision_population_count: "400",
+          supervision_count_all: "4440",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+      ];
+      statePopulationData = [
+        {
+          gender: "MALE",
+          population_count: "30000",
+          total_state_population_count: "3000000",
+        },
+        {
+          gender: "FEMALE",
+          population_count: "40000",
+          total_state_population_count: "4000000",
+        },
+      ];
+    });
+
+    describe("when the chart is not stacked", () => {
+      it("does not sum the denominator", () => {
+        const stacked = false;
+        const expected = {
+          data: ["3.16", "90.91", "1.00"],
+          denominators: [411, 660, 4000000],
+          numerators: [13, 600, 40000],
+        };
+        const chartData = createGenerateChartData(
+          {
+            filteredData,
+            statePopulationData,
+          },
+          stacked
+        )("FEMALE");
+        expect(chartData.data.datasets[0].data).toEqual(expected.data);
+        expect(chartData.numerators).toEqual(expected.numerators);
+        expect(chartData.denominators).toEqual(expected.denominators);
+      });
+    });
+
+    describe("when the chart is stacked", () => {
+      it("does not sum the denominator when there are more than one admission_type", () => {
+        const stacked = true;
+        const expected = {
+          data: [
+            ["0.00", "0.00", "1.00"],
+            ["3.16", "90.91", "1.00"],
+          ],
+          denominators: [
+            [0, 0, 3000000],
+            [411, 660, 4000000],
+          ],
+          numerators: [
+            [0, 0, 30000],
+            [13, 600, 40000],
+          ],
+        };
+        const chartData = createGenerateChartData(
+          {
+            filteredData,
+            statePopulationData,
+          },
+          stacked
+        )();
+        expect(chartData.data.datasets[0].data).toEqual(expected.data[0]);
+        expect(chartData.data.datasets[1].data).toEqual(expected.data[1]);
+        expect(chartData.numerators).toEqual(expected.numerators);
+        expect(chartData.denominators).toEqual(expected.denominators);
+      });
+    });
   });
 });

--- a/src/lantern/RevocationsByRace/__tests__/createGenerateChartData.test.js
+++ b/src/lantern/RevocationsByRace/__tests__/createGenerateChartData.test.js
@@ -194,76 +194,111 @@ describe("createGenerateChartData", () => {
     expect(chartData.denominators).toEqual(expected.denominators);
   });
 
-  it("does not sum the denominator when there are more than one admission_type", () => {
-    const filteredData = [
-      {
-        admission_type: "SCI_6",
-        level_2_supervision_location: "03",
-        revocation_count: "1",
-        revocation_count_all: "100",
-        race: "WHITE",
-        supervision_population_count: "200",
-        supervision_count_all: "220",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-      {
-        admission_type: "SCI_6",
-        level_2_supervision_location: "04",
-        revocation_count: "4",
-        revocation_count_all: "104",
-        race: "WHITE",
-        supervision_population_count: "400",
-        supervision_count_all: "440",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-      {
-        admission_type: "SCI_12",
-        level_2_supervision_location: "03",
-        revocation_count: "2",
-        revocation_count_all: "101",
-        race: "WHITE",
-        supervision_population_count: "200",
-        supervision_count_all: "220",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-      {
-        admission_type: "SCI_12",
-        level_2_supervision_location: "04",
-        revocation_count: "6",
-        revocation_count_all: "106",
-        race: "WHITE",
-        supervision_population_count: "400",
-        supervision_count_all: "4440",
-        recommended_for_revocation_count: "0",
-        recommended_for_revocation_count_all: "0",
-      },
-    ];
-    const statePopulationData = [
-      {
-        race_or_ethnicity: "BLACK",
-        population_count: "30000",
-        total_state_population_count: "3000000",
-      },
-      {
-        race_or_ethnicity: "WHITE",
-        population_count: "40000",
-        total_state_population_count: "4000000",
-      },
-    ];
-    const expected = {
-      data: ["3.16", "90.91", "1.00"],
-      denominators: [411, 660, 4000000],
-      numerators: [13, 600, 40000],
-    };
-    const chartData = createGenerateChartData({
-      filteredData,
-      statePopulationData,
-    })("WHITE");
-    expect(chartData.data.datasets[0].data).toEqual(expected.data);
-    expect(chartData.numerators).toEqual(expected.numerators);
-    expect(chartData.denominators).toEqual(expected.denominators);
+  describe("when there are more than one admission_type", () => {
+    let filteredData = [];
+    let statePopulationData = [];
+
+    beforeEach(() => {
+      filteredData = [
+        {
+          admission_type: "SCI_6",
+          level_2_supervision_location: "03",
+          revocation_count: "1",
+          revocation_count_all: "100",
+          race: "WHITE",
+          supervision_population_count: "200",
+          supervision_count_all: "220",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+        {
+          admission_type: "SCI_6",
+          level_2_supervision_location: "04",
+          revocation_count: "4",
+          revocation_count_all: "104",
+          race: "WHITE",
+          supervision_population_count: "400",
+          supervision_count_all: "440",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+        {
+          admission_type: "SCI_12",
+          level_2_supervision_location: "03",
+          revocation_count: "2",
+          revocation_count_all: "101",
+          race: "WHITE",
+          supervision_population_count: "200",
+          supervision_count_all: "220",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+        {
+          admission_type: "SCI_12",
+          level_2_supervision_location: "04",
+          revocation_count: "6",
+          revocation_count_all: "106",
+          race: "WHITE",
+          supervision_population_count: "400",
+          supervision_count_all: "4440",
+          recommended_for_revocation_count: "0",
+          recommended_for_revocation_count_all: "0",
+        },
+      ];
+      statePopulationData = [
+        {
+          race_or_ethnicity: "BLACK",
+          population_count: "30000",
+          total_state_population_count: "3000000",
+        },
+        {
+          race_or_ethnicity: "WHITE",
+          population_count: "40000",
+          total_state_population_count: "4000000",
+        },
+      ];
+    });
+
+    describe("when the chart is not stacked", () => {
+      it("does not sum the denominator", () => {
+        const stacked = false;
+        const expected = {
+          data: ["3.16", "90.91", "1.00"],
+          denominators: [411, 660, 4000000],
+          numerators: [13, 600, 40000],
+        };
+        const chartData = createGenerateChartData(
+          {
+            filteredData,
+            statePopulationData,
+          },
+          stacked
+        )("WHITE");
+        expect(chartData.data.datasets[0].data).toEqual(expected.data);
+        expect(chartData.numerators).toEqual(expected.numerators);
+        expect(chartData.denominators).toEqual(expected.denominators);
+      });
+    });
+
+    describe("when the chart is stacked", () => {
+      it("does not sum the denominator", () => {
+        const stacked = true;
+        const expected = {
+          data: [["3.16", "90.91", "1.00"]],
+          denominators: [411, 660, 4000000],
+          numerators: [13, 600, 40000],
+        };
+        const chartData = createGenerateChartData(
+          {
+            filteredData,
+            statePopulationData,
+          },
+          stacked
+        )();
+        expect(chartData.data.datasets[0].data).toEqual(expected.data[0]);
+        expect(chartData.numerators[0]).toEqual(expected.numerators);
+        expect(chartData.denominators[0]).toEqual(expected.denominators);
+      });
+    });
   });
 });

--- a/src/lantern/RevocationsByRace/createGenerateChartData.js
+++ b/src/lantern/RevocationsByRace/createGenerateChartData.js
@@ -53,45 +53,11 @@ export const generateDatasets = (dataPoints, denominators) => {
   }));
 };
 
-const createGenerateStackedChartData = ({
-  filteredData,
-  statePopulationData,
-}) => {
+const transformData = (filteredData, statePopulationData) => {
   const raceLabelMap = translate("raceLabelMap");
   const races = Object.keys(raceLabelMap);
-  const { dataPoints, numerators, denominators } = pipe(
-    reduce(createPopulationMap("race"), {}),
-    (data) =>
-      getCounts(
-        data,
-        getStatePopulations(),
-        races,
-        statePopulationData,
-        "race_or_ethnicity"
-      )
-  )(filteredData);
 
-  const datasets = generateDatasets(dataPoints, denominators);
-
-  const data = {
-    labels: getStatePopulationsLabels(),
-    datasets,
-  };
-
-  return {
-    data,
-    numerators,
-    denominators,
-  };
-};
-
-const createGenerateChartDataByMode = (
-  { filteredData, statePopulationData },
-  mode
-) => {
-  const raceLabelMap = translate("raceLabelMap");
-  const races = Object.keys(raceLabelMap);
-  const { dataPoints, numerators, denominators } = pipe(
+  return pipe(
     groupBy((d) => [d.race, d.admission_type]),
     map((dataset) => ({
       race: dataset[0].race,
@@ -148,7 +114,38 @@ const createGenerateChartDataByMode = (
         "race_or_ethnicity"
       )
   )(filteredData);
+};
 
+const createGenerateStackedChartData = ({
+  filteredData,
+  statePopulationData,
+}) => {
+  const { dataPoints, numerators, denominators } = transformData(
+    filteredData,
+    statePopulationData
+  );
+  const datasets = generateDatasets(dataPoints, denominators);
+
+  const data = {
+    labels: getStatePopulationsLabels(),
+    datasets,
+  };
+
+  return {
+    data,
+    numerators,
+    denominators,
+  };
+};
+
+const createGenerateChartDataByMode = (
+  { filteredData, statePopulationData },
+  mode
+) => {
+  const { dataPoints, numerators, denominators } = transformData(
+    filteredData,
+    statePopulationData
+  );
   const datasets = generateDatasets(dataPoints, denominators);
   const datasetIndex = datasets.findIndex(
     (d) => d.label === translate("raceLabelMap")[mode]


### PR DESCRIPTION
## Description of the change

Fixes double counting of numerators/denominators in stacked horizontal bar chart when there are multiple admission_types.

We fixed this in the non stacked race/gender charts, but it did not make it into the new stacked charts during the merge.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
