### PR TITLE
Remove mode from metricTitle in stacked horizontal bar charts

### DIFF
--- a/src/lantern/RevocationsByGender/RevocationsByGender.js
+++ b/src/lantern/RevocationsByGender/RevocationsByGender.js
@@ -58,7 +58,9 @@ const RevocationsByGender = observer(
           stacked
         )}
         chartTitle={CHART_TITLE}
-        metricTitle={(mode) => `${CHART_TITLE}: ${mode}`}
+        metricTitle={
+          stacked ? CHART_TITLE : (mode) => `${CHART_TITLE}: ${mode}`
+        }
         timeDescription={timeDescription}
         modes={stacked ? [] : Object.keys(genderValueToLabel)}
         defaultMode={DEFAULT_MODE}

--- a/src/lantern/RevocationsByRace/RevocationsByRace.js
+++ b/src/lantern/RevocationsByRace/RevocationsByRace.js
@@ -57,8 +57,10 @@ const RevocationsByRace = observer(
           stacked
         )}
         chartTitle={CHART_TITLE}
-        metricTitle={(mode) =>
-          `${CHART_TITLE}: ${translate("raceLabelMap")[mode]}`
+        metricTitle={
+          stacked
+            ? CHART_TITLE
+            : (mode) => `${CHART_TITLE}: ${translate("raceLabelMap")[mode]}`
         }
         timeDescription={timeDescription}
         modes={stacked ? [] : Object.keys(translate("raceLabelMap"))}


### PR DESCRIPTION
## Description of the change

Removes the mode identifier from the metric title in stacked horizontal bar charts. This was surfacing in the downloads.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1095

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [x] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
