### PR TITLE
Make the facilities projection page the projection view

### DIFF
--- a/src/core/utils/filterOptions.ts
+++ b/src/core/utils/filterOptions.ts
@@ -77,7 +77,6 @@ export const PopulationFilterOptions: PopulationFilters = {
       { label: "2 years", value: "24" },
       { label: "1 year", value: "12" },
       { label: "6 months", value: "6" },
-      { label: "1 month", value: "1" },
     ],
     get defaultOption(): FilterOption {
       return this.options[3];

--- a/src/tenants.ts
+++ b/src/tenants.ts
@@ -103,7 +103,7 @@ const TENANTS: Tenants = {
     enableUserRestrictions: false,
     navigation: {
       ...(flags.enableProjectionsDashboard
-        ? { community: ["projections"], facilities: ["projections"] }
+        ? { facilities: ["projections"], community: ["projections"] }
         : { community: [], facilities: [] }),
       ...(flags.showMethodologyDropdown
         ? { methodology: ["projections"] }

--- a/src/utils/__tests__/navigation.test.ts
+++ b/src/utils/__tests__/navigation.test.ts
@@ -42,7 +42,7 @@ describe("getPathsFromNavigation", () => {
 
   it("returns the correct allowed paths path for US_ID", () => {
     const allowedPaths = getPathsFromNavigation(tenants.US_ID.navigation);
-    const expected = ["/community/projections", "/facilities/projections"];
+    const expected = ["/facilities/projections", "/community/projections"];
     expect(allowedPaths).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Description of the change

When an ID user logs in, they'll be directed to the facilities projection by default instead of the community one.

## Type of change

- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #1143 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
