### PR TITLE
update filters text on projections page download

### DIFF
--- a/src/core/CoreStore/PageProjectionsStore.ts
+++ b/src/core/CoreStore/PageProjectionsStore.ts
@@ -22,8 +22,12 @@ import {
   formatMonthAndYear,
   getRecordDate,
 } from "../PopulationTimeSeriesChart/helpers";
-import { toTitleCase, formatDate } from "../../utils/formatStrings";
-import { getCompartmentFromView } from "../views";
+import {
+  toTitleCase,
+  formatDate,
+  toHumanReadable,
+} from "../../utils/formatStrings";
+import { CORE_VIEWS, getCompartmentFromView } from "../views";
 import { downloadChartAsData } from "../../utils/downloads/downloadData";
 
 export default class PageProjectionsStore {
@@ -70,15 +74,23 @@ export default class PageProjectionsStore {
   get filtersText(): string {
     const { view } = this.rootStore;
     const {
-      filters: { gender, supervisionType },
+      filters: { gender, supervisionType, legalStatus },
       timePeriodLabel,
     } = this.rootStore.filtersStore;
     const compartment = getCompartmentFromView(view);
-    return `${toTitleCase(
-      compartment
-    )} - ${timePeriodLabel}; Gender: ${toTitleCase(
-      gender
-    )}; Supervision Type: ${toTitleCase(supervisionType)},,,`;
+    const description =
+      view === CORE_VIEWS.facilities
+        ? `${toTitleCase(
+            compartment
+          )} - ${timePeriodLabel}; Gender: ${toTitleCase(
+            gender
+          )}; Legal Status: ${toTitleCase(toHumanReadable(legalStatus))},,,`
+        : `${toTitleCase(
+            compartment
+          )} - ${timePeriodLabel}; Gender: ${toTitleCase(
+            gender
+          )}; Supervision Type: ${toTitleCase(supervisionType)},,,`;
+    return description;
   }
 
   async fetchMethodologyPDF(): Promise<Record<string, any>> {

--- a/src/core/CoreStore/__tests__/PageProjectionsStore.test.ts
+++ b/src/core/CoreStore/__tests__/PageProjectionsStore.test.ts
@@ -106,6 +106,7 @@ describe("PageProjectionsStore", () => {
 
   describe("filtersText", () => {
     it("formats the filters description for the csv file", () => {
+      coreStore.setView("/community/projections");
       expect(pageProjectionsStore.filtersText).toEqual(
         "Supervision - 6 months; Gender: All; Supervision Type: All,,,"
       );
@@ -114,7 +115,7 @@ describe("PageProjectionsStore", () => {
     it("formats the filters text according to the view", () => {
       coreStore.setView("/facilities/projections");
       expect(pageProjectionsStore.filtersText).toEqual(
-        "Incarceration - 6 months; Gender: All; Supervision Type: All,,,"
+        "Incarceration - 6 months; Gender: All; Legal Status: All,,,"
       );
     });
   });

--- a/src/core/CoreStore/index.ts
+++ b/src/core/CoreStore/index.ts
@@ -44,7 +44,7 @@ export default class CoreStore {
 
   pageProjectionsStore: PageProjectionsStore;
 
-  view: CoreView = CORE_VIEWS.community;
+  view: CoreView = CORE_VIEWS.facilities;
 
   constructor({ userStore, tenantStore }: CoreStoreProps) {
     makeAutoObservable(this);


### PR DESCRIPTION
## Description of the change

Updates the filters text in the data download on the Projections Page to match the view's enabled filters.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
