### PR TITLE
Remove methodology and projection flags

### DIFF
--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -36,9 +36,6 @@ import VitalsMethodology from "../core/VitalsMethodology";
 
 const METADATA_NAMESPACE = process.env.REACT_APP_METADATA_NAMESPACE;
 
-jest.mock("../flags", () => ({
-  showMethodologyDropdown: true,
-}));
 jest.mock("../utils/initIntercomSettings");
 jest.mock("../utils/initFontAwesome");
 jest.mock("../utils/i18nSettings");

--- a/src/flags.js
+++ b/src/flags.js
@@ -3,27 +3,21 @@ export default process.env.REACT_APP_DEPLOY_ENV === "production"
   ? {
       // TODO(395): Set to true when we have debugged the issues with the exit rate calculations
       enableRevocationRateByExit: false,
-      showMethodologyDropdown: false,
       enableCoreTabNavigation: true,
       enableVitalsDashboard: false,
       enableVitalsOfficerView: false,
-      enableProjectionsDashboard: false,
     }
   : process.env.REACT_APP_DEPLOY_ENV === "staging"
   ? {
       enableRevocationRateByExit: false,
-      showMethodologyDropdown: false,
       enableCoreTabNavigation: true,
       enableVitalsDashboard: true,
       enableVitalsOfficerView: false,
-      enableProjectionsDashboard: true,
     }
   : {
       // Development
       enableRevocationRateByExit: false,
-      showMethodologyDropdown: true,
       enableCoreTabNavigation: true,
       enableVitalsDashboard: true,
       enableVitalsOfficerView: false,
-      enableProjectionsDashboard: true,
     };

--- a/src/tenants.ts
+++ b/src/tenants.ts
@@ -60,10 +60,9 @@ const TENANTS: Tenants = {
     navigation: {
       goals: [],
       ...(flags.enableVitalsDashboard
-        ? { community: ["explore", "vitals"] }
+        ? { community: ["explore", "vitals"], methodology: ["vitals"] }
         : { community: ["explore"] }),
       facilities: ["explore"],
-      ...(flags.showMethodologyDropdown ? { methodology: ["vitals"] } : {}),
     },
     vitalsMetrics: [
       {
@@ -102,12 +101,9 @@ const TENANTS: Tenants = {
     availableStateCodes: [core.US_ID],
     enableUserRestrictions: false,
     navigation: {
-      ...(flags.enableProjectionsDashboard
-        ? { facilities: ["projections"], community: ["projections"] }
-        : { community: [], facilities: [] }),
-      ...(flags.showMethodologyDropdown
-        ? { methodology: ["projections"] }
-        : {}),
+      facilities: ["projections"],
+      community: ["projections"],
+      methodology: ["projections"],
     },
   },
   [lantern.US_PA]: {

--- a/src/utils/__tests__/navigation.test.ts
+++ b/src/utils/__tests__/navigation.test.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2019 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -23,7 +23,6 @@ import {
 import tenants from "../../tenants";
 
 jest.mock("../../flags", () => ({
-  showMethodologyDropdown: false,
   enableVitalsDashboard: true,
   enableProjectionsDashboard: true,
 }));
@@ -35,6 +34,7 @@ describe("getPathsFromNavigation", () => {
       "/goals",
       "/community/explore",
       "/community/vitals",
+      "/methodology/vitals",
       "/facilities/explore",
     ];
     expect(allowedPaths).toEqual(expected);
@@ -42,7 +42,11 @@ describe("getPathsFromNavigation", () => {
 
   it("returns the correct allowed paths path for US_ID", () => {
     const allowedPaths = getPathsFromNavigation(tenants.US_ID.navigation);
-    const expected = ["/facilities/projections", "/community/projections"];
+    const expected = [
+      "/facilities/projections",
+      "/community/projections",
+      "/methodology/projections",
+    ];
     expect(allowedPaths).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Description of the change

Remove the flags enabling the methodology dropdown and population projections. For the former, control of any methodology pages is linked to the feature itself. For the latter, we're launching it, so no need to have a flag anymore.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
