### PR TITLE
handle leading 0 in restricted district id

### DIFF
--- a/src/lantern/LanternStore/UserRestrictionsStore.ts
+++ b/src/lantern/LanternStore/UserRestrictionsStore.ts
@@ -51,11 +51,19 @@ export default class UserRestrictionsStore {
   }
 
   get allowedSupervisionLocationIds(): string[] {
-    return this.rootStore.userStore.allowedSupervisionLocationIds || [];
+    const normalizedIds = this.rootStore.districtsStore.districtIds.filter(
+      (district) => {
+        return this.rootStore.userStore.allowedSupervisionLocationIds
+          .map((d) => safeToInt(d))
+          .includes(safeToInt(district));
+      }
+    );
+
+    return normalizedIds || [];
   }
 
   verifyUserRestrictions(): void {
-    const unverifiedLocations = this.allowedSupervisionLocationIds
+    const unverifiedLocations = this.rootStore.userStore.allowedSupervisionLocationIds
       .map((d) => safeToInt(d))
       .filter((supervisionLocationId) => {
         return !this.rootStore.districtsStore.districtIds
@@ -63,13 +71,13 @@ export default class UserRestrictionsStore {
           .includes(supervisionLocationId);
       });
     if (
-      this.allowedSupervisionLocationIds.length > 0 &&
+      this.rootStore.userStore.allowedSupervisionLocationIds.length > 0 &&
       unverifiedLocations.length > 0
     ) {
       const authError = new Error(ERROR_MESSAGES.unauthorized);
       Sentry.captureException(authError, {
         tags: {
-          allowedSupervisionLocationIds: this.allowedSupervisionLocationIds.join(
+          allowedSupervisionLocationIds: this.rootStore.userStore.allowedSupervisionLocationIds.join(
             ","
           ),
         },

--- a/src/lantern/LanternStore/UserRestrictionsStore.ts
+++ b/src/lantern/LanternStore/UserRestrictionsStore.ts
@@ -20,6 +20,7 @@ import { ERROR_MESSAGES } from "../../constants/errorMessages";
 import type LanternStore from ".";
 import { US_MO } from "../../RootStore/TenantStore/lanternTenants";
 import { CHARTS } from "./DataStore/RevocationsChartStore";
+import { safeToInt } from "../../utils";
 
 type ConstructorProps = {
   rootStore: LanternStore;
@@ -54,14 +55,13 @@ export default class UserRestrictionsStore {
   }
 
   verifyUserRestrictions(): void {
-    const unverifiedLocations = this.allowedSupervisionLocationIds.filter(
-      (supervisionLocationId) => {
-        return !this.rootStore.districtsStore.districtIds.includes(
-          supervisionLocationId
-        );
-      }
-    );
-
+    const unverifiedLocations = this.allowedSupervisionLocationIds
+      .map((d) => safeToInt(d))
+      .filter((supervisionLocationId) => {
+        return !this.rootStore.districtsStore.districtIds
+          .map((d) => safeToInt(d))
+          .includes(supervisionLocationId);
+      });
     if (
       this.allowedSupervisionLocationIds.length > 0 &&
       unverifiedLocations.length > 0

--- a/src/lantern/LanternStore/__tests__/FiltersStore.test.js
+++ b/src/lantern/LanternStore/__tests__/FiltersStore.test.js
@@ -84,11 +84,19 @@ describe("FiltersStore", () => {
 
     it("sets the defaultFilters to allowedSupervisionLocationIds if it exists", () => {
       const tenantId = "US_MO";
-
+      const mockDistricts = [
+        {
+          level_2_supervision_location_external_id: "99",
+          level_2_supervision_location_name: "HARRISBURG - 99",
+          level_1_supervision_location_external_id: "99",
+          level_1_supervision_location_name: "LANCASTER DO - 99",
+        },
+      ];
       rootStore = new LanternStore(RootStore);
 
       runInAction(() => {
         rootStore.tenantStore.currentTenantId = tenantId;
+        rootStore.districtsStore.apiData = { data: mockDistricts };
         rootStore.districtsStore.isLoading = false;
         rootStore.userStore.user = {
           "test-metadata-namespace/app_metadata": {
@@ -96,7 +104,6 @@ describe("FiltersStore", () => {
           },
         };
       });
-
       expect(
         rootStore.filtersStore.defaultFilterValues[
           getDistrictFilterKey(tenantId)

--- a/src/lantern/LanternStore/__tests__/UserRestrictionsStore.test.ts
+++ b/src/lantern/LanternStore/__tests__/UserRestrictionsStore.test.ts
@@ -234,5 +234,11 @@ describe("UserRestrictionsStore", () => {
     it("does not set an auth error", () => {
       expect(rootStore.userStore.setAuthError).toHaveBeenCalledTimes(0);
     });
+
+    it("correctly sets the allowedSupervisionLocationIds", () => {
+      expect(userRestrictionsStore.allowedSupervisionLocationIds).toEqual([
+        "03",
+      ]);
+    });
   });
 });

--- a/src/lantern/LanternStore/__tests__/UserRestrictionsStore.test.ts
+++ b/src/lantern/LanternStore/__tests__/UserRestrictionsStore.test.ts
@@ -27,7 +27,7 @@ jest.mock("..");
 const mockLanternStore = LanternStore as jest.Mock;
 const mockSetAuthError = jest.fn();
 
-const userDistrict = "13";
+let userDistrict = "13";
 const authError = new Error(ERROR_MESSAGES.unauthorized);
 const tenantId = "US_MO";
 const mockRootStore = {
@@ -147,6 +147,92 @@ describe("UserRestrictionsStore", () => {
           allowedSupervisionLocationIds: mockInvalidId,
         },
       });
+    });
+  });
+
+  describe("when the user restriction is valid", () => {
+    beforeEach(async () => {
+      mockLanternStore.mockImplementationOnce(() => {
+        return {
+          currentTenantId: "US_MO",
+          districtsStore: {
+            districtIds: [userDistrict, otherDistrict],
+          },
+          userStore: {
+            setAuthError: mockSetAuthError,
+            allowedSupervisionLocationIds: [userDistrict],
+          },
+        };
+      });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("does not set an auth error for numeric district", () => {
+      userDistrict = "03";
+      rootStore = new LanternStore(mockRootStore);
+      userRestrictionsStore = new UserRestrictionsStore({
+        rootStore,
+      });
+      userRestrictionsStore.verifyUserRestrictions();
+
+      expect(rootStore.userStore.setAuthError).toHaveBeenCalledTimes(0);
+    });
+
+    it("does not set an auth error for string district", () => {
+      userDistrict = "TSCL";
+      rootStore = new LanternStore(mockRootStore);
+      userRestrictionsStore = new UserRestrictionsStore({
+        rootStore,
+      });
+      userRestrictionsStore.verifyUserRestrictions();
+
+      expect(rootStore.userStore.setAuthError).toHaveBeenCalledTimes(0);
+    });
+
+    it("does not set an auth error for alphanumeric district", () => {
+      userDistrict = "13N";
+      rootStore = new LanternStore(mockRootStore);
+      userRestrictionsStore = new UserRestrictionsStore({
+        rootStore,
+      });
+      userRestrictionsStore.verifyUserRestrictions();
+
+      expect(rootStore.userStore.setAuthError).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("when the user restriction is valid but missing a leading 0", () => {
+    const mockMalformedId = "3";
+
+    beforeEach(async () => {
+      mockLanternStore.mockImplementationOnce(() => {
+        return {
+          currentTenantId: "US_MO",
+          districtsStore: {
+            districtIds: ["03", "13N", "TSCL"],
+          },
+          userStore: {
+            setAuthError: mockSetAuthError,
+            allowedSupervisionLocationIds: [mockMalformedId],
+          },
+        };
+      });
+      rootStore = new LanternStore(mockRootStore);
+      userRestrictionsStore = new UserRestrictionsStore({
+        rootStore,
+      });
+      userRestrictionsStore.verifyUserRestrictions();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("does not set an auth error", () => {
+      expect(rootStore.userStore.setAuthError).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/utils/__tests__/formatStrings.test.js
+++ b/src/utils/__tests__/formatStrings.test.js
@@ -62,6 +62,12 @@ describe("formatStrings", () => {
     expect(dataErrorAfterTest).toBe(NaN);
   });
 
+  it("safeToInt", () => {
+    expect(utils.safeToInt("03")).toBe(3);
+    expect(utils.safeToInt("03N")).toBe("03N");
+    expect(utils.safeToInt("TSCL")).toBe("TSCL");
+  });
+
   it("to title case", () => {
     const dataForTest = "LOS ANGELES";
     const dataAfterTest = utils.toTitleCase(dataForTest);

--- a/src/utils/formatStrings.ts
+++ b/src/utils/formatStrings.ts
@@ -79,6 +79,10 @@ function toHumanReadable(string: string): string {
   return string.replace(/[-_]/g, " ");
 }
 
+function safeToInt(nonInt: string): number | string {
+  return !Number.isNaN(Number(nonInt)) ? parseInt(nonInt) : nonInt;
+}
+
 function toInt(nonInt: string): number {
   return parseInt(nonInt);
 }
@@ -181,6 +185,7 @@ export {
   raceValueToHumanReadable,
   toHtmlFriendly,
   toHumanReadable,
+  safeToInt,
   toInt,
   toNumber,
   toTitleCase,


### PR DESCRIPTION
## Description of the change

We had an issue last week where MO had entered district ids for some users that were missing the leading 0. So the id was "3" instead of "03". This PR converts any strings that are integers to integers while verifying the id to ensure that a leading 0 does not cause an error.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1148

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [x] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
