### PR TITLE
Use enabled filters from filterOptions for pop proj download

### DIFF
--- a/src/core/CoreStore/__tests__/PageProjectionsStore.test.ts
+++ b/src/core/CoreStore/__tests__/PageProjectionsStore.test.ts
@@ -108,14 +108,14 @@ describe("PageProjectionsStore", () => {
     it("formats the filters description for the csv file", () => {
       coreStore.setView("/community/projections");
       expect(pageProjectionsStore.filtersText).toEqual(
-        "Supervision - 6 months; Gender: All; Supervision Type: All,,,"
+        "Supervision - 6 months; Gender: All; Supervision Type: All"
       );
     });
 
     it("formats the filters text according to the view", () => {
       coreStore.setView("/facilities/projections");
       expect(pageProjectionsStore.filtersText).toEqual(
-        "Incarceration - 6 months; Gender: All; Legal Status: All,,,"
+        "Incarceration - 6 months; Gender: All; Legal Status: All"
       );
     });
   });

--- a/src/core/utils/filterOptions.ts
+++ b/src/core/utils/filterOptions.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 import { CORE_VIEWS } from "../views";
 import { METRIC_TYPES, FILTER_TYPES } from "./constants";
-import { US_ID } from "../../RootStore/TenantStore/coreTenants";
+import { US_ID, US_ND } from "../../RootStore/TenantStore/coreTenants";
 import {
   FilterOption,
   PopulationFilters,
@@ -156,4 +156,5 @@ export const defaultPopulationFilterValues: PopulationFilterValues = {
 
 export default {
   [US_ID]: PopulationFilterOptions,
+  [US_ND]: undefined,
 } as const;


### PR DESCRIPTION
## Description of the change

We merged a quick fix for a filters text bug on the population projections download filter text yesterday. This cleans that up and builds the filters text dynamically based on the enabled filter options per `currentTenantId`/`view`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1152

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
