### PR TITLE
Move mobx configure to the root store

### DIFF
--- a/src/RootStore/index.ts
+++ b/src/RootStore/index.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { computed, makeObservable } from "mobx";
+import { configure, computed, makeObservable } from "mobx";
 import { Auth0ClientOptions, User } from "@auth0/auth0-spa-js";
 import TenantStore from "./TenantStore";
 import UserStore from "./UserStore";
@@ -40,6 +40,19 @@ export function getAuthSettings(): Auth0ClientOptions {
     redirect_uri: `${window.location.origin}`,
   };
 }
+
+// This needs to be called from the RootStore so the instance is exported after
+// mobx is configured.
+configure({
+  // make proxies optional for IE 11 support
+  useProxies: "ifavailable",
+  // activate runtime linting
+  computedRequiresReaction: true,
+  reactionRequiresObservable: true,
+  // This linter gives too many false positives when propTypes is defined
+  // https://mobx.js.org/configuration.html#observablerequiresreaction-boolean
+  observableRequiresReaction: false,
+});
 
 class RootStore {
   tenantStore: TenantStore;

--- a/src/index.js
+++ b/src/index.js
@@ -19,22 +19,10 @@ import "react-app-polyfill/ie11";
 import "react-app-polyfill/stable";
 import React from "react";
 import ReactDOM from "react-dom";
-import { configure } from "mobx";
 
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
-
-configure({
-  // make proxies optional for IE 11 support
-  useProxies: "ifavailable",
-  // activate runtime linting
-  computedRequiresReaction: true,
-  reactionRequiresObservable: true,
-  // This linter gives too many false positives when propTypes is defined
-  // https://mobx.js.org/configuration.html#observablerequiresreaction-boolean
-  observableRequiresReaction: false,
-});
 
 ReactDOM.render(<App />, document.getElementById("root"));
 


### PR DESCRIPTION
## Description of the change

This moves the configuration for mobx that toggles IE11 unsupported features off to the RootStore so that it is called before the RootStore instance is created.

This fixes the production issue found on 4/28/21 that was causing IE11 login flow to crash.

Answer found here: https://github.com/mobxjs/mobx/issues/2642#issuecomment-733809065

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
