### PR TITLE
Use Redis cache instead of memory cache for all metric types

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,12 +1,42 @@
 cron:
-  - description: "Refresh US_PA external cache"
-    url: /api/US_PA/refreshCache
+  - description: "Refresh US_PA newRevocation external cache"
+    url: /api/US_PA/newRevocation/refreshCache
     # Every day at 06:00 UTC / 02:00 EST / 23:00 PST
     schedule: every day 06:00
     target: default
 
-  - description: "Refresh US_MO external cache"
-    url: /api/US_MO/refreshCache
+  - description: "Refresh US_MO newRevocation external cache"
+    url: /api/US_MO/newRevocation/refreshCache
     # Every day at 06:30 UTC / 02:30 EST / 23:30 PST
     schedule: every day 06:30
+    target: default
+
+  - description: "Refresh US_ID populationProjections external cache"
+    url: /api/US_ID/populationProjections/refreshCache
+    # Every day at 07:00 UTC / 03:00 EST / 00:00 PST
+    schedule: every day 07:00
+    target: default
+
+  - description: "Refresh US_ND vitals external cache"
+    url: /api/US_ND/vitals/refreshCache
+    # Every day at 07:00 UTC / 03:00 EST / 00:00 PST
+    schedule: every day 07:00
+    target: default
+
+  - description: "Refresh US_ND goals external cache"
+    url: /api/US_ND/goals/refreshCache
+    # Every day at 07:00 UTC / 03:00 EST / 00:00 PST
+    schedule: every day 07:00
+    target: default
+
+  - description: "Refresh US_ND communityExplore external cache"
+    url: /api/US_ND/communityExplore/refreshCache
+    # Every day at 07:00 UTC / 03:00 EST / 00:00 PST
+    schedule: every day 07:00
+    target: default
+
+  - description: "Refresh US_ND facilitiesExplore external cache"
+    url: /api/US_ND/facilitiesExplore/refreshCache
+    # Every day at 07:00 UTC / 03:00 EST / 00:00 PST
+    schedule: every day 07:00
     target: default

--- a/server/app.js
+++ b/server/app.js
@@ -116,7 +116,11 @@ if (isDemoMode) {
   };
 }
 
-app.get("/api/:stateCode/refreshCache", validateCronRequest, api.refreshCache);
+app.get(
+  "/api/:stateCode/:metricType/refreshCache",
+  validateCronRequest,
+  api.refreshCache
+);
 app.get("/api/:stateCode/newRevocations", checkJwt, api.newRevocations);
 app.get(
   "/api/:stateCode/newRevocations/:file",

--- a/server/core/__tests__/cacheManager.test.js
+++ b/server/core/__tests__/cacheManager.test.js
@@ -37,7 +37,7 @@ describe("cacheManager", () => {
       });
 
       it("returns a memory cache with 'none' store", () => {
-        const cache = getCache("");
+        const cache = getCache();
         expect(cache.store.name).toEqual("none");
       });
     });
@@ -53,7 +53,7 @@ describe("cacheManager", () => {
       });
 
       it("returns a memory cache", () => {
-        const cache = getCache("");
+        const cache = getCache();
         expect(cache.store.name).toEqual("memory");
       });
     });
@@ -67,13 +67,9 @@ describe("cacheManager", () => {
         jest.resetModules();
         getCache = require("../cacheManager").getCache;
       });
-      it("returns a redis cache for newRevocation", () => {
-        const cache = getCache("US_PA-newRevocation-");
-        expect(cache.store.name).toEqual("redis");
-      });
 
-      it("returns a redis cache for facilitiesExplore", () => {
-        const cache = getCache("US_ND-facilitiesExplore");
+      it("returns a redis cache", () => {
+        const cache = getCache();
         expect(cache.store.name).toEqual("redis");
       });
     });

--- a/server/core/__tests__/cacheManager.test.js
+++ b/server/core/__tests__/cacheManager.test.js
@@ -58,7 +58,7 @@ describe("cacheManager", () => {
       });
     });
 
