### PR TITLE
Population projections download and methodology links

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build-staging": "env-cmd -e staging react-scripts build",
     "test-e2e-lantern": "env-cmd -e e2e wdio ./wdio.conf.js --suite login --suite lantern --retry 2",
     "test-e2e-users": "env-cmd -e e2e,demo wdio ./wdio.conf.js --suite userAccess --retry 2",
+    "test-e2e-core": "env-cmd -e e2e,demo wdio ./wdio.conf.js --suite core --retry 2",
     "test-react": "TZ=UTC react-scripts test --env=jest-environment-jsdom-sixteen",
     "test-server": "TZ=UTC jest ./server",
     "test-filters": "TZ=UTC jest ./shared-filters",

--- a/server/app.js
+++ b/server/app.js
@@ -138,7 +138,10 @@ app.get("/api/:stateCode/community/explore", checkJwt, api.communityExplore);
 app.get("/api/:stateCode/facilities/explore", checkJwt, api.facilitiesExplore);
 app.get("/api/:stateCode/projections", checkJwt, api.populationProjections);
 app.get("/api/:stateCode/vitals", checkJwt, api.vitals);
-
+app.get(
+  "/api/:stateCode/projections/methodology.pdf",
+  api.populationProjectionsMethodology
+);
 app.post(
   "/api/generateFileLink",
   checkJwt,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -185,6 +185,14 @@ function populationProjections(req, res) {
   );
 }
 
