### PR TITLE
Guard for when Time Series data does not have 90 or 30 days data to generate % change

### DIFF
--- a/src/core/CoreStore/PageVitalsStore.ts
+++ b/src/core/CoreStore/PageVitalsStore.ts
@@ -245,17 +245,24 @@ export default class PageVitalsStore {
     };
   }
 
-  get monthlyChange():
-    | { thirtyDayChange: number; ninetyDayChange: number }
-    | undefined {
+  get monthlyChange(): {
+    thirtyDayChange?: number;
+    ninetyDayChange?: number;
+  } {
     const timeSeries = this.selectedMetricTimeSeries;
-    if (timeSeries === undefined) return undefined;
-
-    const ninetyDaysAgo = timeSeries[timeSeries.length - 89];
-    const thirtyDaysAgo = timeSeries[timeSeries.length - 29];
+    if (timeSeries === undefined)
+      return { thirtyDayChange: undefined, ninetyDayChange: undefined };
+    const ninetyDaysAgo =
+      timeSeries.length >= 90 ? timeSeries[timeSeries.length - 89] : undefined;
+    const thirtyDaysAgo =
+      timeSeries.length >= 30 ? timeSeries[timeSeries.length - 29] : undefined;
     const latestDay = timeSeries[timeSeries.length - 1];
-    const thirtyDayChange = latestDay.monthlyAvg - thirtyDaysAgo.monthlyAvg;
-    const ninetyDayChange = latestDay.monthlyAvg - ninetyDaysAgo.monthlyAvg;
+    const thirtyDayChange = thirtyDaysAgo
+      ? latestDay.monthlyAvg - thirtyDaysAgo.monthlyAvg
+      : undefined;
+    const ninetyDayChange = ninetyDaysAgo
+      ? latestDay.monthlyAvg - ninetyDaysAgo.monthlyAvg
+      : undefined;
     return { thirtyDayChange, ninetyDayChange };
   }
 

--- a/src/core/CoreStore/PageVitalsStore.ts
+++ b/src/core/CoreStore/PageVitalsStore.ts
@@ -253,9 +253,9 @@ export default class PageVitalsStore {
     if (timeSeries === undefined)
       return { thirtyDayChange: undefined, ninetyDayChange: undefined };
     const ninetyDaysAgo =
-      timeSeries.length >= 90 ? timeSeries[timeSeries.length - 89] : undefined;
+      timeSeries.length >= 90 ? timeSeries[timeSeries.length - 90] : undefined;
     const thirtyDaysAgo =
-      timeSeries.length >= 30 ? timeSeries[timeSeries.length - 29] : undefined;
+      timeSeries.length >= 30 ? timeSeries[timeSeries.length - 30] : undefined;
     const latestDay = timeSeries[timeSeries.length - 1];
     const thirtyDayChange = thirtyDaysAgo
       ? latestDay.monthlyAvg - thirtyDaysAgo.monthlyAvg

--- a/src/core/VitalsMonthlyChange/index.tsx
+++ b/src/core/VitalsMonthlyChange/index.tsx
@@ -25,7 +25,7 @@ import { useCoreStore } from "../CoreStoreProvider";
 
 type MonthlyChangeProps = {
   numDays: number;
-  value: number;
+  value?: number;
 };
 
 const MonthlyChange: React.FC<MonthlyChangeProps> = ({ numDays, value }) => {

--- a/src/core/controls/PercentDelta.tsx
+++ b/src/core/controls/PercentDelta.tsx
@@ -46,10 +46,10 @@ function getDeltaDirection({
   value,
   improvesOnIncrease = false,
 }: {
-  value: number;
+  value?: number;
   improvesOnIncrease?: boolean;
 }): { color: string; rotate: number; direction: DeltaDirections } {
-  if (value === 0)
+  if (value === 0 || value === undefined)
     return {
       direction: deltaDirections.noChange,
       color: deltaColorMap.noChange,
@@ -84,7 +84,7 @@ function getDeltaDirection({
 }
 
 type PropTypes = {
-  value: number;
+  value?: number;
   className?: string;
   width?: number;
   height?: number;
@@ -117,7 +117,9 @@ const PercentDelta: React.FC<PropTypes> = ({
           rotate={deltaDirection.rotate}
         />
       )}
-      <div className="PercentDelta__value">{formatPercent(value)}</div>
+      <div className="PercentDelta__value">
+        {value ? formatPercent(value) : "N/A"}
+      </div>
     </div>
   );
 };

--- a/src/core/controls/__tests__/PercentDelta.test.tsx
+++ b/src/core/controls/__tests__/PercentDelta.test.tsx
@@ -23,7 +23,7 @@ import PercentDelta, { ROTATE_DOWN, ROTATE_UP } from "../PercentDelta";
 
 describe("PercentDelta", () => {
   type PropTypes = {
-    value: number;
+    value?: number;
     width?: number;
     height?: number;
     improvesOnIncrease?: boolean;
@@ -95,5 +95,22 @@ describe("PercentDelta", () => {
       color: styles.slate60,
     });
     expect(wrapper.find("Icon").exists()).toEqual(false);
+  });
+
+  it("does not render an icon when the change is undefined", () => {
+    const wrapper = renderPercentDelta({
+      value: undefined,
+    });
+    expect(wrapper.find(".PercentDelta").prop("style")).toEqual({
+      color: styles.slate60,
+    });
+    expect(wrapper.find("Icon").exists()).toEqual(false);
+  });
+
+  it("displays N/A when the change is undefined", () => {
+    const wrapper = renderPercentDelta({
+      value: undefined,
+    });
+    expect(wrapper.find(".PercentDelta__value").text()).toEqual("N/A");
   });
 });


### PR DESCRIPTION
## Description of the change

We have a bug where the page throws an error when clicking on 'CONTACTS' because there is not 90  days worth of data to generate the 90 day monthly change metric.

This code guards for the case when there is not enough data to calculate 90 day or 30 day change, and displays 'N/A' in that case.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1167

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
