### PR TITLE
remove vitals fetch from lantern dashboard

### DIFF
--- a/src/core/CoreStore/PageVitalsStore.ts
+++ b/src/core/CoreStore/PageVitalsStore.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { when, makeAutoObservable, observable } from "mobx";
+import { makeAutoObservable } from "mobx";
 import type RootStore from ".";
 import { formatISODateString, formatPercent } from "../../utils/formatStrings";
 import {
@@ -49,39 +49,21 @@ export default class PageVitalsStore {
 
   currentEntityId: string;
 
-  summaries: VitalsSummaryRecord[];
-
-  timeSeries: VitalsTimeSeriesRecord[];
-
   selectedMetricId: MetricType;
 
   constructor({ rootStore }: { rootStore: RootStore }) {
-    makeAutoObservable(this, {
-      summaries: observable.ref,
-      timeSeries: observable.ref,
-    });
+    makeAutoObservable(this);
     this.rootStore = rootStore;
     this.currentEntityId = DEFAULT_ENTITY_ID;
     this.selectedMetricId = METRIC_TYPES.OVERALL;
-    this.summaries = [];
-    this.timeSeries = [];
-
-    when(
-      () => !this.rootStore.metricsStore.vitals.isLoading,
-      () => {
-        const { summaries, timeSeries } = this.rootStore.metricsStore.vitals;
-        this.setSummaries(summaries);
-        this.setTimeSeries(timeSeries);
-      }
-    );
   }
 
-  setSummaries(summaries: VitalsSummaryRecord[]): void {
-    this.summaries = summaries;
+  get summaries(): VitalsSummaryRecord[] {
+    return this.rootStore.metricsStore.vitals.summaries;
   }
 
-  setTimeSeries(timeSeries: VitalsTimeSeriesRecord[]): void {
-    this.timeSeries = timeSeries;
+  get timeSeries(): VitalsTimeSeriesRecord[] {
+    return this.rootStore.metricsStore.vitals.timeSeries;
   }
 
   setSelectedMetricId(metricId: MetricType): void {

--- a/src/core/CoreStore/__tests__/PageVitalsStore.test.ts
+++ b/src/core/CoreStore/__tests__/PageVitalsStore.test.ts
@@ -17,7 +17,6 @@
 import PageVitalsStore, { getSummaryStatus } from "../PageVitalsStore";
 import RootStore from "../../../RootStore";
 import CoreStore from "..";
-import { ENTITY_TYPES } from "../../models/types";
 
 describe("getSummaryStatus", () => {
   describe("when value is less than 70", () => {
@@ -57,25 +56,9 @@ describe("getSummaryStatus", () => {
   });
 });
 
-jest.mock("../../models/VitalsMetrics");
-jest.mock("../../models/ProjectionsMetrics");
-jest.mock("../../../RootStore/TenantStore", () => {
+jest.mock("../../models/VitalsMetrics", () => {
   return jest.fn().mockImplementation(() => ({
-    currentTenantId: "US_ND",
-  }));
-});
-
-let coreStore: CoreStore;
-let pageVitalsStore: PageVitalsStore;
-
-describe("PageVitalsStore", () => {
-  beforeEach(() => {
-    coreStore = new CoreStore(RootStore);
-    pageVitalsStore = coreStore.pageVitalsStore;
-  });
-
-  describe("getTimeSeriesDownloadableData", () => {
-    const data = [
+    timeSeries: [
       {
         date: "2021-03-11",
         entityId: "STATE_DOC",
@@ -132,8 +115,52 @@ describe("PageVitalsStore", () => {
         value: 35.5,
         monthlyAvg: 35.8,
       },
-    ];
+    ],
+    summaries: [
+      {
+        entityId: "OFFICE_A",
+        entityName: "Office A",
+        entityType: "LEVEL_1_SUPERVISION_LOCATION",
+        overall: 85,
+        overall30Day: 0,
+        overall90Day: -2,
+        parentEntityId: "STATE_DOC",
+        timelyContact: 60,
+        timelyDischarge: 63,
+        timelyRiskAssessment: 69,
+      },
+      {
+        entityId: "OFFICE_B",
+        entityName: "Office B",
+        entityType: "LEVEL_1_SUPERVISION_LOCATION",
+        overall: 95,
+        overall30Day: 0,
+        overall90Day: -2,
+        parentEntityId: "STATE_DOC",
+        timelyContact: 90,
+        timelyDischarge: 93,
+        timelyRiskAssessment: 99,
+      },
+    ],
+  }));
+});
+jest.mock("../../models/ProjectionsMetrics");
+jest.mock("../../../RootStore/TenantStore", () => {
+  return jest.fn().mockImplementation(() => ({
+    currentTenantId: "US_ND",
+  }));
+});
 
+let coreStore: CoreStore;
+let pageVitalsStore: PageVitalsStore;
+
+describe("PageVitalsStore", () => {
+  beforeEach(() => {
+    coreStore = new CoreStore(RootStore);
+    pageVitalsStore = coreStore.pageVitalsStore;
+  });
+
+  describe("getTimeSeriesDownloadableData", () => {
     it("returns the data formatted for download", () => {
       const expected = {
         chartDatasets: [
@@ -195,40 +222,12 @@ describe("PageVitalsStore", () => {
         chartId: "MetricsOverTime",
         dataExportLabel: "Date",
       };
-      pageVitalsStore.setTimeSeries(data);
       const result = pageVitalsStore.timeSeriesDownloadableData;
       expect(result).toEqual(expected);
     });
   });
 
   describe("getSummaryDownloadableData", () => {
-    const data = [
-      {
-        entityId: "OFFICE_A",
-        entityName: "Office A",
-        entityType: ENTITY_TYPES.LEVEL_1_SUPERVISION_LOCATION,
-        overall: 85,
-        overall30Day: 0,
-        overall90Day: -2,
-        parentEntityId: "STATE_DOC",
-        timelyContact: 60,
-        timelyDischarge: 63,
-        timelyRiskAssessment: 69,
-      },
-      {
-        entityId: "OFFICE_B",
-        entityName: "Office B",
-        entityType: ENTITY_TYPES.LEVEL_1_SUPERVISION_LOCATION,
-        overall: 95,
-        overall30Day: 0,
-        overall90Day: -2,
-        parentEntityId: "STATE_DOC",
-        timelyContact: 90,
-        timelyDischarge: 93,
-        timelyRiskAssessment: 99,
-      },
-    ];
-
     it("returns the data formatted for download", () => {
       const expected = {
         chartDatasets: [
@@ -258,8 +257,6 @@ describe("PageVitalsStore", () => {
         chartId: "MetricsByOffice",
         dataExportLabel: "Office",
       };
-
-      pageVitalsStore.setSummaries(data);
       const result = pageVitalsStore.summaryDownloadableData;
       expect(result).toEqual(expected);
     });

--- a/src/core/VitalsSummaryCards/__tests__/VitalsSummaryCards.test.tsx
+++ b/src/core/VitalsSummaryCards/__tests__/VitalsSummaryCards.test.tsx
@@ -18,7 +18,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import { ENTITY_TYPES } from "../../models/types";
 import { useCoreStore } from "../../CoreStoreProvider";
 import VitalsSummaryCards from "..";
 import RootStore from "../../../RootStore";
@@ -28,8 +27,38 @@ import { VitalsMetric } from "../../PageVitals/types";
 import TENANTS from "../../../tenants";
 
 jest.mock("../../CoreStoreProvider");
-jest.mock("../../models/VitalsMetrics");
 jest.mock("../../models/ProjectionsMetrics");
+jest.mock("../../models/VitalsMetrics", () => {
+  return jest.fn().mockImplementation(() => ({
+    timeSeries: [],
+    summaries: [
+      {
+        entityId: "OFFICE_A",
+        entityName: "Office A",
+        entityType: "LEVEL_1_SUPERVISION_LOCATION",
+        overall: 85,
+        overall30Day: 0,
+        overall90Day: -2,
+        parentEntityId: "STATE_DOC",
+        timelyContact: 60,
+        timelyDischarge: 63,
+        timelyRiskAssessment: 69,
+      },
+      {
+        entityId: "STATE_DOC",
+        entityName: "State DOC",
+        entityType: "LEVEL_1_SUPERVISION_LOCATION",
+        overall: 95,
+        overall30Day: 0,
+        overall90Day: -2,
+        parentEntityId: "STATE_DOC",
+        timelyContact: 90,
+        timelyDischarge: 93,
+        timelyRiskAssessment: 99,
+      },
+    ],
+  }));
+});
 jest.mock("../../../RootStore/TenantStore", () => {
   return jest.fn().mockImplementation(() => ({
     currentTenantId: "US_ND",
@@ -40,40 +69,10 @@ let coreStore: CoreStore;
 let pageVitalsStore: PageVitalsStore;
 
 describe("VitalsSummaryCards", () => {
-  const summaryData = [
-    {
-      entityId: "OFFICE_A",
-      entityName: "Office A",
-      entityType: ENTITY_TYPES.LEVEL_1_SUPERVISION_LOCATION,
-      overall: 85,
-      overall30Day: 0,
-      overall90Day: -2,
-      parentEntityId: "STATE_DOC",
-      timelyContact: 60,
-      timelyDischarge: 63,
-      timelyRiskAssessment: 69,
-    },
-    {
-      entityId: "STATE_DOC",
-      entityName: "State DOC",
-      entityType: ENTITY_TYPES.LEVEL_1_SUPERVISION_LOCATION,
-      overall: 95,
-      overall30Day: 0,
-      overall90Day: -2,
-      parentEntityId: "STATE_DOC",
-      timelyContact: 90,
-      timelyDischarge: 93,
-      timelyRiskAssessment: 99,
-    },
-  ];
-
   beforeEach(() => {
     coreStore = new CoreStore(RootStore);
     pageVitalsStore = coreStore.pageVitalsStore;
-
-    pageVitalsStore.setSummaries(summaryData);
-    // @ts-ignore
-    useCoreStore.mockReturnValue({ pageVitalsStore });
+    (useCoreStore as jest.Mock).mockReturnValue({ pageVitalsStore });
   });
 
   describe("metrics by tenant", () => {

--- a/src/core/VitalsSummaryTable/__tests__/VitalsSummaryTable.test.tsx
+++ b/src/core/VitalsSummaryTable/__tests__/VitalsSummaryTable.test.tsx
@@ -19,7 +19,6 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
-import { ENTITY_TYPES } from "../../models/types";
 import { useCoreStore } from "../../CoreStoreProvider";
 import VitalsSummaryTable from "../VitalsSummaryTable";
 import RootStore from "../../../RootStore";
@@ -29,8 +28,38 @@ import { VitalsMetric } from "../../PageVitals/types";
 import TENANTS from "../../../tenants";
 
 jest.mock("../../CoreStoreProvider");
-jest.mock("../../models/VitalsMetrics");
 jest.mock("../../models/ProjectionsMetrics");
+jest.mock("../../models/VitalsMetrics", () => {
+  return jest.fn().mockImplementation(() => ({
+    timeSeries: [],
+    summaries: [
+      {
+        entityId: "OFFICE_A",
+        entityName: "Office A",
+        entityType: "LEVEL_1_SUPERVISION_LOCATION",
+        overall: 85,
+        overall30Day: 0,
+        overall90Day: -2,
+        parentEntityId: "STATE_DOC",
+        timelyContact: 60,
+        timelyDischarge: 63,
+        timelyRiskAssessment: 69,
+      },
+      {
+        entityId: "STATE_DOC",
+        entityName: "State DOC",
+        entityType: "LEVEL_1_SUPERVISION_LOCATION",
+        overall: 95,
+        overall30Day: 0,
+        overall90Day: -2,
+        parentEntityId: "STATE_DOC",
+        timelyContact: 90,
+        timelyDischarge: 93,
+        timelyRiskAssessment: 99,
+      },
+    ],
+  }));
+});
 jest.mock("../../../RootStore/TenantStore", () => {
   return jest.fn().mockImplementation(() => ({
     currentTenantId: "US_ND",
@@ -41,40 +70,10 @@ let coreStore: CoreStore;
 let pageVitalsStore: PageVitalsStore;
 
 describe("VitalsSummaryTable", () => {
-  const summaryData = [
-    {
-      entityId: "OFFICE_A",
-      entityName: "Office A",
-      entityType: ENTITY_TYPES.LEVEL_1_SUPERVISION_LOCATION,
-      overall: 85,
-      overall30Day: 0,
-      overall90Day: -2,
-      parentEntityId: "STATE_DOC",
-      timelyContact: 60,
-      timelyDischarge: 63,
-      timelyRiskAssessment: 69,
-    },
-    {
-      entityId: "STATE_DOC",
-      entityName: "State DOC",
-      entityType: ENTITY_TYPES.LEVEL_1_SUPERVISION_LOCATION,
-      overall: 95,
-      overall30Day: 0,
-      overall90Day: -2,
-      parentEntityId: "STATE_DOC",
-      timelyContact: 90,
-      timelyDischarge: 93,
-      timelyRiskAssessment: 99,
-    },
-  ];
-
   beforeEach(() => {
     coreStore = new CoreStore(RootStore);
     pageVitalsStore = coreStore.pageVitalsStore;
-
-    pageVitalsStore.setSummaries(summaryData);
-    // @ts-ignore
-    useCoreStore.mockReturnValue({ pageVitalsStore });
+    (useCoreStore as jest.Mock).mockReturnValue({ pageVitalsStore });
   });
 
   describe("metrics by tenant", () => {

--- a/src/core/models/Metric.ts
+++ b/src/core/models/Metric.ts
@@ -51,6 +51,7 @@ export default abstract class Metric<RecordFormat extends MetricRecord> {
       isError: observable,
       isLoading: observable,
       apiData: observable.ref,
+      tenantId: observable,
     });
 
     this.tenantId = tenantId;


### PR DESCRIPTION
## Description of the change

The `when` reaction in the `PageVitalsStore` was causing the vitals metric to be computed on the Lantern Dashboard, since it added an observable computed value to the constructor. This accesses the computed values directly in the store so that we're not fetching vitals data from lantern.   

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Closes #1130

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [x] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