+function populationProjectionsMethodology(req, res) {
+  const { stateCode } = req.params;
+  const file = `${path.resolve(
+    "./"
+  )}/server/assets/populationProjections/${stateCode.toLowerCase()}_methodology.pdf`;
+  res.download(file);
+}
+
 function vitals(req, res) {
   const { stateCode } = req.params;
   const metricType = "vitals";
@@ -256,6 +264,7 @@ module.exports = {
   communityExplore,
   facilitiesExplore,
   populationProjections,
+  populationProjectionsMethodology,
   vitals,
   responder,
   refreshCache,

--- a/src/core/CoreNavigation.tsx
+++ b/src/core/CoreNavigation.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import { useLocation, Link } from "react-router-dom";
 import { useRootStore } from "../components/StoreProvider";
+import { useCoreStore } from "./CoreStoreProvider";
 import CoreSectionSelector from "./CoreSectionSelector";
 import CorePageSelector from "./CorePageSelector";
 import TopBarUserMenuForAuthenticatedUser from "../components/TopBar/TopBarUserMenuForAuthenticatedUser";
@@ -31,7 +32,7 @@ import "./CoreNavigation.scss";
 const CoreNavigation: React.FC = () => {
   const { pathname } = useLocation();
   const { currentTenantId } = useRootStore();
-
+  const { setView } = useCoreStore();
   if (!currentTenantId) return null;
 
   // @ts-ignore
@@ -63,7 +64,10 @@ const CoreNavigation: React.FC = () => {
             />
           </Link>
         </div>
-        <CoreSectionSelector menu={menu} />
+        <CoreSectionSelector
+          onClick={(link: string) => setView(link)}
+          menu={menu}
+        />
       </div>
       <div className="CoreNavigation__right">
         {flags.enableCoreTabNavigation && (

--- a/src/core/CoreSectionSelector.tsx
+++ b/src/core/CoreSectionSelector.tsx
@@ -26,9 +26,10 @@ import {
 
 type propTypes = {
   menu: { label: string; link: string }[];
+  onClick: (link: string) => void;
 };
 
-const CoreSectionSelector: React.FC<propTypes> = ({ menu }) => {
+const CoreSectionSelector: React.FC<propTypes> = ({ menu, onClick }) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const toggle = () => setDropdownOpen((prevState) => !prevState);
 
@@ -56,7 +57,7 @@ const CoreSectionSelector: React.FC<propTypes> = ({ menu }) => {
         cssModule={{ transform: "translate3d(0px, 24px, 0px)" }}
       >
         {filteredMenu.map(({ label, link }) => (
-          <Link key={label} to={link}>
+          <Link key={label} to={link} onClick={() => onClick(link)}>
             <DropdownItem className="CoreSectionSelector__item" tag="button">
               {label}
             </DropdownItem>

--- a/src/core/CoreStore/PageProjectionsStore.ts
+++ b/src/core/CoreStore/PageProjectionsStore.ts
@@ -46,8 +46,9 @@ export default class PageProjectionsStore {
     return this.rootStore.metricsStore.projections.timeSeries;
   }
 
-  getTimeSeriesDownloadableData(view: string): DownloadableData | undefined {
+  getTimeSeriesDownloadableData(): DownloadableData | undefined {
     if (!this.timeSeries) return undefined;
+    const { view } = this.rootStore;
     const filteredData = this.rootStore.metricsStore.projections.getFilteredDataByView(
       view
     );
@@ -76,7 +77,8 @@ export default class PageProjectionsStore {
     };
   }
 
-  getFiltersText(view: string): string {
+  getFiltersText(): string {
+    const { view } = this.rootStore;
     const {
       filters: { gender, supervisionType },
       timePeriodLabel,
@@ -100,14 +102,14 @@ export default class PageProjectionsStore {
     return jsFileDownload.start();
   }
 
-  async downloadData(view: string): Promise<void> {
+  async downloadData(): Promise<void> {
     return downloadChartAsData({
-      fileContents: [this.getTimeSeriesDownloadableData(view)],
-      chartTitle: `Population Projections: ${this.getFiltersText(view)}`,
+      fileContents: [this.getTimeSeriesDownloadableData()],
+      chartTitle: `Population Projections: ${this.getFiltersText()}`,
       shouldZipDownload: true,
       getTokenSilently: this.rootStore.userStore.getTokenSilently,
-      includeFiltersRowInCSV: true,
-      filters: { filtersDescription: this.getFiltersText(view) },
+      includeFiltersDescriptionInCSV: true,
+      filters: { filtersDescription: this.getFiltersText() },
       lastUpdatedOn: formatDate(
         this.rootStore.metricsStore.projections.simulationDate
       ),

--- a/src/core/CoreStore/PageProjectionsStore.ts
+++ b/src/core/CoreStore/PageProjectionsStore.ts
@@ -1,0 +1,116 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import { makeAutoObservable } from "mobx";
+import JsFileDownloader from "js-file-downloader";
+import type CoreStore from ".";
+import { PopulationProjectionTimeSeriesRecord } from "../models/types";
+import { DownloadableDataset, DownloadableData } from "../PageVitals/types";
+import {
+  formatMonthAndYear,
+  getRecordDate,
+} from "../PopulationTimeSeriesChart/helpers";
+import { toTitleCase, formatDate } from "../../utils/formatStrings";
+import { getCompartmentFromView } from "../views";
+import { isMobileSafari } from "../../api/exportData/exportDataOnMobileDevices";
+import { downloadChartAsData } from "../../utils/downloads/downloadData";
+
+export default class PageProjectionsStore {
+  protected readonly rootStore;
+
+  constructor({ rootStore }: { rootStore: CoreStore }) {
+    makeAutoObservable(this);
+    this.rootStore = rootStore;
+    this.getTimeSeriesDownloadableData = this.getTimeSeriesDownloadableData.bind(
+      this
+    );
+    this.getFiltersText = this.getFiltersText.bind(this);
+    this.downloadMethodologyPDF = this.downloadMethodologyPDF.bind(this);
+    this.downloadData = this.downloadData.bind(this);
+  }
+
+  get timeSeries(): PopulationProjectionTimeSeriesRecord[] {
+    return this.rootStore.metricsStore.projections.timeSeries;
+  }
+
+  getTimeSeriesDownloadableData(view: string): DownloadableData | undefined {
+    if (!this.timeSeries) return undefined;
+    const filteredData = this.rootStore.metricsStore.projections.getFilteredDataByView(
+      view
+    );
+
+    const datasets = [] as DownloadableDataset[];
+    const data: Record<string, number>[] = [];
+    const labels: string[] = [];
+
+    filteredData.forEach((d: PopulationProjectionTimeSeriesRecord) => {
+      data.push({
+        Population: Math.round(d.totalPopulation),
+        "CI Lower": Math.round(d.totalPopulationMin),
+        "CI Upper": Math.round(d.totalPopulationMax),
+      });
+
+      labels.push(formatMonthAndYear(getRecordDate(d)));
+    });
+
+    datasets.push({ data, label: "" });
+
+    return {
+      chartDatasets: datasets,
+      chartLabels: labels,
+      chartId: "Population Projection",
+      dataExportLabel: "Month",
+    };
+  }
+
+  getFiltersText(view: string): string {
+    const {
+      filters: { gender, supervisionType },
+      timePeriodLabel,
+    } = this.rootStore.filtersStore;
+    const compartment = getCompartmentFromView(view);
+    return `${toTitleCase(
+      compartment
+    )} - ${timePeriodLabel}; Gender: ${toTitleCase(
+      gender
+    )}; Supervision Type: ${toTitleCase(supervisionType)},,,`;
+  }
+
+  async downloadMethodologyPDF(): Promise<void> {
+    const endpoint = `${process.env.REACT_APP_API_URL}/api/${this.rootStore.currentTenantId}/projections/methodology.pdf`;
+    const jsFileDownload = new JsFileDownloader({
+      forceDesktopMode: isMobileSafari,
+      autoStart: false,
+      filename: "methodology.pdf",
+      url: endpoint,
+    });
+    return jsFileDownload.start();
+  }
+
+  async downloadData(view: string): Promise<void> {
+    return downloadChartAsData({
+      fileContents: [this.getTimeSeriesDownloadableData(view)],
+      chartTitle: `Population Projections: ${this.getFiltersText(view)}`,
+      shouldZipDownload: true,
+      getTokenSilently: this.rootStore.userStore.getTokenSilently,
+      includeFiltersRowInCSV: true,
+      filters: { filtersDescription: this.getFiltersText(view) },
+      lastUpdatedOn: formatDate(
+        this.rootStore.metricsStore.projections.simulationDate
+      ),
+    });
+  }
+}

--- a/src/core/CoreStore/PageProjectionsStore.ts
+++ b/src/core/CoreStore/PageProjectionsStore.ts
@@ -34,24 +34,16 @@ export default class PageProjectionsStore {
   constructor({ rootStore }: { rootStore: CoreStore }) {
     makeAutoObservable(this);
     this.rootStore = rootStore;
-    this.getTimeSeriesDownloadableData = this.getTimeSeriesDownloadableData.bind(
-      this
-    );
-    this.getFiltersText = this.getFiltersText.bind(this);
     this.downloadMethodologyPDF = this.downloadMethodologyPDF.bind(this);
     this.downloadData = this.downloadData.bind(this);
   }
 
-  get timeSeries(): PopulationProjectionTimeSeriesRecord[] {
-    return this.rootStore.metricsStore.projections.timeSeries;
-  }
-
-  getTimeSeriesDownloadableData(): DownloadableData | undefined {
-    if (!this.timeSeries) return undefined;
+  get timeSeriesDownloadableData(): DownloadableData | undefined {
     const { view } = this.rootStore;
     const filteredData = this.rootStore.metricsStore.projections.getFilteredDataByView(
       view
     );
+    if (!filteredData) return undefined;
 
     const datasets = [] as DownloadableDataset[];
     const data: Record<string, number>[] = [];
@@ -77,7 +69,7 @@ export default class PageProjectionsStore {
     };
   }
 
-  getFiltersText(): string {
+  get filtersText(): string {
     const { view } = this.rootStore;
     const {
       filters: { gender, supervisionType },
@@ -104,12 +96,12 @@ export default class PageProjectionsStore {
 
   async downloadData(): Promise<void> {
     return downloadChartAsData({
-      fileContents: [this.getTimeSeriesDownloadableData()],
-      chartTitle: `Population Projections: ${this.getFiltersText()}`,
+      fileContents: [this.timeSeriesDownloadableData],
+      chartTitle: `Population Projections: ${this.filtersText}`,
       shouldZipDownload: true,
       getTokenSilently: this.rootStore.userStore.getTokenSilently,
       includeFiltersDescriptionInCSV: true,
-      filters: { filtersDescription: this.getFiltersText() },
+      filters: { filtersDescription: this.filtersText },
       lastUpdatedOn: formatDate(
         this.rootStore.metricsStore.projections.simulationDate
       ),

--- a/src/core/CoreStore/PageVitalsStore.ts
+++ b/src/core/CoreStore/PageVitalsStore.ts
@@ -35,6 +35,8 @@ import {
   VitalsMetric,
 } from "../PageVitals/types";
 import TENANTS from "../../tenants";
+import { downloadChartAsData } from "../../utils/downloads/downloadData";
+import content from "../content";
 
 export function getSummaryStatus(value: number): SummaryStatus {
   if (value < 70) return "POOR";
@@ -56,6 +58,7 @@ export default class PageVitalsStore {
     this.rootStore = rootStore;
     this.currentEntityId = DEFAULT_ENTITY_ID;
     this.selectedMetricId = METRIC_TYPES.OVERALL;
+    this.downloadDataZip = this.downloadDataZip.bind(this);
   }
 
   get summaries(): VitalsSummaryRecord[] {
@@ -260,5 +263,25 @@ export default class PageVitalsStore {
       this.summaryCards.find((card) => card.id === this.selectedMetricId) ||
       this.summaryCards[0]
     );
+  }
+
+  async downloadDataZip(): Promise<void> {
+    if (!this.rootStore.currentTenantId) return;
+
+    const { vitals: vitalsMethodology } = content[
+      this.rootStore.currentTenantId
+    ];
+    return downloadChartAsData({
+      fileContents: [
+        this.timeSeriesDownloadableData,
+        this.summaryDownloadableData,
+      ],
+      chartTitle: `${this.rootStore.tenantStore.stateName} At A Glance`,
+      shouldZipDownload: true,
+      methodology: vitalsMethodology.content,
+      getTokenSilently: this.rootStore.userStore.getTokenSilently,
+      filters: this.filtersText,
+      lastUpdatedOn: this.lastUpdatedOn,
+    });
   }
 }

--- a/src/core/CoreStore/PageVitalsStore.ts
+++ b/src/core/CoreStore/PageVitalsStore.ts
@@ -58,7 +58,7 @@ export default class PageVitalsStore {
     this.rootStore = rootStore;
     this.currentEntityId = DEFAULT_ENTITY_ID;
     this.selectedMetricId = METRIC_TYPES.OVERALL;
-    this.downloadDataZip = this.downloadDataZip.bind(this);
+    this.downloadData = this.downloadData.bind(this);
   }
 
   get summaries(): VitalsSummaryRecord[] {
@@ -265,7 +265,7 @@ export default class PageVitalsStore {
     );
   }
 
-  async downloadDataZip(): Promise<void> {
+  async downloadData(): Promise<void> {
     if (!this.rootStore.currentTenantId) return;
 
     const { vitals: vitalsMethodology } = content[
@@ -278,7 +278,7 @@ export default class PageVitalsStore {
       ],
       chartTitle: `${this.rootStore.tenantStore.stateName} At A Glance`,
       shouldZipDownload: true,
-      methodology: vitalsMethodology.content,
+      methodologyContent: vitalsMethodology.content,
       getTokenSilently: this.rootStore.userStore.getTokenSilently,
       filters: this.filtersText,
       lastUpdatedOn: this.lastUpdatedOn,

--- a/src/core/CoreStore/__tests__/PageProjectionsStore.test.ts
+++ b/src/core/CoreStore/__tests__/PageProjectionsStore.test.ts
@@ -1,0 +1,121 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import PageProjectionsStore from "../PageProjectionsStore";
+import RootStore from "../../../RootStore";
+import CoreStore from "..";
+
+jest.mock("../../models/ProjectionsMetrics", () => {
+  return jest.fn().mockImplementation(() => ({
+    getFilteredDataByView: () => [
+      {
+        year: 2021,
+        month: 1,
+        compartment: "SUPERVISION",
+        legalStatus: "PAROLE",
+        gender: "MALE",
+        totalPopulation: 1000,
+        totalPopulationMax: 1200,
+        totalPopulationMin: 900,
+      },
+      {
+        year: 2021,
+        month: 2,
+        compartment: "SUPERVISION",
+        legalStatus: "PAROLE",
+        gender: "MALE",
+        totalPopulation: 2000,
+        totalPopulationMax: 2100,
+        totalPopulationMin: 1900,
+      },
+      {
+        year: 2021,
+        month: 3,
+        compartment: "SUPERVISION",
+        legalStatus: "PAROLE",
+        gender: "MALE",
+        totalPopulation: 1000,
+        totalPopulationMax: 1200,
+        totalPopulationMin: 900,
+      },
+    ],
+  }));
+});
+jest.mock("../../models/VitalsMetrics");
+jest.mock("../../../RootStore/TenantStore", () => {
+  return jest.fn().mockImplementation(() => ({
+    currentTenantId: "US_ID",
+  }));
+});
+
+let coreStore: CoreStore;
+let pageProjectionsStore: PageProjectionsStore;
+
+describe("PageProjectionsStore", () => {
+  beforeEach(() => {
+    coreStore = new CoreStore(RootStore);
+    pageProjectionsStore = coreStore.pageProjectionsStore;
+  });
+
+  describe("timeSeriesDownloadableData", () => {
+    it("returns the data formatted for download", () => {
+      const expected = {
+        chartDatasets: [
+          {
+            data: [
+              {
+                "CI Lower": 900,
+                "CI Upper": 1200,
+                Population: 1000,
+              },
+              {
+                "CI Lower": 1900,
+                "CI Upper": 2100,
+                Population: 2000,
+              },
+              {
+                "CI Lower": 900,
+                "CI Upper": 1200,
+                Population: 1000,
+              },
+            ],
+            label: "",
+          },
+        ],
+        chartLabels: ["Jan '21", "Feb '21", "Mar '21"],
+        chartId: "Population Projection",
+        dataExportLabel: "Month",
+      };
+      const result = pageProjectionsStore.timeSeriesDownloadableData;
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("filtersText", () => {
+    it("formats the filters description for the csv file", () => {
+      expect(pageProjectionsStore.filtersText).toEqual(
+        "Supervision - 6 months; Gender: All; Supervision Type: All,,,"
+      );
+    });
+
+    it("formats the filters text according to the view", () => {
+      coreStore.setView("/facilities/projections");
+      expect(pageProjectionsStore.filtersText).toEqual(
+        "Incarceration - 6 months; Gender: All; Supervision Type: All,,,"
+      );
+    });
+  });
+});

--- a/src/core/CoreStore/index.ts
+++ b/src/core/CoreStore/index.ts
@@ -24,6 +24,7 @@ import { TenantId } from "../models/types";
 import MetricsStore from "./MetricsStore";
 import PageVitalsStore from "./PageVitalsStore";
 import PageProjectionsStore from "./PageProjectionsStore";
+import { CoreView, CORE_VIEWS, getViewFromPathname } from "../views";
 
 interface CoreStoreProps {
   userStore: UserStore;
@@ -43,6 +44,8 @@ export default class CoreStore {
 
   pageProjectionsStore: PageProjectionsStore;
 
+  view: CoreView = CORE_VIEWS.community;
+
   constructor({ userStore, tenantStore }: CoreStoreProps) {
     makeAutoObservable(this);
 
@@ -61,6 +64,12 @@ export default class CoreStore {
     this.pageProjectionsStore = new PageProjectionsStore({
       rootStore: this,
     });
+
+    this.setView = this.setView.bind(this);
+  }
+
+  setView(pathname: string): void {
+    this.view = getViewFromPathname(pathname);
   }
 
   get filters(): PopulationFilterValues {

--- a/src/core/CoreStore/index.ts
+++ b/src/core/CoreStore/index.ts
@@ -23,6 +23,7 @@ import { PopulationFilterValues } from "../types/filters";
 import { TenantId } from "../models/types";
 import MetricsStore from "./MetricsStore";
 import PageVitalsStore from "./PageVitalsStore";
+import PageProjectionsStore from "./PageProjectionsStore";
 
 interface CoreStoreProps {
   userStore: UserStore;
@@ -40,6 +41,8 @@ export default class CoreStore {
 
   pageVitalsStore: PageVitalsStore;
 
+  pageProjectionsStore: PageProjectionsStore;
+
   constructor({ userStore, tenantStore }: CoreStoreProps) {
     makeAutoObservable(this);
 
@@ -52,6 +55,10 @@ export default class CoreStore {
     this.metricsStore = new MetricsStore({ rootStore: this });
 
     this.pageVitalsStore = new PageVitalsStore({
+      rootStore: this,
+    });
+
+    this.pageProjectionsStore = new PageProjectionsStore({
       rootStore: this,
     });
   }

--- a/src/core/DownloadDataButton.tsx
+++ b/src/core/DownloadDataButton.tsx
@@ -30,6 +30,7 @@ interface PropTypes {
   methodology: MethodologyContent[];
   filters: string;
   lastUpdatedOn: string;
+  includeFiltersRowInCSV?: boolean;
 }
 
 const DownloadDataButton: React.FC<PropTypes> = ({
@@ -38,13 +39,14 @@ const DownloadDataButton: React.FC<PropTypes> = ({
   methodology,
   filters,
   lastUpdatedOn,
+  includeFiltersRowInCSV = false,
 }) => {
   const { getTokenSilently } = useRootStore();
 
   return (
     <button
       className="btn btn-link DetailsGroup__button"
-      id="downloadChartData-VitalsSummaryChart"
+      id="downloadChartData"
       type="button"
       aria-expanded="true"
       aria-controls="importantNotes"
@@ -55,6 +57,7 @@ const DownloadDataButton: React.FC<PropTypes> = ({
           shouldZipDownload: true,
           methodology,
           getTokenSilently,
+          includeFiltersRowInCSV,
           filters: { filtersDescription: filters },
           lastUpdatedOn,
         })

--- a/src/core/DownloadDataButton.tsx
+++ b/src/core/DownloadDataButton.tsx
@@ -17,32 +17,14 @@
 import React from "react";
 
 import { Icon, IconSVG } from "@recidiviz/case-triage-components";
-import { DownloadableData } from "./PageVitals/types";
-import { downloadChartAsData } from "../utils/downloads/downloadData";
-import { useRootStore } from "../components/StoreProvider";
-import { MethodologyContent } from "./models/types";
 import "./DetailsGroup.scss";
 import * as styles from "./CoreConstants.scss";
 
 interface PropTypes {
-  data: DownloadableData[];
-  title: string;
-  methodology: MethodologyContent[];
-  filters: string;
-  lastUpdatedOn: string;
-  includeFiltersRowInCSV?: boolean;
+  handleOnClick: () => Promise<void>;
 }
 
-const DownloadDataButton: React.FC<PropTypes> = ({
-  data,
-  title,
-  methodology,
-  filters,
-  lastUpdatedOn,
-  includeFiltersRowInCSV = false,
-}) => {
-  const { getTokenSilently } = useRootStore();
-
+const DownloadDataButton: React.FC<PropTypes> = ({ handleOnClick }) => {
   return (
     <button
       className="btn btn-link DetailsGroup__button"
@@ -50,18 +32,7 @@ const DownloadDataButton: React.FC<PropTypes> = ({
       type="button"
       aria-expanded="true"
       aria-controls="importantNotes"
-      onClick={() =>
-        downloadChartAsData({
-          fileContents: data,
-          chartTitle: title,
-          shouldZipDownload: true,
-          methodology,
-          getTokenSilently,
-          includeFiltersRowInCSV,
-          filters: { filtersDescription: filters },
-          lastUpdatedOn,
-        })
-      }
+      onClick={handleOnClick}
     >
       <Icon
         className="DetailsGroup__icon"

--- a/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
+++ b/src/core/PageProjections/PopulationProjectionLastUpdated.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import React from "react";
+import { formatDate } from "../../utils/formatStrings";
 import "./PopulationProjectionLastUpdated.scss";
 
 type Props = {
@@ -37,11 +38,7 @@ const PopulationProjectionLastUpdated: React.FC<Props> = ({
   return (
     <div className="PopulationProjectionLastUpdated">
       Historical and projected population data were generated{" "}
-      {simulationDate.toLocaleString("default", {
-        month: "long",
-        year: "numeric",
-      })}
-      .
+      {formatDate(simulationDate, "MMMM yyyy")}.
     </div>
   );
 };

--- a/src/core/PageVitals/index.tsx
+++ b/src/core/PageVitals/index.tsx
@@ -31,26 +31,19 @@ import { useCoreStore } from "../CoreStoreProvider";
 import DownloadDataButton from "../DownloadDataButton";
 import DetailsGroup from "../DetailsGroup";
 import { ENTITY_TYPES } from "../models/types";
-import content from "../content";
 import withRouteSync from "../../withRouteSync";
 
 import "../DetailsGroup.scss";
 import "./PageVitals.scss";
 
 const PageVitals: React.FC = () => {
-  const { metricsStore, tenantStore, pageVitalsStore } = useCoreStore();
+  const { metricsStore, pageVitalsStore } = useCoreStore();
   const { isLoading, isError } = metricsStore.vitals;
   const {
     currentEntitySummary,
-    filtersText,
     lastUpdatedOn,
-    timeSeriesDownloadableData,
-    summaryDownloadableData,
+    downloadDataZip,
   } = pageVitalsStore;
-  const { stateName, currentTenantId } = tenantStore;
-
-  // @ts-ignore TODO TS
-  const { vitals: vitalsMethodology } = content[currentTenantId];
 
   // TODO: add in Error state
   if (isError || currentEntitySummary === undefined) {
@@ -73,13 +66,7 @@ const PageVitals: React.FC = () => {
           <div className="DetailsGroup__item">
             Last updated on {lastUpdatedOn}
           </div>
-          <DownloadDataButton
-            data={[timeSeriesDownloadableData, summaryDownloadableData]}
-            title={`${stateName} At A Glance`}
-            methodology={vitalsMethodology.content}
-            filters={filtersText}
-            lastUpdatedOn={lastUpdatedOn}
-          />
+          <DownloadDataButton handleOnClick={downloadDataZip} />
           <MethodologyLink path={CORE_PATHS.methodologyVitals} />
         </DetailsGroup>
       </div>

--- a/src/core/PageVitals/index.tsx
+++ b/src/core/PageVitals/index.tsx
@@ -39,11 +39,7 @@ import "./PageVitals.scss";
 const PageVitals: React.FC = () => {
   const { metricsStore, pageVitalsStore } = useCoreStore();
   const { isLoading, isError } = metricsStore.vitals;
-  const {
-    currentEntitySummary,
-    lastUpdatedOn,
-    downloadDataZip,
-  } = pageVitalsStore;
+  const { currentEntitySummary, lastUpdatedOn, downloadData } = pageVitalsStore;
 
   // TODO: add in Error state
   if (isError || currentEntitySummary === undefined) {
@@ -66,7 +62,7 @@ const PageVitals: React.FC = () => {
           <div className="DetailsGroup__item">
             Last updated on {lastUpdatedOn}
           </div>
-          <DownloadDataButton handleOnClick={downloadDataZip} />
+          <DownloadDataButton handleOnClick={downloadData} />
           <MethodologyLink path={CORE_PATHS.methodologyVitals} />
         </DetailsGroup>
       </div>

--- a/src/core/PopulationFilterBar.tsx
+++ b/src/core/PopulationFilterBar.tsx
@@ -21,96 +21,34 @@ import { get } from "mobx";
 import { CoreSelect } from "./controls/CoreSelect";
 import { useCoreStore } from "./CoreStoreProvider";
 import { getFilterOption } from "./utils/filterOptions";
-import { PopulationFilters, PopulationFilterValues } from "./types/filters";
+import { PopulationFilters } from "./types/filters";
 
 import Filter from "./controls/Filter";
 import FilterBar from "./controls/FilterBar";
-import { CORE_PATHS, CORE_VIEWS, getCompartmentFromView } from "./views";
+import { CORE_PATHS, CORE_VIEWS } from "./views";
 import DownloadDataButton from "./DownloadDataButton";
 import MethodologyLink from "./MethodologyLink";
 import DetailsGroup from "./DetailsGroup";
-import { PopulationProjectionTimeSeriesRecord } from "./models/types";
-import { DownloadableDataset } from "./PageVitals/types";
-import content from "./content";
-import {
-  formatMonthAndYear,
-  getRecordDate,
-} from "./PopulationTimeSeriesChart/helpers";
-import { toTitleCase, formatDate } from "../utils/formatStrings";
-
-function getTimeSeriesDownloadableData(
-  timeSeries: PopulationProjectionTimeSeriesRecord[]
-) {
-  if (!timeSeries) return undefined;
-
-  const datasets = [] as DownloadableDataset[];
-  const data: Record<string, number>[] = [];
-  const labels: string[] = [];
-
-  timeSeries.forEach((d: PopulationProjectionTimeSeriesRecord) => {
-    data.push({
-      Population: Math.round(d.totalPopulation),
-      "CI Lower": Math.round(d.totalPopulationMin),
-      "CI Upper": Math.round(d.totalPopulationMax),
-    });
-
-    labels.push(formatMonthAndYear(getRecordDate(d)));
-  });
-
-  datasets.push({ data, label: "" });
-
-  return {
-    chartDatasets: datasets,
-    chartLabels: labels,
-    chartId: "Population Projection",
-    dataExportLabel: "Month",
-  };
-}
-
-function getFiltersText(
-  filters: PopulationFilterValues,
-  view: keyof typeof CORE_VIEWS,
-  timePeriodLabel: string
-): string {
-  const { gender, supervisionType } = filters;
-  const compartment = getCompartmentFromView(view);
-  return `${toTitleCase(
-    compartment
-  )} - ${timePeriodLabel}; Gender: ${toTitleCase(
-    gender
-  )}; Supervision Type: ${toTitleCase(supervisionType)},,,`;
-}
 
 const PopulationFilterBar: React.FC<{
   view: keyof typeof CORE_VIEWS;
   filterOptions: PopulationFilters;
 }> = ({ filterOptions, view }) => {
-  const { filtersStore, metricsStore } = useCoreStore();
-  const { filters, timePeriodLabel } = filtersStore;
+  const { filtersStore, pageProjectionsStore } = useCoreStore();
+  const { filters } = filtersStore;
+  const { downloadMethodologyPDF, downloadData } = pageProjectionsStore;
   const filterTypes = Object.keys(filterOptions) as Array<
     keyof PopulationFilters
   >;
-  const { simulationDate } = metricsStore.projections;
-  const filteredData = metricsStore.projections.getFilteredDataByView(view);
-  // @ts-ignore TODO TS
-  const { vitals: vitalsMethodology } = content.US_ND;
-
+  const handleDownload = async () => {
+    await downloadMethodologyPDF();
+    await downloadData(view);
+  };
   return (
     <FilterBar
       details={
         <DetailsGroup>
-          <DownloadDataButton
-            data={[getTimeSeriesDownloadableData(filteredData)]}
-            title={`Population Projections: ${getFiltersText(
-              filters,
-              view,
-              timePeriodLabel
-            )}`}
-            methodology={vitalsMethodology.content}
-            lastUpdatedOn={formatDate(simulationDate)}
-            filters={getFiltersText(filters, view, timePeriodLabel)}
-            includeFiltersRowInCSV
-          />
+          <DownloadDataButton handleOnClick={handleDownload} />
           <MethodologyLink path={CORE_PATHS.methodologyProjections} />
         </DetailsGroup>
       }

--- a/src/core/PopulationFilterBar.tsx
+++ b/src/core/PopulationFilterBar.tsx
@@ -25,7 +25,10 @@ import { PopulationFilters } from "./types/filters";
 
 import Filter from "./controls/Filter";
 import FilterBar from "./controls/FilterBar";
-import { CORE_VIEWS } from "./views";
+import { CORE_PATHS, CORE_VIEWS } from "./views";
+import DownloadDataButton from "./DownloadDataButton";
+import MethodologyLink from "./MethodologyLink";
+import DetailsGroup from "./DetailsGroup";
 
 const PopulationFilterBar: React.FC<{
   view: keyof typeof CORE_VIEWS;
@@ -38,7 +41,22 @@ const PopulationFilterBar: React.FC<{
   >;
 
   return (
-    <FilterBar>
+    <FilterBar
+      details={
+        <DetailsGroup>
+          <DownloadDataButton
+            data={[]}
+            title="Population Projections"
+            // @ts-ignore
+            methodology="hi"
+            filters=""
+            // @ts-ignore
+            lastUpdatedOn="1/10/2021"
+          />
+          <MethodologyLink path={CORE_PATHS.methodologyProjections} />
+        </DetailsGroup>
+      }
+    >
       {filterTypes.map((filterType) => {
         const filter = filterOptions[filterType];
         if (!filter.enabledViews.includes(view)) return null;

--- a/src/core/PopulationFilterBar.tsx
+++ b/src/core/PopulationFilterBar.tsx
@@ -36,14 +36,12 @@ const PopulationFilterBar: React.FC<{
 }> = ({ filterOptions, view }) => {
   const { filtersStore, pageProjectionsStore } = useCoreStore();
   const { filters } = filtersStore;
-  const { downloadMethodologyPDF, downloadData } = pageProjectionsStore;
+  const { downloadData } = pageProjectionsStore;
   const filterTypes = Object.keys(filterOptions) as Array<
     keyof PopulationFilters
   >;
-  const handleDownload = async () => {
-    await downloadMethodologyPDF();
-    await downloadData();
-  };
+  const handleDownload = async () => downloadData();
+
   return (
     <FilterBar
       details={

--- a/src/core/PopulationFilterBar.tsx
+++ b/src/core/PopulationFilterBar.tsx
@@ -42,7 +42,7 @@ const PopulationFilterBar: React.FC<{
   >;
   const handleDownload = async () => {
     await downloadMethodologyPDF();
-    await downloadData(view);
+    await downloadData();
   };
   return (
     <FilterBar

--- a/src/core/PopulationTimeSeriesChart/PopulationTimeSeriesTooltip.tsx
+++ b/src/core/PopulationTimeSeriesChart/PopulationTimeSeriesTooltip.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import React from "react";
-
+import { formatDate } from "../../utils/formatStrings";
 import "./PopulationTimeSeriesTooltip.scss";
 
 type PropTypes = {
@@ -40,10 +40,10 @@ const PopulationTimeSeriesTooltip: React.FC<PropTypes> = ({ d }) => {
   return (
     <div className="PopulationTimeseriesTooltip">
       <div className="PopulationTimeseriesTooltip__Date">
-        {date.toLocaleString("default", { month: "long", year: "numeric" })}
+        {formatDate(date, "MMMM yyyy")}
       </div>
       <div className="PopulationTimeseriesTooltip__Value">
-        {value.toLocaleString("default", { maximumFractionDigits: 0 })}
+        {value.toLocaleString(undefined, { maximumFractionDigits: 0 })}
       </div>
       {lowerBound && upperBound && (
         <div className="PopulationTimeseriesTooltip__Range">

--- a/src/core/PopulationTimeSeriesChart/helpers.ts
+++ b/src/core/PopulationTimeSeriesChart/helpers.ts
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { PopulationProjectionTimeSeriesRecord } from "../models/types";
+import { formatDate } from "../../utils/formatStrings";
 
 export type MonthOptions = 1 | 6 | 12 | 24 | 60;
 
@@ -106,7 +107,5 @@ export const getDateRange = (
 };
 
 export const formatMonthAndYear = (date: Date): string => {
-  return `${date.toLocaleString("default", { month: "short" })} '${
-    date.getFullYear() % 100
-  }`;
+  return formatDate(date, "MMM ''yy");
 };

--- a/src/core/PopulationTimeSeriesChart/helpers.ts
+++ b/src/core/PopulationTimeSeriesChart/helpers.ts
@@ -104,3 +104,9 @@ export const getDateRange = (
 
   return { beginDate, endDate };
 };
+
+export const formatMonthAndYear = (date: Date): string => {
+  return `${date.toLocaleString("default", { month: "short" })} '${
+    date.getFullYear() % 100
+  }`;
+};

--- a/src/core/PopulationTimeSeriesChart/index.tsx
+++ b/src/core/PopulationTimeSeriesChart/index.tsx
@@ -30,7 +30,13 @@ import PopulationTimeSeriesTooltip from "./PopulationTimeSeriesTooltip";
 import PopulationTimeSeriesErrorBar from "./PopulationTimeSeriesErrorBar";
 import * as styles from "../CoreConstants.scss";
 
-import { ChartPoint, getDateRange, MonthOptions, prepareData } from "./helpers";
+import {
+  ChartPoint,
+  getDateRange,
+  MonthOptions,
+  prepareData,
+  formatMonthAndYear,
+} from "./helpers";
 import { CoreLoading } from "../CoreLoadingIndicator";
 
 type PlotLine = {
@@ -220,10 +226,7 @@ const PopulationTimeSeriesChart: React.FC<Props> = ({ isLoading = false }) => {
             tickValues: historicalPopulation
               .concat(projectedPopulation.slice(1)) // don't double-draw center date
               .map((r) => r.date),
-            tickFormat: (d: Date) =>
-              `${d.toLocaleString("default", { month: "short" })} '${
-                d.getFullYear() % 100
-              }`,
+            tickFormat: (d: Date) => formatMonthAndYear(d),
           },
         ]}
       />

--- a/src/core/content/index.ts
+++ b/src/core/content/index.ts
@@ -15,5 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import { US_ND } from "./usNdMethodology";
+import { TenantId } from "../../RootStore/types";
+import { ViewMethodology } from "../models/types";
 
-export default { US_ND } as const;
+type TenantMethodology = {
+  [key in TenantId]: ViewMethodology;
+};
+
+export default { US_ND } as TenantMethodology;

--- a/src/core/controls/FilterBar.scss
+++ b/src/core/controls/FilterBar.scss
@@ -6,10 +6,10 @@
   justify-content: center;
   padding: 1rem 0 0.5rem;
 
-  &__filters {
+  &__container {
     display: flex;
     flex-wrap: wrap;
-    font-weight: 500;
+    justify-content: space-between;
     max-width: $core-max-view-width;
     width: 100%;
 
@@ -28,5 +28,10 @@
         white-space: nowrap;
       }
     }
+  }
+
+  &__filters {
+    display: flex;
+    flex-flow: row wrap;
   }
 }

--- a/src/core/controls/FilterBar.tsx
+++ b/src/core/controls/FilterBar.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 import React from "react";
 import Sticky from "react-sticky-fill";
+import DetailsGroup from "../DetailsGroup";
 import "./FilterBar.scss";
 
 const FILTER_BAR_STYLE = {
@@ -23,11 +24,17 @@ const FILTER_BAR_STYLE = {
   top: 79,
 };
 
-const FilterBar: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const FilterBar: React.FC<{
+  details?: React.ReactElement;
+  children: React.ReactNode;
+}> = ({ details = null, children }) => {
   return (
     <Sticky style={FILTER_BAR_STYLE}>
       <div className="FilterBar">
-        <div className="FilterBar__filters">{children}</div>
+        <div className="FilterBar__container">
+          <div className="FilterBar__filters">{children}</div>
+          {details && details}
+        </div>
       </div>
     </Sticky>
   );

--- a/src/core/controls/FilterBar.tsx
+++ b/src/core/controls/FilterBar.tsx
@@ -16,7 +16,6 @@
 // =============================================================================
 import React from "react";
 import Sticky from "react-sticky-fill";
-import DetailsGroup from "../DetailsGroup";
 import "./FilterBar.scss";
 
 const FILTER_BAR_STYLE = {

--- a/src/core/utils/configureDownloadButtons.js
+++ b/src/core/utils/configureDownloadButtons.js
@@ -35,7 +35,7 @@ export function configureDownloadButtons({
   shouldZipDownload,
   fixLabelsInColumns = false,
   dataExportLabel = "Month",
-  methodology,
+  methodologyContent,
 }) {
   const filename = configureFilename(chartId, filters, shouldZipDownload);
   const downloadChartAsImageButton = document.getElementById(
@@ -69,7 +69,7 @@ export function configureDownloadButtons({
       timeWindowDescription,
       shouldZipDownload,
       fixLabelsInColumns,
-      methodology,
+      methodologyContent,
     });
   }
 

--- a/src/core/views.ts
+++ b/src/core/views.ts
@@ -21,9 +21,9 @@ export const CORE_VIEWS: Record<string, string> = {
   facilities: "facilities",
   goals: "goals",
   methodology: "methodology",
-};
+} as const;
 
-type CoreView = keyof typeof CORE_VIEWS;
+export type CoreView = keyof typeof CORE_VIEWS;
 
 export const CORE_PATHS: Record<string, string> = {
   goals: "/goals",
@@ -52,6 +52,6 @@ export function getCompartmentFromView(view: CoreView): SimulationCompartment {
   return view === CORE_VIEWS.community ? "SUPERVISION" : "INCARCERATION";
 }
 
-export function getViewFromPathname(pathname: string): CoreView {
+export function getViewFromPathname(pathname: string): string {
   return pathnameToView[pathname];
 }

--- a/src/cucumber/features/core/projectionsPage.feature
+++ b/src/cucumber/features/core/projectionsPage.feature
@@ -1,0 +1,15 @@
+Feature: Navigate to Population Projections Dashboard
+    As a user
+    I want to login to the Population Projections dashboard
+    And see the projections chart
+
+    Background:
+      Given I am logged in as a "admin" user
+      And I click on the profile link
+      And I select the state "Idaho"
+
+    Scenario: Viewing the Projections Chart
+        When I'm on the "Facilities" view
+        Then I should see the projections chart for "facilities"
+        When I'm on the "Community" view
+        Then I should see the projections chart for "community"

--- a/src/cucumber/pages/projectionsPage.js
+++ b/src/cucumber/pages/projectionsPage.js
@@ -1,0 +1,25 @@
+/* eslint-disable class-methods-use-this */
+import Page from ".";
+
+class ProjectionsPage extends Page {
+  open() {
+    super.open(`${browser.config.baseUrl}/community/projections`);
+  }
+
+  get viewSelector() {
+    return $(".CoreSectionSelector");
+  }
+
+  selectView(view) {
+    this.viewSelector.click();
+    const option = $(`button.CoreSectionSelector__item=${view}`);
+    option.waitForClickable();
+    option.click();
+  }
+
+  get projectionsChartHeader() {
+    return $(".PopulationTimeSeriesChart__Header");
+  }
+}
+
+export default new ProjectionsPage({ redirectPause: 1000 });

--- a/src/cucumber/steps/projectionsPageSteps.js
+++ b/src/cucumber/steps/projectionsPageSteps.js
@@ -1,0 +1,33 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { When, Then } from "@cucumber/cucumber";
+import projectionsPage from "../pages/projectionsPage";
+
+When("I'm on the {string} view", (view) => {
+  projectionsPage.selectView(view);
+});
+
+Then("I should see the projections chart for {string}", (view) => {
+  const header = projectionsPage.projectionsChartHeader.getText();
+  if (view === "facilities") {
+    expect(header).toContain("Total Incarcerated Population");
+  }
+  if (view === "community") {
+    expect(header).toContain("Total Supervised Population");
+  }
+});

--- a/src/lantern/ExportMenu.js
+++ b/src/lantern/ExportMenu.js
@@ -80,7 +80,7 @@ const ExportMenu = ({
                   filters: filtersStore.filtersDescriptions,
                   timeWindowDescription,
                   shouldZipDownload: true,
-                  methodology: methodology[chartId],
+                  methodologyContent: methodology[chartId],
                   getTokenSilently,
                 })
               }
@@ -98,7 +98,7 @@ const ExportMenu = ({
                   filters: filtersStore.filtersDescriptions,
                   timeWindowDescription,
                   shouldZipDownload: true,
-                  methodology: methodology[chartId],
+                  methodologyContent: methodology[chartId],
                   getTokenSilently,
                 })
               }
@@ -123,7 +123,7 @@ const ExportMenu = ({
                 timeWindowDescription,
                 shouldZipDownload: true,
                 fixLabelsInColumns,
-                methodology: methodology[chartId],
+                methodologyContent: methodology[chartId],
                 getTokenSilently,
               })
             }

--- a/src/utils/downloads/__tests__/createMethodologyFile.test.js
+++ b/src/utils/downloads/__tests__/createMethodologyFile.test.js
@@ -44,7 +44,7 @@ describe("createMethodologyFile functions", () => {
       chartTitle: mockChartTitle,
       timeWindowDescription: mockTimeWindowDescription,
       filters,
-      methodology: methodology[mockChartId],
+      methodologyContent: methodology[mockChartId],
       violation,
       lastUpdatedOn,
     });
@@ -70,7 +70,7 @@ describe("createMethodologyFile functions", () => {
     ];
     const actual = createMethodologyFile({
       chartTitle: mockChartTitle,
-      methodology: methodologyWithMarkup,
+      methodologyContent: methodologyWithMarkup,
     });
 
     expect(actual.data).toBe(
@@ -94,7 +94,7 @@ describe("createMethodologyFile functions", () => {
         chartTitle: mockChartTitle,
         timeWindowDescription: mockTimeWindowDescription,
         filters,
-        methodology: methodologyWithoutHeader[mockChartId],
+        methodologyContent: methodologyWithoutHeader[mockChartId],
         violation,
       });
       expect(actual.data).toBe(

--- a/src/utils/downloads/createMethodologyFile.js
+++ b/src/utils/downloads/createMethodologyFile.js
@@ -21,11 +21,11 @@ function createMethodologyFile({
   chartTitle,
   timeWindowDescription,
   filters,
-  methodology,
+  methodologyContent,
   violation,
   lastUpdatedOn,
 }) {
-  const infoChart = methodology || [];
+  const infoChart = methodologyContent || [];
   const exportDate = moment().format("M/D/YYYY");
 
   let text = `Chart: ${chartTitle}\n`;

--- a/src/utils/downloads/downloadData.js
+++ b/src/utils/downloads/downloadData.js
@@ -208,7 +208,7 @@ export function configureDataDownloadButton({
   methodology,
   getTokenSilently,
   lastUpdatedOn,
-  includeFiltersRowInCSV,
+  includeFiltersDescriptionInCSV,
 }) {
   return () => {
     const methodologyFile =
@@ -240,7 +240,7 @@ export function configureDataDownloadButton({
             filters,
             shouldZipDownload
           );
-          const formattedCSV = includeFiltersRowInCSV
+          const formattedCSV = includeFiltersDescriptionInCSV
             ? [filters, csv].join("\n")
             : csv;
 
@@ -290,7 +290,7 @@ export function downloadChartAsData({
   methodology = null,
   getTokenSilently,
   lastUpdatedOn = null,
-  includeFiltersRowInCSV = false,
+  includeFiltersDescriptionInCSV = false,
 }) {
   const downloadChartData = configureDataDownloadButton({
     fileContents: fileContents.filter(Boolean),
@@ -303,7 +303,7 @@ export function downloadChartAsData({
     methodology,
     getTokenSilently,
     lastUpdatedOn,
-    includeFiltersRowInCSV,
+    includeFiltersDescriptionInCSV,
   });
   downloadChartData();
 }

--- a/src/utils/downloads/downloadData.js
+++ b/src/utils/downloads/downloadData.js
@@ -64,7 +64,7 @@ export function downloadCanvasAsImage({
   chartId,
   timeWindowDescription,
   shouldZipDownload,
-  methodology,
+  methodologyContent,
   getTokenSilently,
 }) {
   const imageData = transformCanvasToBase64(
@@ -81,7 +81,7 @@ export function downloadCanvasAsImage({
           chartTitle,
           timeWindowDescription,
           filters,
-          methodology,
+          methodologyContent,
           violation,
         });
 
@@ -123,6 +123,7 @@ export function downloadData({
   chartId,
   getTokenSilently,
   methodologyFile = null,
+  methodologyPDF = null,
 }) {
   try {
     if (shouldZipDownload || isMobile) {
@@ -136,6 +137,10 @@ export function downloadData({
 
       if (methodologyFile) {
         files.push(methodologyFile);
+      }
+
+      if (methodologyPDF) {
+        files.push(methodologyPDF);
       }
 
       downloadZipFile({
@@ -175,7 +180,7 @@ export function downloadHtmlElementAsImage({
   filters,
   timeWindowDescription,
   shouldZipDownload,
-  methodology,
+  methodologyContent,
   getTokenSilently,
 }) {
   const element = document.getElementById(chartId);
@@ -190,7 +195,7 @@ export function downloadHtmlElementAsImage({
       chartId,
       timeWindowDescription,
       shouldZipDownload,
-      methodology,
+      methodologyContent,
       getTokenSilently,
     });
   });
@@ -205,7 +210,8 @@ export function configureDataDownloadButton({
   timeWindowDescription,
   shouldZipDownload,
   fixLabelsInColumns,
-  methodology,
+  methodologyContent,
+  methodologyPDF,
   getTokenSilently,
   lastUpdatedOn,
   includeFiltersDescriptionInCSV,
@@ -213,13 +219,13 @@ export function configureDataDownloadButton({
   return () => {
     const methodologyFile =
       shouldZipDownload &&
-      methodology &&
+      methodologyContent &&
       createMethodologyFile({
         chartTitle,
         timeWindowDescription,
         filters,
         violation,
-        methodology,
+        methodologyContent,
         lastUpdatedOn,
       });
     const promises = fileContents.map((file) => {
@@ -251,6 +257,7 @@ export function configureDataDownloadButton({
         }),
         getTokenSilently,
         methodologyFile,
+        methodologyPDF,
       });
     });
   };
@@ -262,7 +269,7 @@ export function downloadChartAsImage({
   filters,
   timeWindowDescription,
   shouldZipDownload,
-  methodology,
+  methodologyContent,
   getTokenSilently,
 }) {
   const filename = configureFilename(chartId, filters, shouldZipDownload);
@@ -275,7 +282,7 @@ export function downloadChartAsImage({
     chartId,
     timeWindowDescription,
     shouldZipDownload,
-    methodology,
+    methodologyContent,
     getTokenSilently,
   });
 }
@@ -287,7 +294,8 @@ export function downloadChartAsData({
   timeWindowDescription = null,
   shouldZipDownload,
   fixLabelsInColumns = false,
-  methodology = null,
+  methodologyContent = null,
+  methodologyPDF = null,
   getTokenSilently,
   lastUpdatedOn = null,
   includeFiltersDescriptionInCSV = false,
@@ -300,7 +308,8 @@ export function downloadChartAsData({
     timeWindowDescription,
     shouldZipDownload,
     fixLabelsInColumns,
-    methodology,
+    methodologyContent,
+    methodologyPDF,
     getTokenSilently,
     lastUpdatedOn,
     includeFiltersDescriptionInCSV,

--- a/src/utils/downloads/downloadData.js
+++ b/src/utils/downloads/downloadData.js
@@ -213,6 +213,7 @@ export function configureDataDownloadButton({
   return () => {
     const methodologyFile =
       shouldZipDownload &&
+      methodology &&
       createMethodologyFile({
         chartTitle,
         timeWindowDescription,
@@ -286,7 +287,7 @@ export function downloadChartAsData({
   timeWindowDescription = null,
   shouldZipDownload,
   fixLabelsInColumns = false,
-  methodology,
+  methodology = null,
   getTokenSilently,
   lastUpdatedOn = null,
   includeFiltersRowInCSV = false,

--- a/src/utils/downloads/downloadData.js
+++ b/src/utils/downloads/downloadData.js
@@ -208,6 +208,7 @@ export function configureDataDownloadButton({
   methodology,
   getTokenSilently,
   lastUpdatedOn,
+  includeFiltersRowInCSV,
 }) {
   return () => {
     const methodologyFile =
@@ -238,8 +239,12 @@ export function configureDataDownloadButton({
             filters,
             shouldZipDownload
           );
+          const formattedCSV = includeFiltersRowInCSV
+            ? [filters, csv].join("\n")
+            : csv;
+
           return {
-            csv,
+            csv: formattedCSV,
             filename: `${filename}.csv`,
           };
         }),
@@ -284,6 +289,7 @@ export function downloadChartAsData({
   methodology,
   getTokenSilently,
   lastUpdatedOn = null,
+  includeFiltersRowInCSV = false,
 }) {
   const downloadChartData = configureDataDownloadButton({
     fileContents: fileContents.filter(Boolean),
@@ -296,6 +302,7 @@ export function downloadChartAsData({
     methodology,
     getTokenSilently,
     lastUpdatedOn,
+    includeFiltersRowInCSV,
   });
   downloadChartData();
 }

--- a/src/utils/formatStrings.ts
+++ b/src/utils/formatStrings.ts
@@ -169,6 +169,10 @@ function formatISODateString(date: string): string {
   return format(parseISO(date), "M/d/yy");
 }
 
+function formatDate(date: Date, pattern = "M/d/yy"): string {
+  return format(date, pattern);
+}
+
 export {
   getPeriodLabelFromMetricPeriodMonthsFilter,
   getTrailingLabelFromMetricPeriodMonthsFilter,
@@ -193,4 +197,5 @@ export {
   formatLargeNumber,
   formatPercent,
   formatISODateString,
+  formatDate,
 };


### PR DESCRIPTION
## Description of the change

Opening this as a draft in case someone else can work on it while I'm OOO! Here's what I did so far:

- Added the links next to the filter bar on the population projections page
- Formatted the data and filters description for the CSV file to download

TODO: 
- [x] Add the methodology PDF to the zip download
- [x] Move where the data and filters description are generated out of the component and probably into something like `PageProjectionsStore` to align with the `PageVitalsStore`
- [x] Test download in Firefox & IE11

NOTE:
- The filters description is added into the CSV file as an extra row because the methodology file will be the PDF not a txt file due to the tables and formatting requirements

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes https://github.com/Recidiviz/recidiviz-data/issues/6116

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
