### PR TITLE
Consolidate API calls for Goals and Explore pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "test": "yarn test-server && yarn test-filters && yarn test-react",
     "spa": "BROWSER=none react-scripts start",
     "server": "nodemon server.js",
-    "server:dev": "npm-run-all --parallel server redis-server",
-    "server:demo": "IS_DEMO=true yarn server:dev",
+    "server:dev": "env-cmd -e server npm-run-all --parallel server redis-server",
+    "server:demo": "env-cmd -e server,demo yarn server:dev",
     "redis-server": "redis-server",
     "lint": "tsc && eslint '**/*.{js,ts,tsx}'",
     "dev": "env-cmd -e development npm-run-all --parallel spa server:dev",
-    "demo": "npm-run-all --parallel spa server:demo"
+    "demo": "env-cmd -e development,demo npm-run-all --parallel spa server:demo"
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.12.1",

--- a/server/app.js
+++ b/server/app.js
@@ -123,16 +123,10 @@ app.get(
   [checkJwt, ...newRevocationsParamValidations],
   api.newRevocationFile
 );
-app.get("/api/:stateCode/community/goals", checkJwt, api.communityGoals);
+app.get("/api/:stateCode/goals", checkJwt, api.goals);
 app.get("/api/:stateCode/community/explore", checkJwt, api.communityExplore);
-app.get("/api/:stateCode/facilities/goals", checkJwt, api.facilitiesGoals);
 app.get("/api/:stateCode/facilities/explore", checkJwt, api.facilitiesExplore);
 app.get("/api/:stateCode/projections", checkJwt, api.populationProjections);