-    describe("when cacheKey includes -newRevocation", () => {
+    describe("all other requests", () => {
       beforeEach(() => {
         process.env = Object.assign(process.env, {
           IS_DEMO: "false",
@@ -67,24 +67,14 @@ describe("cacheManager", () => {
         jest.resetModules();
         getCache = require("../cacheManager").getCache;
       });
-      it("returns a redis cache", () => {
+      it("returns a redis cache for newRevocation", () => {
         const cache = getCache("US_PA-newRevocation-");
         expect(cache.store.name).toEqual("redis");
       });
-    });
 
-    describe("when cacheKey does not include -newRevocation", () => {
-      beforeEach(() => {
-        process.env = Object.assign(process.env, {
-          IS_DEMO: "false",
-          NODE_ENV: "development",
-        });
-        jest.resetModules();
-        getCache = require("../cacheManager").getCache;
-      });
-      it("returns a redis cache", () => {
-        const cache = getCache("");
-        expect(cache.store.name).toEqual("memory");
+      it("returns a redis cache for facilitiesExplore", () => {
+        const cache = getCache("US_ND-facilitiesExplore");
+        expect(cache.store.name).toEqual("redis");
       });
     });
   });

--- a/server/core/__tests__/refreshRedisCache.test.js
+++ b/server/core/__tests__/refreshRedisCache.test.js
@@ -218,46 +218,46 @@ describe("refreshRedisCache", () => {
   });
 
   describe("when metricType is not newRevocation", () => {
-    describe("refreshing the cache for files without subsets", () => {
-      beforeEach(() => {
-        fileName = "random_file_name";
-        metricType = "vitals";
-        metricFile = { [fileName]: fileContents };
-      });
+    beforeEach(() => {
+      metricType = "vitals";
+      metricFile = {
+        fileName: fileContents,
+        secondFileName: fileContents,
+      };
+    });
 
-      it("calls the cache with the correct key and value", (done) => {
-        const cacheKey = `${stateCode}-${metricType}`;
-        refreshRedisCache(
-          mockFetchValue,
-          stateCode,
-          metricType,
-          (err, result) => {
-            expect(err).toBeNull();
-            expect(result).toEqual("OK");
+    it("calls the cache with the correct key and value", (done) => {
+      const cacheKey = `${stateCode}-${metricType}`;
+      refreshRedisCache(
+        mockFetchValue,
+        stateCode,
+        metricType,
+        (err, result) => {
+          expect(err).toBeNull();
+          expect(result).toEqual("OK");
 
-            expect(mockFetchValue).toHaveBeenCalledTimes(1);
-            expect(mockCache.set).toHaveBeenCalledTimes(1);
-            expect(mockCache.set).toHaveBeenCalledWith(cacheKey, metricFile);
-            done();
-          }
-        );
-      });
-
-      it("returns an error response when caching fails", (done) => {
-        const error = new Error("Error setting cache value");
-        mockCache.set.mockImplementationOnce(() => {
-          throw error;
-        });
-
-        refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
+          expect(mockFetchValue).toHaveBeenCalledTimes(1);
           expect(mockCache.set).toHaveBeenCalledTimes(1);
-          expect(err).toEqual(error);
-          expect(Sentry.captureException).toHaveBeenCalledWith(
-            "Error occurred while caching files for metricType: vitals",
-            error
-          );
+          expect(mockCache.set).toHaveBeenCalledWith(cacheKey, metricFile);
           done();
-        });
+        }
+      );
+    });
+
+    it("returns an error response when caching fails", (done) => {
+      const error = new Error("Error setting cache value");
+      mockCache.set.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
+        expect(mockCache.set).toHaveBeenCalledTimes(1);
+        expect(err).toEqual(error);
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          "Error occurred while caching files for metricType: vitals",
+          error
+        );
+        done();
       });
     });
   });

--- a/server/core/__tests__/refreshRedisCache.test.js
+++ b/server/core/__tests__/refreshRedisCache.test.js
@@ -48,8 +48,8 @@ describe("refreshRedisCache", () => {
   let fileName;
   let metricFile;
   let mockFetchValue;
+  let metricType;
   const stateCode = "US_DEMO";
-  const metricType = "metric_type";
   const fileContents = {
     flattenedValueMatrix: "a bunch of numbers",
     metadata: {
@@ -71,146 +71,193 @@ describe("refreshRedisCache", () => {
     jest.clearAllMocks();
   });
 
-  describe("refreshing the cache for files without subsets", () => {
-    beforeEach(() => {
-      fileName = "random_file_name";
-      metricFile = { [fileName]: fileContents };
-    });
-
-    it("calls the cache with the correct key and value", (done) => {
-      const cacheKey = `${stateCode}-${metricType}-${fileName}`;
-      refreshRedisCache(
-        mockFetchValue,
-        stateCode,
-        metricType,
-        (err, result) => {
-          expect(err).toBeNull();
-          expect(result).toEqual("OK");
-
-          expect(mockFetchValue).toHaveBeenCalledTimes(1);
-          expect(mockCache.set).toHaveBeenCalledTimes(1);
-          expect(mockCache.set).toHaveBeenCalledWith(cacheKey, metricFile);
-          done();
-        }
-      );
-    });
-
-    it("returns an error response when caching fails", (done) => {
-      const error = new Error("Error setting cache value");
-      mockCache.set.mockImplementationOnce(() => {
-        throw error;
+  describe("when metricType is newRevocation", () => {
+    describe("refreshing the cache for files without subsets", () => {
+      beforeEach(() => {
+        metricType = "newRevocation";
+        fileName = "random_file_name";
+        metricFile = { [fileName]: fileContents };
       });
 
-      refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
-        expect(mockCache.set).toHaveBeenCalledTimes(1);
-        expect(err).toEqual(error);
-        expect(Sentry.captureException).toHaveBeenCalledWith(
-          "Error occurred while caching files for metricType: metric_type",
-          error
+      it("calls the cache with the correct key and value", (done) => {
+        const cacheKey = `${stateCode}-${metricType}-${fileName}`;
+        refreshRedisCache(
+          mockFetchValue,
+          stateCode,
+          metricType,
+          (err, result) => {
+            expect(err).toBeNull();
+            expect(result).toEqual("OK");
+
+            expect(mockFetchValue).toHaveBeenCalledTimes(1);
+            expect(mockCache.set).toHaveBeenCalledTimes(1);
+            expect(mockCache.set).toHaveBeenCalledWith(cacheKey, metricFile);
+            done();
+          }
         );
-        done();
+      });
+
+      it("returns an error response when caching fails", (done) => {
+        const error = new Error("Error setting cache value");
+        mockCache.set.mockImplementationOnce(() => {
+          throw error;
+        });
+
+        refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
+          expect(mockCache.set).toHaveBeenCalledTimes(1);
+          expect(err).toEqual(error);
+          expect(Sentry.captureException).toHaveBeenCalledWith(
+            "Error occurred while caching files for metricType: newRevocation",
+            error
+          );
+          done();
+        });
+      });
+    });
+
+    describe("refreshing the cache for files that have subsets", () => {
+      beforeEach(() => {
+        fileName = "revocations_matrix_distribution_by_district";
+        metricFile = { [fileName]: fileContents };
+        createSubset.mockImplementation(() => metricFile);
+      });
+
+      it("caches a subset file for each subset combination", (done) => {
+        refreshRedisCache(
+          mockFetchValue,
+          stateCode,
+          metricType,
+          (err, result) => {
+            expect(err).toEqual(null);
+            expect(result).toEqual("OK");
+            expect(createSubset).toHaveBeenCalledTimes(6);
+            [
+              { violation_type: 0, charge_category: 0 },
+              { violation_type: 0, charge_category: 1 },
+              { violation_type: 0, charge_category: 2 },
+              { violation_type: 1, charge_category: 0 },
+              { violation_type: 1, charge_category: 1 },
+              { violation_type: 1, charge_category: 2 },
+            ].forEach((subsetCombination, index) => {
+              const transformedFilters = createSubsetFilters({
+                filters: subsetCombination,
+              });
+              expect(createSubset).toHaveBeenNthCalledWith(
+                index + 1,
+                fileName,
+                transformedFilters,
+                metricFile
+              );
+            });
+            done();
+          }
+        );
+      });
+
+      it("sets the cache key for each possible subset", (done) => {
+        const cacheKeyPrefix = `${stateCode}-${metricType}-${fileName}`;
+
+        refreshRedisCache(
+          mockFetchValue,
+          stateCode,
+          metricType,
+          (err, result) => {
+            expect(err).toEqual(null);
+            expect(result).toEqual("OK");
+            expect(mockCache.set).toHaveBeenCalledTimes(6);
+            [
+              "-charge_category=0-violation_type=0",
+              "-charge_category=1-violation_type=0",
+              "-charge_category=2-violation_type=0",
+              "-charge_category=0-violation_type=1",
+              "-charge_category=1-violation_type=1",
+              "-charge_category=2-violation_type=1",
+            ].forEach((subsetKey, index) => {
+              expect(mockCache.set).toHaveBeenNthCalledWith(
+                index + 1,
+                `${cacheKeyPrefix}${subsetKey}`,
+                metricFile
+              );
+            });
+            done();
+          }
+        );
+      });
+
+      it("returns an error when caching fails", (done) => {
+        const error = new Error("Error setting cache value");
+        mockCache.set.mockImplementationOnce(() => {
+          throw error;
+        });
+
+        refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
+          expect(mockCache.set).toHaveBeenCalledTimes(1);
+          expect(err).toEqual(error);
+          expect(err).toEqual(error);
+          expect(Sentry.captureException).toHaveBeenCalledWith(
+            "Error occurred while caching files for metricType: newRevocation",
+            error
+          );
+          done();
+        });
+      });
+
+      it("returns an error when filtering fails", (done) => {
+        const error = new Error("Error setting cache value");
+        createSubset.mockReset();
+        createSubset.mockImplementationOnce(() => {
+          throw error;
+        });
+        refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
+          expect(mockCache.set).toHaveBeenCalledTimes(0);
+          expect(err).toEqual(error);
+          done();
+        });
       });
     });
   });
 
-  describe("refreshing the cache for files that have subsets", () => {
-    beforeEach(() => {
-      fileName = "revocations_matrix_distribution_by_district";
-      metricFile = { [fileName]: fileContents };
-      createSubset.mockImplementation(() => metricFile);
-    });
-
-    it("caches a subset file for each subset combination", (done) => {
-      refreshRedisCache(
-        mockFetchValue,
-        stateCode,
-        metricType,
-        (err, result) => {
-          expect(err).toEqual(null);
-          expect(result).toEqual("OK");
-          expect(createSubset).toHaveBeenCalledTimes(6);
-          [
-            { violation_type: 0, charge_category: 0 },
-            { violation_type: 0, charge_category: 1 },
-            { violation_type: 0, charge_category: 2 },
-            { violation_type: 1, charge_category: 0 },
-            { violation_type: 1, charge_category: 1 },
-            { violation_type: 1, charge_category: 2 },
-          ].forEach((subsetCombination, index) => {
-            const transformedFilters = createSubsetFilters({
-              filters: subsetCombination,
-            });
-            expect(createSubset).toHaveBeenNthCalledWith(
-              index + 1,
-              fileName,
-              transformedFilters,
-              metricFile
-            );
-          });
-          done();
-        }
-      );
-    });
-
-    it("sets the cache key for each possible subset", (done) => {
-      const cacheKeyPrefix = `${stateCode}-${metricType}-${fileName}`;
-
-      refreshRedisCache(
-        mockFetchValue,
-        stateCode,
-        metricType,
-        (err, result) => {
-          expect(err).toEqual(null);
-          expect(result).toEqual("OK");
-          expect(mockCache.set).toHaveBeenCalledTimes(6);
-          [
-            "-charge_category=0-violation_type=0",
-            "-charge_category=1-violation_type=0",
-            "-charge_category=2-violation_type=0",
-            "-charge_category=0-violation_type=1",
-            "-charge_category=1-violation_type=1",
-            "-charge_category=2-violation_type=1",
-          ].forEach((subsetKey, index) => {
-            expect(mockCache.set).toHaveBeenNthCalledWith(
-              index + 1,
-              `${cacheKeyPrefix}${subsetKey}`,
-              metricFile
-            );
-          });
-          done();
-        }
-      );
-    });
-
-    it("returns an error when caching fails", (done) => {
-      const error = new Error("Error setting cache value");
-      mockCache.set.mockImplementationOnce(() => {
-        throw error;
+  describe("when metricType is not newRevocation", () => {
+    describe("refreshing the cache for files without subsets", () => {
+      beforeEach(() => {
+        fileName = "random_file_name";
+        metricType = "vitals";
+        metricFile = { [fileName]: fileContents };
       });
 
-      refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
-        expect(mockCache.set).toHaveBeenCalledTimes(1);
-        expect(err).toEqual(error);
-        expect(err).toEqual(error);
-        expect(Sentry.captureException).toHaveBeenCalledWith(
-          "Error occurred while caching files for metricType: metric_type",
-          error
+      it("calls the cache with the correct key and value", (done) => {
+        const cacheKey = `${stateCode}-${metricType}`;
+        refreshRedisCache(
+          mockFetchValue,
+          stateCode,
+          metricType,
+          (err, result) => {
+            expect(err).toBeNull();
+            expect(result).toEqual("OK");
+
+            expect(mockFetchValue).toHaveBeenCalledTimes(1);
+            expect(mockCache.set).toHaveBeenCalledTimes(1);
+            expect(mockCache.set).toHaveBeenCalledWith(cacheKey, metricFile);
+            done();
+          }
         );
-        done();
-      });
-    });
-
-    it("returns an error when filtering fails", (done) => {
-      const error = new Error("Error setting cache value");
-      createSubset.mockReset();
-      createSubset.mockImplementationOnce(() => {
-        throw error;
       });
 
-      refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
-        expect(mockCache.set).toHaveBeenCalledTimes(0);
-        expect(err).toEqual(error);
-        done();
+      it("returns an error response when caching fails", (done) => {
+        const error = new Error("Error setting cache value");
+        mockCache.set.mockImplementationOnce(() => {
+          throw error;
+        });
+
+        refreshRedisCache(mockFetchValue, stateCode, metricType, (err) => {
+          expect(mockCache.set).toHaveBeenCalledTimes(1);
+          expect(err).toEqual(error);
+          expect(Sentry.captureException).toHaveBeenCalledWith(
+            "Error occurred while caching files for metricType: vitals",
+            error
+          );
+          done();
+        });
       });
     });
   });

--- a/server/core/cacheManager.js
+++ b/server/core/cacheManager.js
@@ -72,16 +72,12 @@ if (!testEnv) {
   });
 }
 
-function getCache(cacheKey) {
+function getCache() {
   if (testEnv || isDemoMode) {
     return memoryCache;
   }
 
-  if (cacheKey.includes("-newRevocation")) {
-    return redisCache;
-  }
-
-  return memoryCache;
+  return redisCache;
 }
 
 function clearMemoryCache() {
@@ -89,7 +85,7 @@ function clearMemoryCache() {
 }
 
 function cacheResponse(cacheKey, fetchValue, callback) {
-  const cache = getCache(cacheKey);
+  const cache = getCache();
   return cache
     .wrap(cacheKey, fetchValue)
     .then(

--- a/server/core/refreshRedisCache.js
+++ b/server/core/refreshRedisCache.js
@@ -87,11 +87,7 @@ function cacheFiles({ files, metricType, cacheKeyPrefix }) {
       }
     });
   } else {
-    const data = {};
-    Object.keys(files).forEach((fileKey) => {
-      data[fileKey] = files[fileKey];
-    });
-    cachePromises.push(cache.set(cacheKeyPrefix, data));
+    cachePromises.push(cache.set(cacheKeyPrefix, files));
   }
 
   console.log(

--- a/server/core/refreshRedisCache.js
+++ b/server/core/refreshRedisCache.js
@@ -62,29 +62,38 @@ function cacheEachSubsetFile(
   return cachePromises;
 }
 
-function cacheFiles({ files, cacheKeyPrefix }) {
+function cacheFiles({ files, metricType, cacheKeyPrefix }) {
   const cache = getCache(cacheKeyPrefix);
   const cachePromises = [];
   const subsetCombinations = getSubsetCombinations(getSubsetManifest());
 
-  Object.keys(files).forEach((fileKey) => {
-    const cacheKey = `${cacheKeyPrefix}-${fileKey}`;
-    const metricFile = { [fileKey]: files[fileKey] };
+  if (metricType === "newRevocation") {
+    Object.keys(files).forEach((fileKey) => {
+      const cacheKey = `${cacheKeyPrefix}-${fileKey}`;
+      const metricFile = { [fileKey]: files[fileKey] };
 
-    if (FILES_WITH_SUBSETS.includes(fileKey)) {
-      const subsetCachePromises = cacheEachSubsetFile(
-        cache,
-        cacheKey,
-        fileKey,
-        metricFile,
-        subsetCombinations
-      );
-      cachePromises.push(...subsetCachePromises);
-    } else {
-      console.log(`Setting cache for: ${cacheKey}...`);
-      cachePromises.push(cache.set(cacheKey, metricFile));
-    }
-  });
+      if (FILES_WITH_SUBSETS.includes(fileKey)) {
+        const subsetCachePromises = cacheEachSubsetFile(
+          cache,
+          cacheKey,
+          fileKey,
+          metricFile,
+          subsetCombinations
+        );
+        cachePromises.push(...subsetCachePromises);
+      } else {
+        console.log(`Setting cache for: ${cacheKey}...`);
+        cachePromises.push(cache.set(cacheKey, metricFile));
+      }
+    });
+  } else {
+    const data = {};
+    Object.keys(files).forEach((fileKey) => {
+      data[fileKey] = files[fileKey];
+    });
+    cachePromises.push(cache.set(cacheKeyPrefix, data));
+  }
+
   console.log(
     `Waiting for ${cachePromises.length} cache promises to resolve for ${cacheKeyPrefix}...`
   );

--- a/server/routes/__tests__/api.test.js
+++ b/server/routes/__tests__/api.test.js
@@ -61,6 +61,7 @@ const { clearMemoryCache } = require("../../core/cacheManager");
 
 describe("API GET tests", () => {
   const stateCode = "test_id";
+  const metricType = "newRevocation";
 
   beforeAll(() => {
     // Reduce noise in the test
@@ -74,7 +75,10 @@ describe("API GET tests", () => {
     clearMemoryCache();
   });
 
-  function fakeRequest(routeHandler, req = { params: { stateCode } }) {
+  function fakeRequest(
+    routeHandler,
+    req = { params: { stateCode, metricType } }
+  ) {
     return new Promise((resolve) => {
       const send = resolve;
       const status = jest.fn().mockImplementation(() => {
@@ -152,7 +156,7 @@ describe("API GET tests", () => {
       const file = "file_1";
       const filters = { violationType: "ALL" };
       const request = {
-        params: { stateCode, file },
+        params: { stateCode, metricType, file },
         query: filters,
       };
 
@@ -160,7 +164,7 @@ describe("API GET tests", () => {
       expect(fetchAndFilterNewRevocationFile).toHaveBeenCalledWith({
         metricName: file,
         stateCode,
-        metricType: "newRevocation",
+        metricType,
         queryParams: filters,
         isDemoMode: false,
       });
@@ -170,7 +174,7 @@ describe("API GET tests", () => {
       const file = "file_1";
       const filters = { violationType: "ALL" };
       const request = {
-        params: { stateCode, file },
+        params: { stateCode, metricType, file },
         query: filters,
       };
       await requestAndExpectFetchMetricsCalled(
@@ -208,7 +212,10 @@ describe("API GET tests", () => {
   describe("API fetching and caching for POST requests", () => {
     const userEmail = "thirteen@state.gov";
     const userDistrict = "13";
-    let postRequest = { params: { stateCode }, body: { userEmail } };
+    let postRequest = {
+      params: { stateCode, metricType },
+      body: { userEmail },
+    };
     const file = "supervision_location_restricted_access_emails";
 
     afterEach(async () => {

--- a/server/routes/__tests__/server.test.js
+++ b/server/routes/__tests__/server.test.js
@@ -222,7 +222,7 @@ describe("Server tests", () => {
       });
     });
 
-    it("should respond with a 403 when cron job header is invalid", () => {
+    it("should respond with a 403 when cron job header is invalid for newRevocation", () => {
       return request(app)
         .get("/api/US_PA/newRevocation/refreshCache")
         .then((response) => {
@@ -230,9 +230,43 @@ describe("Server tests", () => {
         });
     });
 
-    it("should respond successfully when cron job header is valid", () => {
+    it("should respond successfully when cron job header is valid for newRevocation", () => {
       return request(app)
         .get("/api/US_PA/newRevocation/refreshCache")
+        .set("X-Appengine-Cron", "true")
+        .then((response) => {
+          expect(response.statusCode).toEqual(200);
+        });
+    });
+
+    it("should respond with a 403 when cron job header is invalid for vitals", () => {
+      return request(app)
+        .get("/api/US_ND/vitals/refreshCache")
+        .then((response) => {
+          expect(response.statusCode).toEqual(403);
+        });
+    });
+
+    it("should respond successfully when cron job header is valid for vitals", () => {
+      return request(app)
+        .get("/api/US_ND/vitals/refreshCache")
+        .set("X-Appengine-Cron", "true")
+        .then((response) => {
+          expect(response.statusCode).toEqual(200);
+        });
+    });
+
+    it("should respond with a 403 when cron job header is invalid for goals", () => {
+      return request(app)
+        .get("/api/US_ND/goals/refreshCache")
+        .then((response) => {
+          expect(response.statusCode).toEqual(403);
+        });
+    });
+
+    it("should respond successfully when cron job header is valid for goals", () => {
+      return request(app)
+        .get("/api/US_ND/goals/refreshCache")
         .set("X-Appengine-Cron", "true")
         .then((response) => {
           expect(response.statusCode).toEqual(200);

--- a/server/routes/__tests__/server.test.js
+++ b/server/routes/__tests__/server.test.js
@@ -205,7 +205,7 @@ describe("Server tests", () => {
     });
   });
 
-  describe("GET /api/:stateCode/refreshCache", () => {
+  describe("GET /api/:stateCode/:metricType/refreshCache", () => {
     beforeEach(() => {
       process.env = Object.assign(process.env, {
         IS_DEMO: "false",
@@ -224,7 +224,7 @@ describe("Server tests", () => {
 
     it("should respond with a 403 when cron job header is invalid", () => {
       return request(app)
-        .get("/api/US_PA/refreshCache")
+        .get("/api/US_PA/newRevocation/refreshCache")
         .then((response) => {
           expect(response.statusCode).toEqual(403);
         });
@@ -232,7 +232,7 @@ describe("Server tests", () => {
 
     it("should respond successfully when cron job header is valid", () => {
       return request(app)
-        .get("/api/US_PA/refreshCache")
+        .get("/api/US_PA/newRevocation/refreshCache")
         .set("X-Appengine-Cron", "true")
         .then((response) => {
           expect(response.statusCode).toEqual(200);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -106,12 +106,11 @@ function restrictedAccess(req, res) {
 }
 
 function refreshCache(req, res) {
-  const { stateCode } = req.params;
-  const metricType = "newRevocation";
+  const { stateCode, metricType } = req.params;
   refreshRedisCache(
     () => fetchMetrics(stateCode, metricType, null, isDemoMode),
     stateCode,
-    "newRevocation",
+    metricType,
     responder(res)
   );
 }


### PR DESCRIPTION
## Description of the change

Uses redis cache instead of memory cache for all metric types. This changes the endpoints to use the Redis cache, as well as updates `refreshCache` endpoint to accept `metricType` param which is then used in `refreshRedisCache` to cache files appropriately depending on the metric type.

Also updates the cron schedule to refresh all of the Vitals, goals, and explore data to be refreshed and cached on a nightly basis.

Note: e2e-lantern tests are currently failing because SSO is enabled and the we don't have test accounts working quite yet.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1089

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
