### PR TITLE
Add can_access booleans to new user signups permissions

### DIFF
--- a/src/auth0/hooks/01-pre-registration-setup.js
+++ b/src/auth0/hooks/01-pre-registration-setup.js
@@ -33,7 +33,7 @@
 @param {function} cb - function (error, response)
 */
 module.exports = async function (user, context, cb) {
-    /**
+  /**
    * This hook allows custom code to prevent creation of a user in the
    * database or to add custom app_metadata or user_metadata to a
    * newly created user.
@@ -50,33 +50,33 @@ module.exports = async function (user, context, cb) {
   const response = {};
 
   /** 1. Domain allow list for registration */
-  const authorizedDomains = ['recidiviz.org', 'csg.org']; // add authorized domains here
-  const emailSplit = user.email.split('@');
+  const authorizedDomains = ["recidiviz.org", "csg.org"]; // add authorized domains here
+  const emailSplit = user.email.split("@");
   const userDomain = emailSplit[emailSplit.length - 1].toLowerCase();
 
-  const userHasAccess = authorizedDomains.some(function(authorizedDomain) {
+  const userHasAccess = authorizedDomains.some(function (authorizedDomain) {
     return userDomain === authorizedDomain;
   });
 
   if (userHasAccess) {
     user.app_metadata = user.app_metadata || {};
 
-    if (['csg.org', 'recidiviz.org'].includes(userDomain)) {
+    if (["csg.org", "recidiviz.org"].includes(userDomain)) {
       // Do not set state_code on internal users, this is done in a rule
       return cb(null, { user });
     }
 
     /** 2. Add user's state_code to the app_metadata */
-    const acceptedStateCodes = ['id', 'mo', 'nd', 'pa'];
-    const domainSplit = userDomain.split('.');
+    const acceptedStateCodes = ["id", "mo", "nd", "pa"];
+    const domainSplit = userDomain.split(".");
 
     // assumes the state is always the second to last component of the domain
     // e.g. @doc.mo.gov or @nd.gov, but not @nd.docr.gov
     let state = domainSplit[domainSplit.length - 2].toLowerCase();
 
     // Idaho does not use the abbreviation in their email addresses
-    if (state === 'idaho') {
-      state = 'id';
+    if (state === "idaho") {
+      state = "id";
     }
 
     const stateCode = `us_${state}`;
@@ -86,11 +86,11 @@ module.exports = async function (user, context, cb) {
 
     /** 3. Add the user's restrictions to the app_metadata */
     // Other states do not currently have any sign up or user restrictions
-    const stateCodesWithRestrictions = ['us_mo'];
+    const stateCodesWithRestrictions = ["us_mo"];
 
     if (stateCodesWithRestrictions.includes(stateCode.toLowerCase())) {
-      const Sentry = require('@sentry/node');
-      const { GoogleAuth } = require('google-auth-library');
+      const Sentry = require("@sentry/node");
+      const { GoogleAuth } = require("google-auth-library");
       Sentry.init({
         dsn: context.webtask.secrets.SENTRY_DSN,
         environment: context.webtask.secrets.SENTRY_ENV,
@@ -104,8 +104,7 @@ module.exports = async function (user, context, cb) {
         const client = await auth.getIdTokenClient(
           context.webtask.secrets.TARGET_AUDIENCE
         );
-        const url = `${context.webtask.secrets
-          .RECIDIVIZ_APP_URL}/auth/dashboard_user_restrictions_by_email?email_address=${user.email}&region_code=${stateCode}`;
+        const url = `${context.webtask.secrets.RECIDIVIZ_APP_URL}/auth/dashboard_user_restrictions_by_email?email_address=${user.email}&region_code=${stateCode}`;
         const apiResponse = await client.request({ url, retry: true });
         const restrictions = apiResponse.data;
 
@@ -114,6 +113,9 @@ module.exports = async function (user, context, cb) {
             restrictions.allowed_supervision_location_ids || [],
           allowed_supervision_location_level:
             restrictions.allowed_supervision_location_level,
+          can_access_case_triage: restrictions.can_access_case_triage || false,
+          can_access_leadership_dashboard:
+            restrictions.can_access_leadership_dashboard || false,
         });
       } catch (apiError) {
         Sentry.captureMessage(
@@ -121,7 +123,7 @@ module.exports = async function (user, context, cb) {
         );
         Sentry.captureException(apiError);
         const clientMessage =
-          'There was a problem registering your account. Please contact your organization administrator, if you don’t know your administrator, contact help@recidiviz.org.';
+          "There was a problem registering your account. Please contact your organization administrator, if you don’t know your administrator, contact help@recidiviz.org.";
         return cb(
           new PreUserRegistrationError(apiError.message, clientMessage)
         );
@@ -131,5 +133,5 @@ module.exports = async function (user, context, cb) {
     response.user = user;
     return cb(null, response);
   }
-  return cb('Access denied.', null);
+  return cb("Access denied.", null);
 };


### PR DESCRIPTION
## Description of the change

This PR updates the `01-pre-registration-setup.js` hook to include the `can_access_case_triage` and `can_access_leadership_dashboard` permissions to new user registrations. Once this PR is merged I'll update the hook in Auth0!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1156 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
