### PR TITLE
Add pre-registration hook that queries restrictions from backend

### DIFF
--- a/src/auth0/hooks/01-pre-registration-setup.js
+++ b/src/auth0/hooks/01-pre-registration-setup.js
@@ -84,7 +84,7 @@ module.exports = function (user, context, cb) {
     }
 
     /** 3. Add the user's restrictions to the app_metadata */
-    // PA and ND do not currently have any sign up or user restrictions
+    // Other states do not currently have any sign up or user restrictions
     const stateCodesWithRestrictions = ["us_id", "us_mo"];
 
     if (stateCodesWithRestrictions.includes(stateCode.toLowerCase())) {

--- a/src/auth0/hooks/01-pre-registration-setup.js
+++ b/src/auth0/hooks/01-pre-registration-setup.js
@@ -85,7 +85,7 @@ module.exports = function (user, context, cb) {
 
     /** 3. Add the user's restrictions to the app_metadata */
     // Other states do not currently have any sign up or user restrictions
-    const stateCodesWithRestrictions = ["us_id", "us_mo"];
+    const stateCodesWithRestrictions = ["us_mo"];
 
     if (stateCodesWithRestrictions.includes(stateCode.toLowerCase())) {
       const Sentry = require("@sentry/node");


### PR DESCRIPTION
## Description of the change

This adds the code that will be used in Auth0's Pre-Registration hook to apply user restrictions to when users first sign up. It's currently configured to only check for restrictions for US_ID and US_MO since those are the only states we have set up. 

The secrets that are added to the Auth0 hook are: 
`SENTRY_DSN` - Used to initialize Sentry for error reporting
`SENTRY_ENV`- Will be either `staging` or `production`
`GOOGLE_APPLICATION_CREDENTIALS` - The service account key file JSON contents
`TARGET_AUDIENCE` - The Client ID of the Recidiviz GAE web resource
`RECIDIVIZ_APP_URL` - The hostname for the Recidiviz GAE web resource

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Related to #1034 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
