### PR TITLE
hide vitals goal line behind flag

### DIFF
--- a/src/core/VitalsSummaryChart/index.tsx
+++ b/src/core/VitalsSummaryChart/index.tsx
@@ -21,6 +21,7 @@ import { curveCatmullRom } from "d3-shape";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 
+import flags from "../../flags";
 import { formatISODateString, formatPercent } from "../../utils/formatStrings";
 import * as styles from "../CoreConstants.scss";
 import { useCoreStore } from "../CoreStoreProvider";
@@ -114,32 +115,34 @@ const VitalsSummaryChart: React.FC = () => {
       <ResponsiveOrdinalFrame
         responsiveWidth
         hoverAnnotation
-        annotations={[
-          {
-            type: "ordinal-line",
-            coordinates: lineCoordinates,
-            lineStyle: {
-              stroke: styles.indigo,
-              strokeWidth: 2,
+        annotations={
+          flags.enableVitalsGoalLine && [
+            {
+              type: "ordinal-line",
+              coordinates: lineCoordinates,
+              lineStyle: {
+                stroke: styles.indigo,
+                strokeWidth: 2,
+              },
+              curve: curveCatmullRom,
             },
-            curve: curveCatmullRom,
-          },
-          {
-            type: "or",
-            ...latestDataPoint,
-          },
-          {
-            type: "react-annotation",
-            date: latestDataPoint.date,
-            value: goal,
-          },
-          {
-            type: "r",
-            value: goal,
-            color: styles.signalLinks,
-            disable: "connector",
-          },
-        ]}
+            {
+              type: "or",
+              ...latestDataPoint,
+            },
+            {
+              type: "react-annotation",
+              date: latestDataPoint.date,
+              value: goal,
+            },
+            {
+              type: "r",
+              value: goal,
+              color: styles.signalLinks,
+              disable: "connector",
+            },
+          ]
+        }
         customHoverBehavior={(piece: any) => {
           if (piece) {
             setHoveredId(piece.index);

--- a/src/flags.js
+++ b/src/flags.js
@@ -6,6 +6,7 @@ export default process.env.REACT_APP_DEPLOY_ENV === "production"
       enableCoreTabNavigation: true,
       enableVitalsDashboard: false,
       enableVitalsOfficerView: false,
+      enableVitalsGoalLine: false,
     }
   : process.env.REACT_APP_DEPLOY_ENV === "staging"
   ? {
@@ -13,11 +14,13 @@ export default process.env.REACT_APP_DEPLOY_ENV === "production"
       enableCoreTabNavigation: true,
       enableVitalsDashboard: true,
       enableVitalsOfficerView: false,
+      enableVitalsGoalLine: false,
     }
   : {
       // Development
       enableRevocationRateByExit: false,
       enableCoreTabNavigation: true,
       enableVitalsDashboard: true,
-      enableVitalsOfficerView: false,
+      enableVitalsOfficerView: true,
+      enableVitalsGoalLine: true,
     };


### PR DESCRIPTION
## Description of the change

Hides VITALS goal line behind a flag until the goal data is confirmed. 

Also enables VITALS officer view in development env by default.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #1168

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally
- [ ] E2E have been run for Lantern changes ([Steps in the Readme](https://github.com/Recidiviz/pulse-dashboard#running-e2e-tests))

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