-app.get(
-  "/api/:stateCode/programming/explore",
-  checkJwt,
-  api.programmingExplore
-);
 app.get("/api/:stateCode/vitals", checkJwt, api.vitals);
 app.post(
   "/api/:stateCode/restrictedAccess",

--- a/server/collections/__tests__/getCollections.test.js
+++ b/server/collections/__tests__/getCollections.test.js
@@ -28,11 +28,9 @@ describe("getCollections", () => {
 
     it("has the collections without dimensions", () => {
       const collections = getCollections("US_ND");
-      expect(collections).toHaveProperty(COLLECTIONS.COMMUNITY_GOALS);
+      expect(collections).toHaveProperty(COLLECTIONS.GOALS);
       expect(collections).toHaveProperty(COLLECTIONS.COMMUNITY_EXPLORE);
-      expect(collections).toHaveProperty(COLLECTIONS.FACILITIES_GOALS);
       expect(collections).toHaveProperty(COLLECTIONS.FACILITIES_EXPLORE);
-      expect(collections).toHaveProperty(COLLECTIONS.PROGRAMMING_EXPLORE);
     });
   });
 

--- a/server/collections/__tests__/getMetricsByType.test.js
+++ b/server/collections/__tests__/getMetricsByType.test.js
@@ -25,11 +25,9 @@ describe("getMetricsByType", () => {
     ["US_MO", COLLECTIONS.NEW_REVOCATION, NewRevocationsMetrics],
     ["US_PA", COLLECTIONS.NEW_REVOCATION, NewRevocationsMetrics],
     ["US_ID", COLLECTIONS.POPULATION_PROJECTIONS, BaseMetrics],
-    ["US_ND", COLLECTIONS.COMMUNITY_GOALS, BaseMetrics],
+    ["US_ND", COLLECTIONS.GOALS, BaseMetrics],
     ["US_ND", COLLECTIONS.COMMUNITY_EXPLORE, BaseMetrics],
-    ["US_ND", COLLECTIONS.FACILITIES_GOALS, BaseMetrics],
     ["US_ND", COLLECTIONS.FACILITIES_EXPLORE, BaseMetrics],
-    ["US_ND", COLLECTIONS.PROGRAMMING_EXPLORE, BaseMetrics],
   ])(
     "stateCode %s for metric %s returns a %p metric class",
     (stateCode, metricType, metricClass) => {

--- a/server/collections/getMetricsByType.js
+++ b/server/collections/getMetricsByType.js
@@ -6,11 +6,9 @@ function getMetricsByType(metricType, stateCode) {
   switch (metricType) {
     case COLLECTIONS.NEW_REVOCATION:
       return new NewRevocationsMetrics(metricType, stateCode);
-    case COLLECTIONS.COMMUNITY_GOALS:
+    case COLLECTIONS.GOALS:
     case COLLECTIONS.COMMUNITY_EXPLORE:
-    case COLLECTIONS.FACILITIES_GOALS:
     case COLLECTIONS.FACILITIES_EXPLORE:
-    case COLLECTIONS.PROGRAMMING_EXPLORE:
     case COLLECTIONS.POPULATION_PROJECTIONS:
     case COLLECTIONS.VITALS:
       return new BaseMetrics(metricType, stateCode);

--- a/server/collections/resources/getCollections.js
+++ b/server/collections/resources/getCollections.js
@@ -141,7 +141,7 @@ function newRevocations(dimensions) {
 }
 
 const CORE_COLLECTIONS = {
-  [COLLECTIONS.COMMUNITY_GOALS]: {
+  [COLLECTIONS.GOALS]: {
     admissions_by_type_by_month: {
       filename: "admissions_by_type_by_month.txt",
     },
@@ -153,6 +153,13 @@ const CORE_COLLECTIONS = {
     },
     average_change_lsir_score_by_period: {
       filename: "average_change_lsir_score_by_period.txt",
+    },
+    avg_days_at_liberty_by_month: {
+      filename: "avg_days_at_liberty_by_month.txt",
+    },
+    reincarcerations_by_month: { filename: "reincarcerations_by_month.txt" },
+    reincarcerations_by_period: {
+      filename: "reincarcerations_by_period.txt",
     },
     revocations_by_month: {
       filename: "revocations_by_month.txt",
@@ -189,6 +196,23 @@ const CORE_COLLECTIONS = {
     case_terminations_by_type_by_officer_by_period: {
       filename: "case_terminations_by_type_by_officer_by_period.txt",
     },
+    ftr_referrals_by_age_by_period: {
+      filename: "ftr_referrals_by_age_by_period.txt",
+    },
+    ftr_referrals_by_gender_by_period: {
+      filename: "ftr_referrals_by_gender_by_period.txt",
+    },
+    ftr_referrals_by_lsir_by_period: {
+      filename: "ftr_referrals_by_lsir_by_period.txt",
+    },
+    ftr_referrals_by_month: { filename: "ftr_referrals_by_month.txt" },
+    ftr_referrals_by_participation_status: {
+      filename: "ftr_referrals_by_participation_status.txt",
+    },
+    ftr_referrals_by_period: { filename: "ftr_referrals_by_period.txt" },
+    ftr_referrals_by_race_and_ethnicity_by_period: {
+      filename: "ftr_referrals_by_race_and_ethnicity_by_period.txt",
+    },
     race_proportions: { filename: "race_proportions.json" },
     revocations_by_month: { filename: "revocations_by_month.txt" },
     revocations_by_officer_by_period: {
@@ -212,15 +236,6 @@ const CORE_COLLECTIONS = {
     },
     site_offices: { filename: "site_offices.json" },
   },
-  [COLLECTIONS.FACILITIES_GOALS]: {
-    avg_days_at_liberty_by_month: {
-      filename: "avg_days_at_liberty_by_month.txt",
-    },
-    reincarcerations_by_month: { filename: "reincarcerations_by_month.txt" },
-    reincarcerations_by_period: {
-      filename: "reincarcerations_by_period.txt",
-    },
-  },
   [COLLECTIONS.FACILITIES_EXPLORE]: {
     admissions_by_type_by_period: {
       filename: "admissions_by_type_by_period.txt",
@@ -241,27 +256,6 @@ const CORE_COLLECTIONS = {
     reincarcerations_by_period: {
       filename: "reincarcerations_by_period.txt",
     },
-  },
-  [COLLECTIONS.PROGRAMMING_EXPLORE]: {
-    ftr_referrals_by_age_by_period: {
-      filename: "ftr_referrals_by_age_by_period.txt",
-    },
-    ftr_referrals_by_gender_by_period: {
-      filename: "ftr_referrals_by_gender_by_period.txt",
-    },
-    ftr_referrals_by_lsir_by_period: {
-      filename: "ftr_referrals_by_lsir_by_period.txt",
-    },
-    ftr_referrals_by_month: { filename: "ftr_referrals_by_month.txt" },
-    ftr_referrals_by_participation_status: {
-      filename: "ftr_referrals_by_participation_status.txt",
-    },
-    ftr_referrals_by_period: { filename: "ftr_referrals_by_period.txt" },
-    ftr_referrals_by_race_and_ethnicity_by_period: {
-      filename: "ftr_referrals_by_race_and_ethnicity_by_period.txt",
-    },
-    race_proportions: { filename: "race_proportions.json" },
-    site_offices: { filename: "site_offices.json" },
   },
   [COLLECTIONS.VITALS]: {
     vitals_summaries: {

--- a/server/constants/collections.js
+++ b/server/constants/collections.js
@@ -1,10 +1,8 @@
 const COLLECTIONS = {
   NEW_REVOCATION: "newRevocation",
-  COMMUNITY_GOALS: "communityGoals",
+  GOALS: "goals",
   COMMUNITY_EXPLORE: "communityExplore",
-  FACILITIES_GOALS: "facilitiesGoals",
   FACILITIES_EXPLORE: "facilitiesExplore",
-  PROGRAMMING_EXPLORE: "programmingExplore",
   POPULATION_PROJECTIONS: "populationProjections",
   VITALS: "vitals",
 };

--- a/server/routes/__tests__/api.test.js
+++ b/server/routes/__tests__/api.test.js
@@ -49,11 +49,9 @@ const {
 const {
   newRevocations,
   newRevocationFile,
-  communityGoals,
+  goals,
   communityExplore,
-  facilitiesGoals,
   facilitiesExplore,
-  programmingExplore,
   refreshCache,
   restrictedAccess,
   responder,
@@ -101,11 +99,9 @@ describe("API GET tests", () => {
   describe("API fetching and caching for GET requests", () => {
     const metricControllers = [
       [newRevocations],
-      [communityGoals],
+      [goals],
       [communityExplore],
-      [facilitiesGoals],
       [facilitiesExplore],
-      [programmingExplore],
     ];
 
     afterEach(async () => {

--- a/server/routes/__tests__/server.test.js
+++ b/server/routes/__tests__/server.test.js
@@ -54,7 +54,7 @@ describe("Server tests", () => {
     process.env = OLD_ENV;
   });
 
-  describe("GET api/:stateCode/facilities/goals", () => {
+  describe("GET api/:stateCode/goals", () => {
     beforeEach(() => {
       process.env = Object.assign(process.env, {
         IS_DEMO: "true",
@@ -65,7 +65,7 @@ describe("Server tests", () => {
     });
     it("should respond with a 200 for a valid stateCode", function () {
       return request(app)
-        .get("/api/US_ND/facilities/goals")
+        .get("/api/US_ND/goals")
         .then((response) => {
           expect(response.statusCode).toEqual(200);
         });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -157,10 +157,9 @@ function newRevocationFile(req, res) {
   }
 }
 
-// TODO(#916): Consolidate API
-function communityGoals(req, res) {
+function goals(req, res) {
   const { stateCode } = req.params;
-  const metricType = "communityGoals";
+  const metricType = "goals";
   const cacheKey = getCacheKey({ stateCode, metricType });
   cacheResponse(
     cacheKey,
@@ -169,22 +168,9 @@ function communityGoals(req, res) {
   );
 }
 
-// TODO(#916): Consolidate API
 function communityExplore(req, res) {
   const { stateCode } = req.params;
   const metricType = "communityExplore";
-  const cacheKey = getCacheKey({ stateCode, metricType });
-  cacheResponse(
-    cacheKey,
-    () => fetchMetrics(stateCode, metricType, null, isDemoMode),
-    responder(res)
-  );
-}
-
-// TODO(#916): Consolidate API
-function facilitiesGoals(req, res) {
-  const { stateCode } = req.params;
-  const metricType = "facilitiesGoals";
   const cacheKey = getCacheKey({ stateCode, metricType });
   cacheResponse(
     cacheKey,
@@ -207,18 +193,6 @@ function facilitiesExplore(req, res) {
 function populationProjections(req, res) {
   const { stateCode } = req.params;
   const metricType = "populationProjections";
-  const cacheKey = getCacheKey({ stateCode, metricType });
-  cacheResponse(
-    cacheKey,
-    () => fetchMetrics(stateCode, metricType, null, isDemoMode),
-    responder(res)
-  );
-}
-
-// TODO(#916): Consolidate API
-function programmingExplore(req, res) {
-  const { stateCode } = req.params;
-  const metricType = "programmingExplore";
   const cacheKey = getCacheKey({ stateCode, metricType });
   cacheResponse(
     cacheKey,
@@ -294,12 +268,10 @@ module.exports = {
   restrictedAccess,
   newRevocations,
   newRevocationFile,
-  communityGoals,
+  goals,
   communityExplore,
-  facilitiesGoals,
   facilitiesExplore,
   populationProjections,
-  programmingExplore,
   vitals,
   responder,
   refreshCache,

--- a/server/utils/__tests__/cacheKeys.test.js
+++ b/server/utils/__tests__/cacheKeys.test.js
@@ -58,11 +58,11 @@ describe("cacheKeys utils", () => {
         expect(
           getCacheKey({
             stateCode: "US_MO",
-            metricType: "communityGoals",
+            metricType: "goals",
             metricName: null,
             cacheKeySubset: {},
           })
-        ).toEqual("US_MO-communityGoals");
+        ).toEqual("US_MO-goals");
       });
     });
 

--- a/src/core/community/Explore.js
+++ b/src/core/community/Explore.js
@@ -54,15 +54,9 @@ import FtrReferralsByGender from "./FtrReferralsByGender";
 import FtrReferralsByAge from "./FtrReferralsByAge";
 
 const CommunityExplore = () => {
-  // TODO(#916): Consolidate API
   const { apiData, isLoading, getTokenSilently } = useChartData(
     "us_nd/community/explore"
   );
-  const {
-    apiData: programmingApiData,
-    isLoading: programmingIsLoading,
-    getTokenSilently: programmingGetTokenSilently,
-  } = useChartData("us_nd/programming/explore");
 
   const [metricType, setMetricType] = useState(defaultMetricType);
   const [metricPeriodMonths, setMetricPeriodMonths] = useState(
@@ -73,7 +67,7 @@ const CommunityExplore = () => {
   );
   const [district, setDistrict] = useState(defaultDistrict);
 
-  if (isLoading || programmingIsLoading) {
+  if (isLoading) {
     return <Loading />;
   }
 
@@ -472,9 +466,7 @@ const CommunityExplore = () => {
             metricPeriodMonths={metricPeriodMonths}
             supervisionType={supervisionType}
             district={district}
-            ftrReferralCountByMonth={
-              programmingApiData.ftr_referrals_by_month.data
-            }
+            ftrReferralCountByMonth={apiData.ftr_referrals_by_month.data}
             getTokenSilently={getTokenSilently}
           />
         }
@@ -486,13 +478,13 @@ const CommunityExplore = () => {
             metricPeriodMonths={metricPeriodMonths}
             supervisionType={supervisionType}
             keyedByOffice
-            officeData={programmingApiData.site_offices.data}
-            dataPointsByOffice={programmingApiData.ftr_referrals_by_period.data}
+            officeData={apiData.site_offices.data}
+            dataPointsByOffice={apiData.ftr_referrals_by_period.data}
             numeratorKeys={["count"]}
             denominatorKeys={["total_supervision_count"]}
             centerLat={47.3}
             centerLong={-100.5}
-            getTokenSilently={programmingGetTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="ftrReferralCountByMonth" />}
@@ -507,9 +499,9 @@ const CommunityExplore = () => {
             supervisionType={supervisionType}
             district={district}
             ftrReferralsByParticipationStatus={
-              programmingApiData.ftr_referrals_by_participation_status.data
+              apiData.ftr_referrals_by_participation_status.data
             }
-            getTokenSilently={programmingGetTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={
@@ -529,11 +521,10 @@ const CommunityExplore = () => {
             supervisionType={supervisionType}
             district={district}
             ftrReferralsByRace={
-              programmingApiData.ftr_referrals_by_race_and_ethnicity_by_period
-                .data
+              apiData.ftr_referrals_by_race_and_ethnicity_by_period.data
             }
-            statePopulationByRace={programmingApiData.race_proportions.data}
-            getTokenSilently={programmingGetTokenSilently}
+            statePopulationByRace={apiData.race_proportions.data}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={
@@ -552,10 +543,8 @@ const CommunityExplore = () => {
             metricPeriodMonths={metricPeriodMonths}
             supervisionType={supervisionType}
             district={district}
-            ftrReferralsByLsir={
-              programmingApiData.ftr_referrals_by_lsir_by_period.data
-            }
-            getTokenSilently={programmingGetTokenSilently}
+            ftrReferralsByLsir={apiData.ftr_referrals_by_lsir_by_period.data}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={
@@ -575,9 +564,9 @@ const CommunityExplore = () => {
             supervisionType={supervisionType}
             district={district}
             ftrReferralsByGender={
-              programmingApiData.ftr_referrals_by_gender_by_period.data
+              apiData.ftr_referrals_by_gender_by_period.data
             }
-            getTokenSilently={programmingGetTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={
@@ -596,9 +585,7 @@ const CommunityExplore = () => {
             metricPeriodMonths={metricPeriodMonths}
             supervisionType={supervisionType}
             district={district}
-            ftrReferralsByAge={
-              programmingApiData.ftr_referrals_by_age_by_period.data
-            }
+            ftrReferralsByAge={apiData.ftr_referrals_by_age_by_period.data}
             getTokenSilently={getTokenSilently}
           />
         }

--- a/src/core/goals/CoreGoalsView.js
+++ b/src/core/goals/CoreGoalsView.js
@@ -33,20 +33,9 @@ import DaysAtLibertySnapshot from "./DaysAtLibertySnapshot";
 import ReincarcerationCountOverTime from "./ReincarcerationCountOverTime";
 
 const CoreGoalsView = () => {
-  // TODO(#916): Consolidate API
-  const {
-    apiData: facilitiesApiData,
-    isLoading: facilitiesIsLoading,
-    getTokenSilently: getFacilitiesTokenSilently,
-  } = useChartData("us_nd/facilities/goals");
+  const { apiData, isLoading, getTokenSilently } = useChartData("us_nd/goals");
 
-  const {
-    apiData: communityApiData,
-    isLoading: communityIsLoading,
-    getTokenSilently: getCommunityTokenSilently,
-  } = useChartData("us_nd/community/goals");
-
-  if (facilitiesIsLoading || communityIsLoading) {
+  if (isLoading) {
     return <Loading />;
   }
 
@@ -61,11 +50,11 @@ const CoreGoalsView = () => {
             metricPeriodMonths={metrics.metricPeriodMonths}
             supervisionType={metrics.supervisionType}
             district={metrics.district}
-            officeData={communityApiData.site_offices.data}
-            revocationCountsByMonth={communityApiData.revocations_by_month.data}
+            officeData={apiData.site_offices.data}
+            revocationCountsByMonth={apiData.revocations_by_month.data}
             header="revocationCountsByMonth-header"
             stateCode="US_ND"
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         geoChart={
@@ -76,13 +65,13 @@ const CoreGoalsView = () => {
             metricPeriodMonths={metrics.metricPeriodMonths}
             supervisionType={metrics.supervisionType}
             keyedByOffice
-            officeData={communityApiData.site_offices.data}
-            dataPointsByOffice={communityApiData.revocations_by_period.data}
+            officeData={apiData.site_offices.data}
+            dataPointsByOffice={apiData.revocations_by_period.data}
             numeratorKeys={["revocation_count"]}
             denominatorKeys={["total_supervision_count"]}
             centerLat={47.3}
             centerLong={-100.5}
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="revocationCountsByMonthGoal" />}
@@ -104,11 +93,11 @@ const CoreGoalsView = () => {
             supervisionType={metrics.supervisionType}
             district={metrics.district}
             supervisionSuccessRates={
-              communityApiData.supervision_termination_by_type_by_month.data
+              apiData.supervision_termination_by_type_by_month.data
             }
             header="supervisionSuccessSnapshot-header"
             stateCode="US_ND"
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         geoChart={
@@ -119,9 +108,9 @@ const CoreGoalsView = () => {
             metricPeriodMonths={metrics.metricPeriodMonths}
             supervisionType={metrics.supervisionType}
             keyedByOffice
-            officeData={communityApiData.site_offices.data}
+            officeData={apiData.site_offices.data}
             dataPointsByOffice={
-              communityApiData.supervision_termination_by_type_by_period.data
+              apiData.supervision_termination_by_type_by_period.data
             }
             numeratorKeys={["successful_termination"]}
             denominatorKeys={[
@@ -130,7 +119,7 @@ const CoreGoalsView = () => {
             ]}
             centerLat={47.3}
             centerLong={-100.5}
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="supervisionSuccessSnapshot" />}
@@ -151,11 +140,11 @@ const CoreGoalsView = () => {
             supervisionType={metrics.supervisionType}
             district={metrics.district}
             lsirScoreChangeByMonth={
-              communityApiData.average_change_lsir_score_by_month.data
+              apiData.average_change_lsir_score_by_month.data
             }
             header="lsirScoreChangeSnapshot-header"
             stateCode="US_ND"
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         geoChart={
@@ -167,15 +156,15 @@ const CoreGoalsView = () => {
             supervisionType={metrics.supervisionType}
             keyedByOffice
             possibleNegativeValues
-            officeData={communityApiData.site_offices.data}
+            officeData={apiData.site_offices.data}
             dataPointsByOffice={
-              communityApiData.average_change_lsir_score_by_period.data
+              apiData.average_change_lsir_score_by_period.data
             }
             numeratorKeys={["average_change"]}
             denominatorKeys={[]}
             centerLat={47.3}
             centerLong={-100.5}
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="lsirScoreChangeSnapshot" />}
@@ -197,11 +186,11 @@ const CoreGoalsView = () => {
             supervisionType={metrics.supervisionType}
             district={metrics.district}
             revocationAdmissionsByMonth={
-              communityApiData.admissions_by_type_by_month.data
+              apiData.admissions_by_type_by_month.data
             }
             header="revocationAdmissionsSnapshot-header"
             stateCode="US_ND"
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         geoChart={
@@ -213,10 +202,8 @@ const CoreGoalsView = () => {
             supervisionType={metrics.supervisionType}
             keyedByOffice
             shareDenominatorAcrossRates
-            officeData={communityApiData.site_offices.data}
-            dataPointsByOffice={
-              communityApiData.admissions_by_type_by_period.data
-            }
+            officeData={apiData.site_offices.data}
+            dataPointsByOffice={apiData.admissions_by_type_by_period.data}
             numeratorKeys={[
               "technicals",
               "non_technicals",
@@ -230,7 +217,7 @@ const CoreGoalsView = () => {
             ]}
             centerLat={47.3}
             centerLong={-100.5}
-            getTokenSilently={getCommunityTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="revocationAdmissionsSnapshotGoal" />}
@@ -247,12 +234,10 @@ const CoreGoalsView = () => {
         chart={
           <DaysAtLibertySnapshot
             metricPeriodMonths={metrics.metricPeriodMonths}
-            daysAtLibertyByMonth={
-              facilitiesApiData.avg_days_at_liberty_by_month.data
-            }
+            daysAtLibertyByMonth={apiData.avg_days_at_liberty_by_month.data}
             header="daysAtLibertySnapshot-header"
             stateCode="US_ND"
-            getTokenSilently={getFacilitiesTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="daysAtLibertySnapshot" />}
@@ -267,11 +252,11 @@ const CoreGoalsView = () => {
             metricPeriodMonths={metrics.metricPeriodMonths}
             district={metrics.district}
             reincarcerationCountsByMonth={
-              facilitiesApiData.reincarcerations_by_month.data
+              apiData.reincarcerations_by_month.data
             }
             header="reincarcerationCountsByMonth-header"
             stateCode="US_ND"
-            getTokenSilently={getFacilitiesTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         geoChart={
@@ -281,14 +266,12 @@ const CoreGoalsView = () => {
             metricType="counts"
             metricPeriodMonths={metrics.metricPeriodMonths}
             stateCode="us_nd"
-            dataPointsByOffice={
-              facilitiesApiData.reincarcerations_by_period.data
-            }
+            dataPointsByOffice={apiData.reincarcerations_by_period.data}
             numeratorKeys={["returns"]}
             denominatorKeys={["total_admissions"]}
             centerLat={47.3}
             centerLong={-100.5}
-            getTokenSilently={getFacilitiesTokenSilently}
+            getTokenSilently={getTokenSilently}
           />
         }
         footer={<Methodology chartId="reincarcerationCountsByMonthGoal" />}


### PR DESCRIPTION
## Description of the change

This consolidates the API so that we have three main endpoints for the core dashboard:
- `/goals`
- `/facilities/explore`
- `/community/explore`

This removes the `/programming/*` endpoint.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #916

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
