### PR TITLE
Remove 1-month option from pop proj dropdown

### DIFF
--- a/src/core/utils/filterOptions.ts
+++ b/src/core/utils/filterOptions.ts
@@ -77,7 +77,6 @@ export const PopulationFilterOptions: PopulationFilters = {
       { label: "2 years", value: "24" },
       { label: "1 year", value: "12" },
       { label: "6 months", value: "6" },
-      { label: "1 month", value: "1" },
     ],
     get defaultOption(): FilterOption {
       return this.options[3];


### PR DESCRIPTION
## Description of the change

Removes the 1 month option for launch until we give it a special treatment.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
