### PR TITLE
Dynamically chose top of population charts

### DIFF
--- a/src/core/PopulationTimeSeriesChart/__tests__/helpers.test.ts
+++ b/src/core/PopulationTimeSeriesChart/__tests__/helpers.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Recidiviz - a data platform for criminal justice reform
+ * Copyright (C) 2021 Recidiviz, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * =============================================================================
+ *
+ */
+import { ChartPoint, getChartTop } from "../helpers";
+
+describe("Tests for getChartTop()", () => {
+  const generateData = (mockData: number[]): ChartPoint[] => {
+    return mockData.map((value: number, index: number) => {
+      const date = new Date();
+      date.setDate(date.getDate() + index);
+      return {
+        date,
+        value,
+      };
+    });
+  };
+
+  const generateDataWithUncertainty = (mockData: number[][]): ChartPoint[] => {
+    return mockData.map((values: number[], index: number) => {
+      const [value, upperBound] = values;
+      const date = new Date();
+      date.setDate(date.getDate() + index);
+      return {
+        date,
+        value,
+        upperBound,
+      };
+    });
+  };
+
+  const checkUpperBound = (mockData: number[], expectedBound: number): void => {
+    const data = generateData(mockData);
+    expect(getChartTop(data)).toEqual(expectedBound);
+  };
+
+  it("returns a reasonable upper bound for values under 200", () => {
+    checkUpperBound([70, 82, 85], 120);
+  });
+
+  it("returns a reasonable upper bound for values under 1000", () => {
+    checkUpperBound([320, 280, 490], 600);
+  });
+
+  it("returns a reasonable upper bound for values under 2000", () => {
+    checkUpperBound([1288, 1588, 1788], 2000);
+  });
+
+  it("returns a reasonable upper bound for values under 10000", () => {
+    checkUpperBound([6800, 2800, 800], 8000);
+  });
+
+  it("returns a reasonable upper bound for large values", () => {
+    checkUpperBound([21000, 18000, 12490], 24000);
+  });
+
+  it("takes into account the upper bound if it is set", () => {
+    const data = generateDataWithUncertainty([
+      [1000, 5000],
+      [2000, 7500],
+    ]);
+    expect(getChartTop(data)).toEqual(9000);
+  });
+});

--- a/src/core/PopulationTimeSeriesChart/helpers.ts
+++ b/src/core/PopulationTimeSeriesChart/helpers.ts
@@ -109,3 +109,27 @@ export const getDateRange = (
 export const formatMonthAndYear = (date: Date): string => {
   return formatDate(date, "MMM ''yy");
 };
+
+export const getChartTop = (plotLine: ChartPoint[]): number => {
+  // Dynamically chose the top of the chart such that there should be a horizonal rule
+  // at the very top for visual separation
+  const maxValue = Math.max(...plotLine.map((d) => d.upperBound ?? d.value));
+
+  let spacing;
+
+  if (maxValue < 200) {
+    spacing = 20;
+  } else if (maxValue < 1000) {
+    spacing = 100;
+  } else if (maxValue < 2000) {
+    spacing = 200;
+  } else if (maxValue < 5000) {
+    spacing = 500;
+  } else if (maxValue < 10000) {
+    spacing = 1000;
+  } else {
+    spacing = 2000;
+  }
+
+  return (Math.ceil(maxValue / spacing) + 1) * spacing;
+};

--- a/src/core/PopulationTimeSeriesChart/index.tsx
+++ b/src/core/PopulationTimeSeriesChart/index.tsx
@@ -36,6 +36,7 @@ import {
   MonthOptions,
   prepareData,
   formatMonthAndYear,
+  getChartTop,
 } from "./helpers";
 import { CoreLoading } from "../CoreLoadingIndicator";
 
@@ -91,8 +92,7 @@ const PopulationTimeSeriesChart: React.FC<Props> = ({ isLoading = false }) => {
   uncertainty[uncertainty.length / 2 - 1].date = endDate;
 
   // set top of chart to the nearest thousand above the highest uncertainty value
-  const maxValue = Math.max(...uncertainty.map((d) => d.value));
-  const chartTop = (Math.ceil(maxValue / 1000) + 1) * 1000;
+  const chartTop = getChartTop(projectedPopulation);
 
   const projectionArea = [
     {

--- a/src/core/utils/filterOptions.ts
+++ b/src/core/utils/filterOptions.ts
@@ -77,7 +77,6 @@ export const PopulationFilterOptions: PopulationFilters = {
       { label: "2 years", value: "24" },
       { label: "1 year", value: "12" },
       { label: "6 months", value: "6" },
-      { label: "1 month", value: "1" },
     ],
     get defaultOption(): FilterOption {
       return this.options[3];

--- a/src/tenants.ts
+++ b/src/tenants.ts
@@ -103,7 +103,7 @@ const TENANTS: Tenants = {
     enableUserRestrictions: false,
     navigation: {
       ...(flags.enableProjectionsDashboard
-        ? { community: ["projections"], facilities: ["projections"] }
+        ? { facilities: ["projections"], community: ["projections"] }
         : { community: [], facilities: [] }),
       ...(flags.showMethodologyDropdown
         ? { methodology: ["projections"] }

--- a/src/utils/__tests__/navigation.test.ts
+++ b/src/utils/__tests__/navigation.test.ts
@@ -42,7 +42,7 @@ describe("getPathsFromNavigation", () => {
 
   it("returns the correct allowed paths path for US_ID", () => {
     const allowedPaths = getPathsFromNavigation(tenants.US_ID.navigation);
-    const expected = ["/community/projections", "/facilities/projections"];
+    const expected = ["/facilities/projections", "/community/projections"];
     expect(allowedPaths).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Description of the change

This diff updated the logic behind how we choose the top of the population charts. The goal is to always have a horizontal line at the very top of the chart to separate it from the background.

The main change is that we now have different granularities the logic will use depending on the magnitude of the largest value in the chart (including errors). This has the added benefit of making plots will small values (i.e. < 1000) fill the chart space instead of hiding at the bottom.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
