### PR TITLE
Do not set auth error for users that have no restrictions

### DIFF
--- a/src/lantern/LanternStore/UserRestrictedAccessStore.ts
+++ b/src/lantern/LanternStore/UserRestrictedAccessStore.ts
@@ -121,7 +121,8 @@ export default class UserRestrictedAccessStore {
       (restrictions &&
         restrictions.allowed_level_1_supervision_location_ids
           .split(",")
-          .map((r) => r.trim())) ||
+          .map((r) => r.trim())
+          .filter(Boolean)) ||
       [];
     this.verifyRestrictedDistrict();
   }

--- a/src/lantern/LanternStore/__tests__/UserRestrictedAccessStore.test.ts
+++ b/src/lantern/LanternStore/__tests__/UserRestrictedAccessStore.test.ts
@@ -235,6 +235,36 @@ describe("fetchRestrictedDistrictData", () => {
     });
   });
 
+  describe("when the user has no restricted districts", () => {
+    beforeEach(async () => {
+      mockCallRestrictedAccessApi.mockResolvedValue({
+        supervision_location_restricted_access_emails: {
+          restricted_user_email: userEmail.toUpperCase(),
+          allowed_level_1_supervision_location_ids: "",
+        },
+      });
+
+      rootStore = new LanternStore(mockRootStore);
+
+      userRestrictedAccessStore = new UserRestrictedAccessStore({
+        rootStore,
+      });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("does not set an authError", () => {
+      expect(rootStore.userStore.setAuthError).toHaveBeenCalledTimes(0);
+    });
+
+    it("keeps restrictedDistricts as an empty array and isLoading to false", () => {
+      expect(userRestrictedAccessStore.restrictedDistricts).toEqual([]);
+      expect(userRestrictedAccessStore.isLoading).toBe(false);
+    });
+  });
+
   describe("when districts is loading", () => {
     beforeEach(async () => {
       mockLanternStore.mockImplementationOnce(() => {


### PR DESCRIPTION
## Description of the change

This fixes an new issue that has come up because we changed the `supervision_location_restricted_access_emails` file that MO sends every week. It used to have only users with restrictions, but now it lists all users that can access the dashboard. Some of these users do not have restrictions listed, which the FE was not parsing correctly and causing an authorization error in production. 

In the meantime I did a hot fix by removing all leadership users from the file and resetting the cache. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Closes #1128

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
